### PR TITLE
feat: Twitch IRC チャットビューアー macOS アプリ 初期実装

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,10 @@ let package = Package(
     platforms: [
         .macOS(.v15)
     ],
+    dependencies: [
+        // Swift Testing フレームワーク（CommandLineTools 環境でのテスト実行に使用）
+        .package(url: "https://github.com/swiftlang/swift-testing.git", branch: "main")
+    ],
     targets: [
         .executableTarget(
             name: "TwitchChat",
@@ -17,22 +21,16 @@ let package = Package(
         ),
         .testTarget(
             name: "TwitchChatTests",
-            dependencies: ["TwitchChat"],
-            path: "Tests/TwitchChatTests",
-            swiftSettings: [
-                // CommandLineTools 環境での Testing フレームワーク参照
-                .unsafeFlags([
-                    "-F",
-                    "/Library/Developer/CommandLineTools/Library/Developer/Frameworks"
-                ])
+            dependencies: [
+                "TwitchChat",
+                .product(name: "Testing", package: "swift-testing")
             ],
+            path: "Tests/TwitchChatTests",
             linkerSettings: [
+                // CommandLineTools 環境で lib_TestingInterop を見つけるためのパス設定
                 .unsafeFlags([
-                    "-F",
-                    "/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
-                    "-framework", "Testing",
-                    "-Xlinker", "-rpath",
-                    "-Xlinker", "/Library/Developer/CommandLineTools/Library/Developer/Frameworks",
+                    "-L",
+                    "/Library/Developer/CommandLineTools/Library/Developer/usr/lib",
                     "-Xlinker", "-rpath",
                     "-Xlinker", "/Library/Developer/CommandLineTools/Library/Developer/usr/lib"
                 ])

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,16 @@ let package = Package(
     targets: [
         .executableTarget(
             name: "TwitchChat",
-            path: "Sources/TwitchChat"
+            path: "Sources/TwitchChat",
+            linkerSettings: [
+                // Info.plist をバイナリに埋め込み、macOS が GUI アプリとして認識できるようにする
+                .unsafeFlags([
+                    "-Xlinker", "-sectcreate",
+                    "-Xlinker", "__TEXT",
+                    "-Xlinker", "__info_plist",
+                    "-Xlinker", "Sources/TwitchChat/Info.plist"
+                ])
+            ]
         ),
         .testTarget(
             name: "TwitchChatTests",

--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -4,8 +4,10 @@
 
 import SwiftUI
 
-/// Twitch IRC チャットビューアーのエントリポイント
-@main
+/// Twitch IRC チャットビューアーのアプリ定義
+///
+/// @main は使わず main.swift でエントリポイントを明示的に指定する
+/// （SPM executable ターゲットで NSApplication を正しく初期化するため）
 struct TwitchChatApp: App {
     var body: some Scene {
         WindowGroup {

--- a/Sources/TwitchChat/App/main.swift
+++ b/Sources/TwitchChat/App/main.swift
@@ -1,0 +1,13 @@
+// main.swift
+// アプリケーションのエントリポイント
+// NSApplication を明示的に初期化して GUI アプリとして起動する
+// SPM executable ターゲットで SwiftUI App を正しく動作させるための設定
+
+import AppKit
+import SwiftUI
+
+// GUI アプリとして起動するためのアクティベーションポリシーを設定
+NSApplication.shared.setActivationPolicy(.regular)
+
+// SwiftUI App を起動
+TwitchChatApp.main()

--- a/Sources/TwitchChat/Info.plist
+++ b/Sources/TwitchChat/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.mtane0412.TwitchChat</string>
+    <key>CFBundleName</key>
+    <string>TwitchChat</string>
+    <key>CFBundleDisplayName</key>
+    <string>Twitch Chat</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>15.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+</dict>
+</plist>

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -1,0 +1,82 @@
+// ChatMessage.swift
+// 表示用チャットメッセージとバッジ情報を表す構造体
+// Twitch IRC の PRIVMSG から変換して UI 表示に使用する
+
+import Foundation
+
+/// Twitch チャットのバッジ情報
+///
+/// バッジ文字列 `"broadcaster/1"` を名前とバージョンに分解して保持する
+struct Badge: Sendable, Equatable {
+    /// バッジ名（例: "broadcaster", "subscriber", "moderator"）
+    let name: String
+
+    /// バッジのバージョン（例: "1", "12", "1000"）
+    let version: String
+
+    /// バッジ文字列を Badge 配列にパースする
+    ///
+    /// - Parameter badgesString: カンマ区切りのバッジ文字列（例: `"broadcaster/1,subscriber/12"`）
+    /// - Returns: パースされた Badge の配列
+    static func parse(_ badgesString: String) -> [Badge] {
+        guard !badgesString.isEmpty else { return [] }
+        return badgesString
+            .split(separator: ",")
+            .compactMap { pair -> Badge? in
+                let parts = pair.split(separator: "/", maxSplits: 1)
+                guard parts.count == 2 else { return nil }
+                return Badge(name: String(parts[0]), version: String(parts[1]))
+            }
+    }
+}
+
+/// 表示用チャットメッセージ
+///
+/// IRCMessage の PRIVMSG から変換し、チャット UI に表示するために使用する
+struct ChatMessage: Sendable, Identifiable {
+    /// メッセージの一意な識別子（Twitch の message id、なければ UUID）
+    let id: String
+
+    /// IRC のユーザー名（小文字）
+    let username: String
+
+    /// 表示名（日本語や大文字を含む場合あり）
+    let displayName: String
+
+    /// メッセージ本文
+    let text: String
+
+    /// ユーザーのチャット文字色（16進数形式 `#RRGGBB`、未設定の場合は nil）
+    let colorHex: String?
+
+    /// バッジ一覧
+    let badges: [Badge]
+
+    /// メッセージの受信時刻
+    let receivedAt: Date
+
+    /// IRCMessage から ChatMessage を生成する
+    ///
+    /// PRIVMSG コマンド以外、または trailing がない場合は nil を返す
+    ///
+    /// - Parameter ircMessage: パース済み IRCMessage
+    /// - Returns: 変換成功時は ChatMessage、失敗時は nil
+    init?(from ircMessage: IRCMessage) {
+        guard ircMessage.command == "PRIVMSG",
+              let text = ircMessage.trailing,
+              let rawPrefix = ircMessage.prefix else { return nil }
+
+        // プレフィックス "nick!user@host" から nick 部分を抽出
+        let username = String(rawPrefix.split(separator: "!").first ?? Substring(rawPrefix))
+
+        self.id = ircMessage.tags["id"] ?? UUID().uuidString
+        self.username = username
+        self.displayName = ircMessage.tags["display-name"]?.isEmpty == false
+            ? ircMessage.tags["display-name"]!
+            : username
+        self.text = text
+        self.colorHex = ircMessage.tags["color"]?.isEmpty == false ? ircMessage.tags["color"] : nil
+        self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
+        self.receivedAt = Date()
+    }
+}

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -66,8 +66,8 @@ struct ChatMessage: Sendable, Identifiable {
               let text = ircMessage.trailing,
               let rawPrefix = ircMessage.prefix else { return nil }
 
-        // プレフィックス "nick!user@host" から nick 部分を抽出
-        let username = String(rawPrefix.split(separator: "!").first ?? Substring(rawPrefix))
+        // プレフィックス "nick!user@host" から nick 部分を抽出し小文字に正規化
+        let username = String(rawPrefix.split(separator: "!").first ?? Substring(rawPrefix)).lowercased()
 
         self.id = ircMessage.tags["id"] ?? UUID().uuidString
         self.username = username

--- a/Sources/TwitchChat/Models/IRCMessage.swift
+++ b/Sources/TwitchChat/Models/IRCMessage.swift
@@ -1,0 +1,28 @@
+// IRCMessage.swift
+// パース済み IRC メッセージを表す構造体
+// RFC 1459 形式に Twitch 固有のタグ（IRCv3）を加えた構造を表現する
+
+import Foundation
+
+/// パース済み IRC メッセージ
+///
+/// IRC メッセージの形式:
+/// `[@tags] [:prefix] <command> [params] [:trailing]`
+///
+/// - Note: Twitch IRC では IRCv3 のタグ拡張が使用される
+struct IRCMessage: Sendable {
+    /// IRCv3 タグ（`@key=value;key2=value2` 形式）
+    let tags: [String: String]
+
+    /// メッセージのプレフィックス（送信者情報: `nick!user@host` 形式）
+    let prefix: String?
+
+    /// IRC コマンド（例: PING, PRIVMSG, JOIN, 001 など）
+    let command: String
+
+    /// コマンドのパラメータ（trailing を除く）
+    let params: [String]
+
+    /// メッセージの trailing 部分（`:` の後ろの文字列）
+    let trailing: String?
+}

--- a/Sources/TwitchChat/Services/IRCMessageParser.swift
+++ b/Sources/TwitchChat/Services/IRCMessageParser.swift
@@ -63,8 +63,9 @@ enum IRCMessageParser {
     /// - Returns: キーと値のディクショナリ
     private static func parseTags(_ tagsString: String) -> [String: String] {
         var result: [String: String] = [:]
-        let pairs = tagsString.split(separator: ";", omittingEmptySubsequences: false)
+        let pairs = tagsString.split(separator: ";", omittingEmptySubsequences: true)
         for pair in pairs {
+            guard !pair.isEmpty else { continue }
             let keyValue = pair.split(separator: "=", maxSplits: 1)
             let key = String(keyValue[0])
             let value = keyValue.count > 1 ? unescapeTagValue(String(keyValue[1])) : ""

--- a/Sources/TwitchChat/Services/IRCMessageParser.swift
+++ b/Sources/TwitchChat/Services/IRCMessageParser.swift
@@ -1,0 +1,141 @@
+// IRCMessageParser.swift
+// IRC メッセージのパーサー
+// RFC 1459 形式 + IRCv3 タグ拡張（Twitch IRC）に対応した純粋関数パーサー
+
+import Foundation
+
+/// IRC メッセージのパーサー
+///
+/// Twitch IRC メッセージ形式:
+/// `[@tags] [:prefix] <command> [params] [:trailing]`
+///
+/// - Note: 副作用なしの純粋関数で実装し、テスト容易性を確保する
+enum IRCMessageParser {
+
+    /// 生の IRC メッセージ文字列をパースして IRCMessage を返す
+    ///
+    /// - Parameter rawMessage: 生の IRC メッセージ文字列
+    /// - Returns: パース成功時は IRCMessage、失敗時は nil
+    static func parse(_ rawMessage: String) -> IRCMessage? {
+        let trimmed = rawMessage.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        var remainder = trimmed
+
+        // タグの抽出（@key=value;key2=value2 形式）
+        var tags: [String: String] = [:]
+        if remainder.hasPrefix("@") {
+            remainder.removeFirst() // @ を除去
+            let parts = remainder.split(separator: " ", maxSplits: 1)
+            guard parts.count == 2 else { return nil }
+            tags = parseTags(String(parts[0]))
+            remainder = String(parts[1])
+        }
+
+        // プレフィックスの抽出（:nick!user@host 形式）
+        var messagePrefix: String?
+        if remainder.hasPrefix(":") {
+            remainder.removeFirst() // : を除去
+            let parts = remainder.split(separator: " ", maxSplits: 1)
+            guard !parts.isEmpty else { return nil }
+            messagePrefix = String(parts[0])
+            remainder = parts.count > 1 ? String(parts[1]) : ""
+        }
+
+        // コマンドとパラメータの抽出
+        let (command, params, trailing) = parseCommandAndParams(remainder)
+        guard !command.isEmpty else { return nil }
+
+        return IRCMessage(
+            tags: tags,
+            prefix: messagePrefix,
+            command: command,
+            params: params,
+            trailing: trailing
+        )
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// タグ文字列をディクショナリに変換する
+    ///
+    /// - Parameter tagsString: セミコロン区切りのタグ文字列（例: `key=value;key2=value2`）
+    /// - Returns: キーと値のディクショナリ
+    private static func parseTags(_ tagsString: String) -> [String: String] {
+        var result: [String: String] = [:]
+        let pairs = tagsString.split(separator: ";", omittingEmptySubsequences: false)
+        for pair in pairs {
+            let keyValue = pair.split(separator: "=", maxSplits: 1)
+            let key = String(keyValue[0])
+            let value = keyValue.count > 1 ? unescapeTagValue(String(keyValue[1])) : ""
+            result[key] = value
+        }
+        return result
+    }
+
+    /// IRCv3 タグ値のエスケープシーケンスを変換する
+    ///
+    /// エスケープシーケンス一覧:
+    /// - `\:` → `;`
+    /// - `\s` → スペース
+    /// - `\\` → `\`
+    /// - `\r` → CR
+    /// - `\n` → LF
+    ///
+    /// - Parameter value: エスケープされたタグ値
+    /// - Returns: アンエスケープされた文字列
+    private static func unescapeTagValue(_ value: String) -> String {
+        var result = ""
+        var iterator = value.makeIterator()
+        while let char = iterator.next() {
+            if char == "\\" {
+                switch iterator.next() {
+                case ":": result.append(";")
+                case "s": result.append(" ")
+                case "\\": result.append("\\")
+                case "r": result.append("\r")
+                case "n": result.append("\n")
+                case let next?: result.append(next)
+                case nil: break
+                }
+            } else {
+                result.append(char)
+            }
+        }
+        return result
+    }
+
+    /// コマンド・パラメータ・trailing を抽出する
+    ///
+    /// - Parameter remainder: プレフィックス除去後の文字列
+    /// - Returns: (コマンド, パラメータ配列, trailing) のタプル
+    private static func parseCommandAndParams(_ remainder: String) -> (String, [String], String?) {
+        guard !remainder.isEmpty else { return ("", [], nil) }
+
+        var parts = remainder.components(separatedBy: " ")
+        guard !parts.isEmpty else { return ("", [], nil) }
+
+        let command = parts.removeFirst()
+        var params: [String] = []
+        var trailing: String?
+
+        // trailing の検出（":" で始まるパラメータ）
+        var trailingStartIndex: Int?
+        for (index, part) in parts.enumerated() {
+            if part.hasPrefix(":") {
+                trailingStartIndex = index
+                break
+            }
+            params.append(part)
+        }
+
+        if let idx = trailingStartIndex {
+            var trailingParts = Array(parts[idx...])
+            // 先頭の ":" を除去
+            trailingParts[0] = String(trailingParts[0].dropFirst())
+            trailing = trailingParts.joined(separator: " ")
+        }
+
+        return (command, params, trailing)
+    }
+}

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -4,6 +4,20 @@
 
 import Foundation
 
+/// Twitch IRC クライアントの抽象化プロトコル
+///
+/// ViewModel がこのプロトコルに依存することで、テスト時にモックへの差し替えが可能になる
+protocol TwitchIRCClientProtocol: Actor {
+    /// 受信した ChatMessage を配信する AsyncStream
+    var messageStream: AsyncStream<ChatMessage> { get }
+
+    /// 指定チャンネルに接続する
+    func connect(to channel: String) async throws
+
+    /// IRC 接続を切断する
+    func disconnect() async
+}
+
 /// Twitch IRC クライアント
 ///
 /// Twitch IRC WebSocket サーバーに匿名接続し、チャットメッセージを AsyncStream で配信する
@@ -16,7 +30,7 @@ import Foundation
 /// }
 /// try await client.connect(to: "channelname")
 /// ```
-actor TwitchIRCClient {
+actor TwitchIRCClient: TwitchIRCClientProtocol {
     // MARK: - 定数
 
     private static let websocketURL = URL(string: "wss://irc-ws.chat.twitch.tv:443")!

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -41,6 +41,8 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
     private let webSocketClient: any WebSocketClientProtocol
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
+    /// 受信ループのタスク（disconnect() でキャンセルするために保持）
+    private var receiveLoopTask: Task<Void, Never>?
 
     /// 受信した ChatMessage を配信する AsyncStream
     let messageStream: AsyncStream<ChatMessage>
@@ -67,13 +69,16 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         let normalizedChannel = channel.lowercased()
         try await webSocketClient.connect(to: Self.websocketURL)
         try await sendAuthSequence(channel: normalizedChannel)
-        await receiveLoop()
+        // receiveLoop を別タスクで起動し、connect() がブロックされないようにする
+        receiveLoopTask = Task { await receiveLoop() }
     }
 
     /// IRC 接続を切断する
     func disconnect() async {
+        receiveLoopTask?.cancel()
+        receiveLoopTask = nil
         await webSocketClient.disconnect()
-        messageContinuation?.finish()
+        // messageContinuation?.finish() を呼ばない → 再接続時に同じストリームを再利用できる
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -1,0 +1,117 @@
+// TwitchIRCClient.swift
+// Twitch IRC 接続を管理するクライアント
+// 匿名接続（justinfan 方式）で Twitch チャットを読み取り専用で受信する
+
+import Foundation
+
+/// Twitch IRC クライアント
+///
+/// Twitch IRC WebSocket サーバーに匿名接続し、チャットメッセージを AsyncStream で配信する
+///
+/// 使用例:
+/// ```swift
+/// let client = TwitchIRCClient()
+/// for await message in await client.messageStream {
+///     print(message.displayName, message.text)
+/// }
+/// try await client.connect(to: "channelname")
+/// ```
+actor TwitchIRCClient {
+    // MARK: - 定数
+
+    private static let websocketURL = URL(string: "wss://irc-ws.chat.twitch.tv:443")!
+    private static let anonymousPassword = "SCHMOOPIIE"
+    private static let anonymousNick = "justinfan12345"
+
+    // MARK: - プロパティ
+
+    private let webSocketClient: any WebSocketClientProtocol
+    private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
+
+    /// 受信した ChatMessage を配信する AsyncStream
+    let messageStream: AsyncStream<ChatMessage>
+
+    // MARK: - 初期化
+
+    /// TwitchIRCClient を初期化する
+    ///
+    /// - Parameter webSocketClient: WebSocket クライアント実装（テスト時はモックを注入）
+    init(webSocketClient: any WebSocketClientProtocol = URLSessionWebSocketClient()) {
+        var continuation: AsyncStream<ChatMessage>.Continuation?
+        self.messageStream = AsyncStream { continuation = $0 }
+        self.messageContinuation = continuation
+        self.webSocketClient = webSocketClient
+    }
+
+    // MARK: - 接続・切断
+
+    /// 指定チャンネルに接続する
+    ///
+    /// - Parameter channel: チャンネル名（`#` なし、大文字小文字は自動変換）
+    /// - Throws: WebSocket 接続エラー
+    func connect(to channel: String) async throws {
+        let normalizedChannel = channel.lowercased()
+        try await webSocketClient.connect(to: Self.websocketURL)
+        try await sendAuthSequence(channel: normalizedChannel)
+        await receiveLoop()
+    }
+
+    /// IRC 接続を切断する
+    func disconnect() async {
+        await webSocketClient.disconnect()
+        messageContinuation?.finish()
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// 匿名認証シーケンスを送信する
+    ///
+    /// Twitch IRC に接続するために必要な初期コマンドを順番に送信する
+    private func sendAuthSequence(channel: String) async throws {
+        try await webSocketClient.send("PASS \(Self.anonymousPassword)")
+        try await webSocketClient.send("NICK \(Self.anonymousNick)")
+        try await webSocketClient.send("CAP REQ :twitch.tv/tags twitch.tv/commands")
+        try await webSocketClient.send("JOIN #\(channel)")
+    }
+
+    /// メッセージ受信ループ
+    ///
+    /// WebSocket からメッセージを連続受信し、IRC メッセージを解析して配信する
+    /// 接続が切断されるまでループを継続する
+    private func receiveLoop() async {
+        while true {
+            do {
+                let raw = try await webSocketClient.receive()
+                // 複数メッセージが改行で連結されて届くことがあるため分割して処理
+                let lines = raw.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+                for line in lines {
+                    await handleLine(line)
+                }
+            } catch {
+                // 切断またはキャンセル時はループ終了
+                break
+            }
+        }
+    }
+
+    /// 1 行の IRC メッセージを処理する
+    private func handleLine(_ line: String) async {
+        guard let ircMessage = IRCMessageParser.parse(line) else { return }
+
+        switch ircMessage.command {
+        case "PING":
+            // PING に対して PONG を返してコネクションを維持する
+            let server = ircMessage.trailing ?? "tmi.twitch.tv"
+            try? await webSocketClient.send("PONG :\(server)")
+
+        case "PRIVMSG":
+            // チャットメッセージを ChatMessage に変換して配信
+            if let chatMessage = ChatMessage(from: ircMessage) {
+                messageContinuation?.yield(chatMessage)
+            }
+
+        default:
+            break
+        }
+    }
+}

--- a/Sources/TwitchChat/Services/WebSocketClient.swift
+++ b/Sources/TwitchChat/Services/WebSocketClient.swift
@@ -26,8 +26,9 @@ protocol WebSocketClientProtocol: Sendable {
 
 /// URLSessionWebSocketTask を使った WebSocket クライアント実装
 ///
+/// actor を使用してスレッドセーフな状態管理を実現する
 /// - Note: macOS 15+ の URLSession WebSocket API を使用する
-final class URLSessionWebSocketClient: WebSocketClientProtocol, @unchecked Sendable {
+actor URLSessionWebSocketClient: WebSocketClientProtocol {
     private let session: URLSession
     private var task: URLSessionWebSocketTask?
 

--- a/Sources/TwitchChat/Services/WebSocketClient.swift
+++ b/Sources/TwitchChat/Services/WebSocketClient.swift
@@ -1,0 +1,69 @@
+// WebSocketClient.swift
+// WebSocket 通信の抽象化プロトコルと URLSession を使った実装
+// テスト時はモック実装に差し替えることで実ネットワーク通信を回避できる
+
+import Foundation
+
+/// WebSocket 通信の抽象化プロトコル
+///
+/// テスト時にモック実装に差し替えられるよう、依存性注入のためのプロトコル
+protocol WebSocketClientProtocol: Sendable {
+    /// 指定した URL に WebSocket 接続する
+    func connect(to url: URL) async throws
+
+    /// テキストメッセージを送信する
+    func send(_ message: String) async throws
+
+    /// テキストメッセージを 1 件受信する
+    ///
+    /// - Returns: 受信したメッセージ文字列
+    /// - Throws: 接続切断時は CancellationError または URLError
+    func receive() async throws -> String
+
+    /// WebSocket 接続を切断する
+    func disconnect() async
+}
+
+/// URLSessionWebSocketTask を使った WebSocket クライアント実装
+///
+/// - Note: macOS 15+ の URLSession WebSocket API を使用する
+final class URLSessionWebSocketClient: WebSocketClientProtocol, @unchecked Sendable {
+    private let session: URLSession
+    private var task: URLSessionWebSocketTask?
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    func connect(to url: URL) async throws {
+        task = session.webSocketTask(with: url)
+        task?.resume()
+    }
+
+    func send(_ message: String) async throws {
+        guard let task else {
+            throw URLError(.notConnectedToInternet)
+        }
+        try await task.send(.string(message))
+    }
+
+    func receive() async throws -> String {
+        guard let task else {
+            throw URLError(.notConnectedToInternet)
+        }
+        let message = try await task.receive()
+        switch message {
+        case .string(let text):
+            return text
+        case .data(let data):
+            return String(data: data, encoding: .utf8) ?? ""
+        @unknown default:
+            return ""
+        }
+    }
+
+    func disconnect() async {
+        task?.cancel(with: .goingAway, reason: nil)
+        task = nil
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -78,12 +78,14 @@ final class ChatViewModel {
         connectionState = .connecting
         messages = []
 
-        receiveTask = Task {
+        receiveTask = Task { [weak self] in
             // メッセージ受信ループを別タスクで開始
-            let stream = await ircClient.messageStream
+            // weak self で循環参照を回避する
+            guard let self else { return }
+            let stream = await self.ircClient.messageStream
             for await message in stream {
                 guard !Task.isCancelled else { break }
-                appendMessage(message)
+                self.appendMessage(message)
             }
         }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -1,0 +1,115 @@
+// ChatViewModel.swift
+// チャット画面の ViewModel
+// @Observable マクロで SwiftUI ビューとのバインディングを管理する
+
+import Foundation
+import Observation
+
+/// チャット接続の状態
+enum ConnectionState: Equatable {
+    /// 未接続
+    case disconnected
+    /// 接続中
+    case connecting
+    /// 接続済み
+    case connected
+    /// エラー
+    case error(String)
+
+    static func == (lhs: ConnectionState, rhs: ConnectionState) -> Bool {
+        switch (lhs, rhs) {
+        case (.disconnected, .disconnected): return true
+        case (.connecting, .connecting): return true
+        case (.connected, .connected): return true
+        case (.error(let l), .error(let r)): return l == r
+        default: return false
+        }
+    }
+}
+
+/// チャット画面の ViewModel
+///
+/// Twitch IRC クライアントを通じてチャットメッセージを受信し、
+/// SwiftUI ビューに表示するためのデータを管理する
+///
+/// - Note: `@MainActor` で UI スレッドでの状態更新を保証する
+@Observable
+@MainActor
+final class ChatViewModel {
+    // MARK: - 定数
+
+    /// メモリ管理のための最大メッセージ保持件数
+    private static let maxMessages = 500
+
+    // MARK: - Published プロパティ
+
+    /// 受信済みチャットメッセージ（最新 500 件）
+    private(set) var messages: [ChatMessage] = []
+
+    /// 接続状態
+    private(set) var connectionState: ConnectionState = .disconnected
+
+    /// 接続中のチャンネル名
+    private(set) var channelName: String = ""
+
+    // MARK: - プライベートプロパティ
+
+    private let ircClient: any TwitchIRCClientProtocol
+    private var receiveTask: Task<Void, Never>?
+
+    // MARK: - 初期化
+
+    /// ChatViewModel を初期化する
+    ///
+    /// - Parameter ircClient: IRC クライアント（テスト時はモックを注入）
+    init(ircClient: any TwitchIRCClientProtocol = TwitchIRCClient()) {
+        self.ircClient = ircClient
+    }
+
+    // MARK: - 接続・切断
+
+    /// 指定チャンネルに接続する
+    ///
+    /// - Parameter channel: チャンネル名（例: "haishinsha"）
+    func connect(to channel: String) async {
+        guard connectionState == .disconnected else { return }
+
+        channelName = channel
+        connectionState = .connecting
+        messages = []
+
+        receiveTask = Task {
+            // メッセージ受信ループを別タスクで開始
+            let stream = await ircClient.messageStream
+            for await message in stream {
+                guard !Task.isCancelled else { break }
+                appendMessage(message)
+            }
+        }
+
+        do {
+            try await ircClient.connect(to: channel)
+            connectionState = .connected
+        } catch {
+            connectionState = .error(error.localizedDescription)
+            receiveTask?.cancel()
+        }
+    }
+
+    /// チャンネルから切断する
+    func disconnect() async {
+        receiveTask?.cancel()
+        await ircClient.disconnect()
+        connectionState = .disconnected
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// メッセージをリストに追加し、上限を超えた場合は古いものを削除する
+    private func appendMessage(_ message: ChatMessage) {
+        messages.append(message)
+        if messages.count > Self.maxMessages {
+            messages.removeFirst(messages.count - Self.maxMessages)
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/ChannelInputView.swift
+++ b/Sources/TwitchChat/Views/ChannelInputView.swift
@@ -1,0 +1,61 @@
+// ChannelInputView.swift
+// チャンネル名入力と接続・切断ボタンを提供するビュー
+// ユーザーが Twitch チャンネル名を入力して IRC 接続を開始・終了できる
+
+import SwiftUI
+
+/// チャンネル名入力 UI
+///
+/// - テキストフィールドでチャンネル名を入力
+/// - 接続/切断ボタンで接続状態を切り替え
+/// - 接続中はインジケーターを表示
+struct ChannelInputView: View {
+    @Binding var channelName: String
+    let connectionState: ConnectionState
+    let onConnect: () -> Void
+    let onDisconnect: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TextField("チャンネル名を入力", text: $channelName)
+                .textFieldStyle(.roundedBorder)
+                .disabled(connectionState == .connected || connectionState == .connecting)
+                .onSubmit {
+                    if connectionState == .disconnected {
+                        onConnect()
+                    }
+                }
+
+            connectionButton
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var connectionButton: some View {
+        switch connectionState {
+        case .disconnected, .error:
+            Button("接続") {
+                onConnect()
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(channelName.trimmingCharacters(in: .whitespaces).isEmpty)
+
+        case .connecting:
+            HStack(spacing: 4) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("接続中...")
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+
+        case .connected:
+            Button("切断") {
+                onDisconnect()
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -1,0 +1,70 @@
+// ChatMessageView.swift
+// チャットメッセージ 1 件を表示するビュー
+// ユーザー名（色付き）・バッジ・メッセージ本文を横並びで表示する
+
+import SwiftUI
+
+/// チャットメッセージ 1 件の表示ビュー
+///
+/// - ユーザー名を Twitch 設定の色で表示
+/// - バッジを絵文字で表現（broadcaster: 📡、moderator: ⚔️、subscriber: ★）
+/// - メッセージ本文を通常テキストで表示
+struct ChatMessageView: View {
+    let message: ChatMessage
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 4) {
+            // バッジ表示
+            if !message.badges.isEmpty {
+                badgesView
+            }
+
+            // ユーザー名（Twitch 設定の色）
+            Text(message.displayName)
+                .fontWeight(.semibold)
+                .foregroundStyle(usernameColor)
+                + Text(": ")
+                .foregroundStyle(.secondary)
+                + Text(message.text)
+                .foregroundStyle(.primary)
+        }
+        .font(.system(size: 13))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 3)
+    }
+
+    /// バッジを絵文字で表示
+    private var badgesView: some View {
+        HStack(spacing: 2) {
+            ForEach(message.badges, id: \.name) { badge in
+                Text(badgeEmoji(for: badge.name))
+                    .font(.system(size: 11))
+            }
+        }
+    }
+
+    /// バッジ名に対応する絵文字を返す
+    private func badgeEmoji(for badgeName: String) -> String {
+        switch badgeName {
+        case "broadcaster": return "📡"
+        case "moderator": return "⚔️"
+        case "subscriber": return "★"
+        case "vip": return "💎"
+        case "partner": return "✓"
+        case "staff": return "🔧"
+        default: return "•"
+        }
+    }
+
+    /// Twitch の色設定を SwiftUI の Color に変換する
+    private var usernameColor: Color {
+        guard let hex = message.colorHex, hex.hasPrefix("#"), hex.count == 7 else {
+            return .accentColor
+        }
+        let r = Double(Int(hex.dropFirst(1).prefix(2), radix: 16) ?? 0) / 255
+        let g = Double(Int(hex.dropFirst(3).prefix(2), radix: 16) ?? 0) / 255
+        let b = Double(Int(hex.dropFirst(5).prefix(2), radix: 16) ?? 0) / 255
+        return Color(red: r, green: g, blue: b)
+    }
+}

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -1,12 +1,72 @@
 // ContentView.swift
 // メインレイアウトビュー
-// チャンネル入力エリアとチャットメッセージリストを配置する
+// チャンネル入力エリアとチャットメッセージリストを縦に配置する
 
 import SwiftUI
 
 /// アプリのメインコンテンツビュー
+///
+/// レイアウト:
+/// - 上部: チャンネル名入力 + 接続/切断ボタン（ChannelInputView）
+/// - 中央: チャットメッセージリスト（ScrollView + LazyVStack）
+/// - エラー時: エラーメッセージを表示
 struct ContentView: View {
+    @State private var viewModel = ChatViewModel()
+    @State private var inputChannel: String = ""
+
     var body: some View {
-        Text("Twitch Chat")
+        VStack(spacing: 0) {
+            // チャンネル入力エリア
+            ChannelInputView(
+                channelName: $inputChannel,
+                connectionState: viewModel.connectionState,
+                onConnect: {
+                    Task {
+                        await viewModel.connect(to: inputChannel)
+                    }
+                },
+                onDisconnect: {
+                    Task {
+                        await viewModel.disconnect()
+                    }
+                }
+            )
+
+            Divider()
+
+            // エラー表示
+            if case .error(let message) = viewModel.connectionState {
+                Text("エラー: \(message)")
+                    .foregroundStyle(.red)
+                    .font(.caption)
+                    .padding(8)
+            }
+
+            // チャットメッセージリスト
+            chatListView
+        }
+        .background(.background)
+    }
+
+    /// チャットメッセージのスクロールビュー
+    private var chatListView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(viewModel.messages) { message in
+                        ChatMessageView(message: message)
+                            .id(message.id)
+                    }
+                }
+            }
+            .onChange(of: viewModel.messages.count) { _, _ in
+                // 新しいメッセージが届いたら最下部にスクロール
+                if let lastId = viewModel.messages.last?.id {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(lastId, anchor: .bottom)
+                    }
+                }
+            }
+        }
     }
 }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -1,0 +1,115 @@
+// ChatMessageTests.swift
+// ChatMessage モデルの単体テスト
+// IRCMessage からの変換と Badge パースを検証する
+
+import Testing
+@testable import TwitchChat
+
+/// ChatMessage モデルのテストスイート
+@Suite("ChatMessage テスト")
+struct ChatMessageTests {
+
+    // MARK: - IRCMessage からの変換
+
+    @Test("PRIVMSG を ChatMessage に変換できる")
+    func PRIVMSGをChatMessageに変換できる() {
+        // 前提: タグ付き PRIVMSG メッセージ
+        let rawMessage = "@badges=subscriber/6;color=#FF0000;display-name=山田太郎;emotes=;id=abc-123;user-id=99999 :yamadataro!yamadataro@yamadataro.tmi.twitch.tv PRIVMSG #テストチャンネル :こんにちは！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: ChatMessage に正しく変換される
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage != nil)
+        #expect(chatMessage?.username == "yamadataro")
+        #expect(chatMessage?.displayName == "山田太郎")
+        #expect(chatMessage?.text == "こんにちは！")
+        #expect(chatMessage?.colorHex == "#FF0000")
+    }
+
+    @Test("display-name がない場合は username をフォールバックとして使用する")
+    func displayNameがない場合はusernameをフォールバックとして使用する() {
+        let rawMessage = ":testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #ch :メッセージ"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.username == "testuser")
+        #expect(chatMessage?.displayName == "testuser")
+    }
+
+    @Test("PRIVMSG 以外のコマンドは nil を返す")
+    func PRIVMSG以外のコマンドはnilを返す() {
+        let rawMessage = "PING :tmi.twitch.tv"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage == nil)
+    }
+
+    @Test("trailing がない PRIVMSG は nil を返す")
+    func trailingがないPRIVMSGはnilを返す() {
+        // trailing なし（テキストなし）のメッセージ
+        let rawMessage = ":user!user@user.tmi.twitch.tv PRIVMSG #ch"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage == nil)
+    }
+
+    // MARK: - Badge のパース
+
+    @Test("broadcaster バッジをパースできる")
+    func broadcasterバッジをパースできる() {
+        let badgeString = "broadcaster/1"
+        let badges = Badge.parse(badgeString)
+
+        #expect(badges.count == 1)
+        #expect(badges[0].name == "broadcaster")
+        #expect(badges[0].version == "1")
+    }
+
+    @Test("複数のバッジをパースできる")
+    func 複数のバッジをパースできる() {
+        let badgeString = "broadcaster/1,subscriber/12,bits/1000"
+        let badges = Badge.parse(badgeString)
+
+        #expect(badges.count == 3)
+        #expect(badges[0].name == "broadcaster")
+        #expect(badges[1].name == "subscriber")
+        #expect(badges[1].version == "12")
+        #expect(badges[2].name == "bits")
+        #expect(badges[2].version == "1000")
+    }
+
+    @Test("空のバッジ文字列は空配列を返す")
+    func 空のバッジ文字列は空配列を返す() {
+        let badges = Badge.parse("")
+        #expect(badges.isEmpty)
+    }
+
+    @Test("PRIVMSG のバッジタグが正しく ChatMessage に反映される")
+    func PRIVMSGのバッジタグが正しくChatMessageに反映される() {
+        let rawMessage = "@badges=broadcaster/1,subscriber/12;color=#0000FF;display-name=配信者 :haishinsha!haishinsha@haishinsha.tmi.twitch.tv PRIVMSG #haishinsha :配信開始！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.badges.count == 2)
+        #expect(chatMessage?.badges[0].name == "broadcaster")
+        #expect(chatMessage?.badges[1].name == "subscriber")
+        #expect(chatMessage?.colorHex == "#0000FF")
+    }
+}

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -1,0 +1,133 @@
+// ChatViewModelTests.swift
+// ChatViewModel の単体テスト
+// MockTwitchIRCClient を使用してネットワーク通信なしで ViewModel の振る舞いを検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - モック
+
+/// テスト用の TwitchIRCClient モック
+actor MockTwitchIRCClient: TwitchIRCClientProtocol {
+    private(set) var connectedChannel: String?
+    private(set) var disconnectCalled = false
+    private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
+    let messageStream: AsyncStream<ChatMessage>
+
+    init() {
+        var continuation: AsyncStream<ChatMessage>.Continuation?
+        self.messageStream = AsyncStream { continuation = $0 }
+        self.messageContinuation = continuation
+    }
+
+    func connect(to channel: String) async throws {
+        connectedChannel = channel
+    }
+
+    func disconnect() async {
+        disconnectCalled = true
+        messageContinuation?.finish()
+    }
+
+    /// テスト用にメッセージを流し込む
+    func sendMessage(_ message: ChatMessage) {
+        messageContinuation?.yield(message)
+    }
+}
+
+// MARK: - テスト
+
+/// ChatViewModel のテストスイート
+@Suite("ChatViewModel テスト")
+@MainActor
+struct ChatViewModelTests {
+
+    // MARK: - 接続状態管理
+
+    @Test("初期状態は disconnected")
+    func 初期状態はdisconnected() {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        #expect(viewModel.connectionState == .disconnected)
+        #expect(viewModel.messages.isEmpty)
+        #expect(viewModel.channelName.isEmpty)
+    }
+
+    @Test("チャンネル接続後は connected 状態になる")
+    func チャンネル接続後はconnected状態になる() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(viewModel.connectionState == .connected)
+        #expect(viewModel.channelName == "テストチャンネル")
+    }
+
+    @Test("切断後は disconnected 状態になる")
+    func 切断後はdisconnected状態になる() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await viewModel.disconnect()
+
+        #expect(viewModel.connectionState == .disconnected)
+    }
+
+    // MARK: - メッセージ受信
+
+    @Test("受信メッセージがリストに追加される")
+    func 受信メッセージがリストに追加される() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // メッセージを流し込む
+        let message = makeTestChatMessage(displayName: "山田太郎", text: "こんにちは")
+        await mockClient.sendMessage(message)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages[0].displayName == "山田太郎")
+        #expect(viewModel.messages[0].text == "こんにちは")
+    }
+
+    // MARK: - メッセージ上限
+
+    @Test("メッセージが 500 件を超えると古いものから削除される")
+    func メッセージが500件を超えると古いものから削除される() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 501 件のメッセージを流し込む
+        for i in 0..<501 {
+            let message = makeTestChatMessage(displayName: "ユーザー\(i)", text: "メッセージ \(i)")
+            await mockClient.sendMessage(message)
+        }
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms 待機
+
+        // 最大 500 件に制限される
+        #expect(viewModel.messages.count <= 500)
+        // 最新のメッセージが残っている
+        #expect(viewModel.messages.last?.text == "メッセージ 500")
+    }
+
+    // MARK: - ヘルパー
+
+    /// テスト用の ChatMessage を生成する
+    private func makeTestChatMessage(displayName: String, text: String) -> ChatMessage {
+        let rawMessage = "@badges=;color=#FF0000;display-name=\(displayName);emotes=;id=\(UUID().uuidString);user-id=12345 :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :\(text)"
+        let ircMessage = IRCMessageParser.parse(rawMessage)!
+        return ChatMessage(from: ircMessage)!
+    }
+}

--- a/Tests/TwitchChatTests/IRCMessageParserTests.swift
+++ b/Tests/TwitchChatTests/IRCMessageParserTests.swift
@@ -1,0 +1,137 @@
+// IRCMessageParserTests.swift
+// IRCMessageParser の単体テスト
+// 各種 IRC メッセージ形式のパースを検証する
+
+import Testing
+@testable import TwitchChat
+
+/// IRCMessageParser のテストスイート
+@Suite("IRCMessageParser テスト")
+struct IRCMessageParserTests {
+
+    // MARK: - PING メッセージ
+
+    @Test("PING メッセージをパースできる")
+    func pingメッセージをパースできる() {
+        let rawMessage = "PING :tmi.twitch.tv"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "PING")
+        #expect(result?.trailing == "tmi.twitch.tv")
+        #expect(result?.tags.isEmpty == true)
+    }
+
+    // MARK: - PRIVMSG メッセージ（タグなし）
+
+    @Test("タグなし PRIVMSG をパースできる")
+    func タグなしPRIVMSGをパースできる() {
+        let rawMessage = ":ユーザー名!ユーザー名@ユーザー名.tmi.twitch.tv PRIVMSG #テストチャンネル :こんにちは世界"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "PRIVMSG")
+        #expect(result?.prefix == "ユーザー名!ユーザー名@ユーザー名.tmi.twitch.tv")
+        #expect(result?.params == ["#テストチャンネル"])
+        #expect(result?.trailing == "こんにちは世界")
+        #expect(result?.tags.isEmpty == true)
+    }
+
+    // MARK: - PRIVMSG メッセージ（タグあり）
+
+    @Test("タグ付き PRIVMSG をパースできる")
+    func タグ付きPRIVMSGをパースできる() {
+        let rawMessage = "@badge-info=subscriber/6;badges=subscriber/6;color=#FF0000;display-name=テストユーザー;emotes=;id=abc-123;mod=0;subscriber=1;tmi-sent-ts=1700000000000;user-id=12345 :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #テストチャンネル :これはテストメッセージです"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "PRIVMSG")
+        #expect(result?.tags["display-name"] == "テストユーザー")
+        #expect(result?.tags["color"] == "#FF0000")
+        #expect(result?.tags["subscriber"] == "1")
+        #expect(result?.tags["user-id"] == "12345")
+        #expect(result?.trailing == "これはテストメッセージです")
+    }
+
+    @Test("broadcaster バッジを持つ PRIVMSG をパースできる")
+    func broadcasterバッジを持つPRIVMSGをパースできる() {
+        let rawMessage = "@badges=broadcaster/1,subscriber/12;color=#8A2BE2;display-name=配信者 :haishinsha!haishinsha@haishinsha.tmi.twitch.tv PRIVMSG #haishinsha :配信中です"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.tags["badges"] == "broadcaster/1,subscriber/12")
+        #expect(result?.tags["display-name"] == "配信者")
+        #expect(result?.tags["color"] == "#8A2BE2")
+    }
+
+    // MARK: - JOIN / PART メッセージ
+
+    @Test("JOIN メッセージをパースできる")
+    func JOINメッセージをパースできる() {
+        let rawMessage = ":testuser!testuser@testuser.tmi.twitch.tv JOIN #テストチャンネル"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "JOIN")
+        #expect(result?.params == ["#テストチャンネル"])
+    }
+
+    @Test("PART メッセージをパースできる")
+    func PARTメッセージをパースできる() {
+        let rawMessage = ":testuser!testuser@testuser.tmi.twitch.tv PART #テストチャンネル"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "PART")
+        #expect(result?.params == ["#テストチャンネル"])
+    }
+
+    // MARK: - CAP ACK
+
+    @Test("CAP ACK レスポンスをパースできる")
+    func CAPACKレスポンスをパースできる() {
+        let rawMessage = ":tmi.twitch.tv CAP * ACK :twitch.tv/tags twitch.tv/commands"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "CAP")
+        #expect(result?.trailing == "twitch.tv/tags twitch.tv/commands")
+    }
+
+    // MARK: - エラーハンドリング
+
+    @Test("空文字列はnilを返す")
+    func 空文字列はnilを返す() {
+        let result = IRCMessageParser.parse("")
+        #expect(result == nil)
+    }
+
+    @Test("スペースのみの文字列はnilを返す")
+    func スペースのみの文字列はnilを返す() {
+        let result = IRCMessageParser.parse("   ")
+        #expect(result == nil)
+    }
+
+    // MARK: - タグのエスケープ
+
+    @Test("タグ値のエスケープシーケンスを正しく変換できる")
+    func タグ値のエスケープシーケンスを正しく変換できる() {
+        // \s はスペース、\: はセミコロン、\\ はバックスラッシュ
+        let rawMessage = "@display-name=テスト\\sユーザー :user!user@user.tmi.twitch.tv PRIVMSG #ch :test"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result?.tags["display-name"] == "テスト ユーザー")
+    }
+
+    // MARK: - 数値コマンド（RPL）
+
+    @Test("数値コマンド 001 をパースできる")
+    func 数値コマンド001をパースできる() {
+        let rawMessage = ":tmi.twitch.tv 001 justinfan12345 :Welcome, GLHF!"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "001")
+        #expect(result?.trailing == "Welcome, GLHF!")
+    }
+}

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -1,0 +1,165 @@
+// TwitchIRCClientTests.swift
+// TwitchIRCClient の単体テスト
+// MockWebSocketClient を使用してネットワーク通信なしで IRC プロトコルを検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - モック
+
+/// テスト用の WebSocket クライアントモック
+///
+/// 実際のネットワーク通信なしに送受信メッセージを制御する
+actor MockWebSocketClient: WebSocketClientProtocol {
+    /// 送信されたメッセージのログ
+    private(set) var sentMessages: [String] = []
+
+    /// 受信待ちのメッセージキュー
+    private var receivableMessages: [String] = []
+
+    /// 接続済みフラグ
+    private(set) var isConnected = false
+
+    /// 受信を待機する継続
+    private var pendingReceiveContinuations: [CheckedContinuation<String, Error>] = []
+
+    func connect(to url: URL) async throws {
+        isConnected = true
+    }
+
+    func send(_ message: String) async throws {
+        sentMessages.append(message)
+    }
+
+    func receive() async throws -> String {
+        // キューにメッセージがあれば即返す
+        if !receivableMessages.isEmpty {
+            return receivableMessages.removeFirst()
+        }
+        // なければ待機
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingReceiveContinuations.append(continuation)
+        }
+    }
+
+    func disconnect() async {
+        isConnected = false
+        // 待機中の継続をすべてキャンセル
+        for continuation in pendingReceiveContinuations {
+            continuation.resume(throwing: CancellationError())
+        }
+        pendingReceiveContinuations.removeAll()
+    }
+
+    /// 受信メッセージをモックに追加する（テスト用）
+    func enqueueMessage(_ message: String) {
+        if let continuation = pendingReceiveContinuations.first {
+            pendingReceiveContinuations.removeFirst()
+            continuation.resume(returning: message)
+        } else {
+            receivableMessages.append(message)
+        }
+    }
+}
+
+// MARK: - テスト
+
+/// TwitchIRCClient のテストスイート
+@Suite("TwitchIRCClient テスト")
+struct TwitchIRCClientTests {
+
+    // MARK: - 接続シーケンス
+
+    @Test("接続時に正しい IRC コマンドが送信される")
+    func 接続時に正しいIRCコマンドが送信される() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // チャンネル接続（接続後すぐ切断して送信メッセージだけ確認）
+        let task = Task {
+            try await client.connect(to: "testchannel")
+        }
+        // 少し待ってから切断
+        try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        await client.disconnect()
+        task.cancel()
+
+        let sent = await mockWS.sentMessages
+        // 接続シーケンスに必要なコマンドが含まれていることを確認
+        #expect(sent.contains("PASS SCHMOOPIIE"))
+        #expect(sent.contains("NICK justinfan12345"))
+        #expect(sent.contains("CAP REQ :twitch.tv/tags twitch.tv/commands"))
+        #expect(sent.contains("JOIN #testchannel"))
+    }
+
+    @Test("チャンネル名は小文字に変換して JOIN する")
+    func チャンネル名は小文字に変換してJOINする() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        let task = Task {
+            try await client.connect(to: "TestChannel")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await client.disconnect()
+        task.cancel()
+
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("JOIN #testchannel"))
+    }
+
+    // MARK: - PING/PONG
+
+    @Test("PING 受信時に PONG を返す")
+    func PING受信時にPONGを返す() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 接続後 PING を送り込む
+        await mockWS.enqueueMessage("PING :tmi.twitch.tv")
+
+        let task = Task {
+            try await client.connect(to: "testchannel")
+        }
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        await client.disconnect()
+        task.cancel()
+
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("PONG :tmi.twitch.tv"))
+    }
+
+    // MARK: - メッセージ受信
+
+    @Test("PRIVMSG 受信時に ChatMessage が AsyncStream に流れる")
+    func PRIVMSG受信時にChatMessageがAsyncStreamに流れる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // テストメッセージを事前にキュー
+        let rawMessage = "@badges=;color=#FF0000;display-name=テストユーザー;emotes=;id=test-id;user-id=12345 :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :こんにちはテストです"
+        await mockWS.enqueueMessage(rawMessage)
+
+        var receivedMessages: [ChatMessage] = []
+        let stream = await client.messageStream
+
+        let connectTask = Task {
+            try await client.connect(to: "testchannel")
+        }
+
+        // 最初のメッセージを受信する
+        for await message in stream {
+            receivedMessages.append(message)
+            break // 1件受信したら終了
+        }
+
+        await client.disconnect()
+        connectTask.cancel()
+
+        #expect(receivedMessages.count == 1)
+        #expect(receivedMessages[0].displayName == "テストユーザー")
+        #expect(receivedMessages[0].text == "こんにちはテストです")
+        #expect(receivedMessages[0].colorHex == "#FF0000")
+    }
+}


### PR DESCRIPTION
## Summary

- Twitch IRC に匿名接続（justinfan 方式）してリアルタイムチャットを表示する macOS 15+ ネイティブアプリ
- SPM（Swift Package Manager）ベース、外部依存なし（swift-testing は開発環境補完のみ）
- TDD（テスト駆動開発）で実装: 29 テストすべてパス

## 実装内容

### Models
- `IRCMessage`: IRCv3 タグ対応の IRC メッセージ構造体
- `ChatMessage`: 表示用チャットメッセージ（PRIVMSG から変換）
- `Badge`: バッジ文字列のパーサー

### Services
- `IRCMessageParser`: Twitch IRC メッセージの純粋関数パーサー（エスケープシーケンス対応）
- `WebSocketClient`: URLSessionWebSocketTask ラッパー（プロトコルで抽象化）
- `TwitchIRCClient`: Twitch IRC 接続管理（PING/PONG keepalive・AsyncStream 配信）

### ViewModels
- `ChatViewModel`: `@Observable` による接続状態・メッセージリスト管理（最新 500 件）

### Views
- `ContentView`: メインレイアウト（チャンネル入力 + メッセージリスト + 自動スクロール）
- `ChannelInputView`: チャンネル名入力・接続/切断ボタン
- `ChatMessageView`: ユーザー名（色付き）・バッジ絵文字・メッセージ本文

## Test plan

- [x] `swift build` でビルド成功
- [x] `swift test` で 29 テスト全パス（4 スイート: IRCMessageParser, ChatMessage, TwitchIRCClient, ChatViewModel）
- [ ] アプリ起動 → チャンネル名入力 → Twitch チャット表示確認（Xcode 必要）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Twitch チャットへの接続機能を実装しました。チャンネル名を入力して接続するだけで、リアルタイムにメッセージを受信・表示できます。
  * チャットメッセージにユーザーバッジ（ブロードキャスター、サブスクライバーなど）を表示するようにしました。
  * ユーザーのチャットカラーを表示に反映させました。
  * 接続状態（接続中、接続、切断、エラー）を UI で明確に表示します。

* **テスト**
  * チャット機能の動作検証に必要なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->