### PR TITLE
feat: Twitch エモートをアニメーション対応でインライン表示する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.xcworkspace/
 .DS_Store
 Package.resolved
+.swiftpm/xcode/xcuserdata/

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -52,6 +52,12 @@ struct ChatMessage: Sendable, Identifiable {
     /// バッジ一覧
     let badges: [Badge]
 
+    /// パース済みエモート位置情報
+    let emotes: [EmotePosition]
+
+    /// メッセージのセグメント分割結果（テキストとエモートの交互配列）
+    let segments: [MessageSegment]
+
     /// メッセージの受信時刻
     let receivedAt: Date
 
@@ -77,6 +83,9 @@ struct ChatMessage: Sendable, Identifiable {
         self.text = text
         self.colorHex = ircMessage.tags["color"]?.isEmpty == false ? ircMessage.tags["color"] : nil
         self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
+        let parsedEmotes = EmoteParser.parse(ircMessage.tags["emotes"] ?? "")
+        self.emotes = parsedEmotes
+        self.segments = MessageSegment.segments(from: text, emotePositions: parsedEmotes)
         self.receivedAt = Date()
     }
 }

--- a/Sources/TwitchChat/Models/MessageSegment.swift
+++ b/Sources/TwitchChat/Models/MessageSegment.swift
@@ -1,0 +1,81 @@
+// MessageSegment.swift
+// チャットメッセージのセグメント表現
+// テキスト部分とエモート部分を区別して保持し、UI での混合表示を可能にする
+
+import Foundation
+
+/// チャットメッセージの構成要素（テキストまたはエモート）
+///
+/// IRCメッセージの本文をテキスト部分とエモート部分に分割した結果の1単位を表す。
+/// `MessageSegment.segments(from:emotePositions:)` で分割して得られる。
+enum MessageSegment: Sendable, Equatable {
+    /// 通常のテキスト部分
+    case text(String)
+
+    /// エモート部分
+    ///
+    /// - Parameters:
+    ///   - id: Twitch エモートの一意ID（画像URLの生成に使用）
+    ///   - name: エモート名（テキスト上の文字列。未取得時のプレースホルダにも使用）
+    case emote(id: String, name: String)
+}
+
+extension MessageSegment {
+
+    /// メッセージテキストと EmotePosition 配列からセグメント配列を生成する
+    ///
+    /// Twitch IRC の emotes タグは UTF-16 コードユニットベースのオフセットを使用するため、
+    /// Swift の String.Index への変換に `String.Index(utf16Offset:in:)` を使用する。
+    ///
+    /// - Parameters:
+    ///   - text: メッセージ本文（Swift String）
+    ///   - emotePositions: `EmoteParser.parse()` の結果（startIndex 昇順であること）
+    /// - Returns: テキストとエモートが交互に並ぶセグメント配列
+    static func segments(from text: String, emotePositions: [EmotePosition]) -> [MessageSegment] {
+        guard !emotePositions.isEmpty else { return [.text(text)] }
+
+        let utf16Count = text.utf16.count
+        // startIndex 昇順でソート（念のため）
+        let sorted = emotePositions.sorted { $0.startIndex < $1.startIndex }
+
+        var result: [MessageSegment] = []
+        // 現在処理済みの末尾 UTF-16 オフセット
+        var currentOffset = 0
+
+        for pos in sorted {
+            // 範囲チェック: 不正なオフセットはスキップ
+            guard pos.startIndex >= currentOffset,
+                  pos.startIndex < utf16Count,
+                  pos.endIndex < utf16Count else { continue }
+
+            // エモート前のテキスト部分
+            if pos.startIndex > currentOffset {
+                let start = String.Index(utf16Offset: currentOffset, in: text)
+                let end = String.Index(utf16Offset: pos.startIndex, in: text)
+                let substr = String(text[start..<end])
+                if !substr.isEmpty {
+                    result.append(.text(substr))
+                }
+            }
+
+            // エモート部分（endIndex は inclusive なので +1 して exclusive に変換）
+            let emoteStart = String.Index(utf16Offset: pos.startIndex, in: text)
+            let emoteEnd = String.Index(utf16Offset: pos.endIndex + 1, in: text)
+            let emoteName = String(text[emoteStart..<emoteEnd])
+            result.append(.emote(id: pos.emoteId, name: emoteName))
+
+            currentOffset = pos.endIndex + 1
+        }
+
+        // 残りのテキスト部分
+        if currentOffset <= utf16Count {
+            let start = String.Index(utf16Offset: currentOffset, in: text)
+            let remaining = String(text[start...])
+            if !remaining.isEmpty {
+                result.append(.text(remaining))
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/TwitchChat/Models/MessageSegment.swift
+++ b/Sources/TwitchChat/Models/MessageSegment.swift
@@ -77,6 +77,9 @@ extension MessageSegment {
             }
         }
 
+        // 全エモートがスキップされた場合のフォールバック
+        if result.isEmpty { return [.text(text)] }
+
         return result
     }
 }

--- a/Sources/TwitchChat/Models/MessageSegment.swift
+++ b/Sources/TwitchChat/Models/MessageSegment.swift
@@ -43,10 +43,11 @@ extension MessageSegment {
         var currentOffset = 0
 
         for pos in sorted {
-            // 範囲チェック: 不正なオフセットはスキップ
+            // 範囲チェック: 不正なオフセット・逆転レンジはスキップ
             guard pos.startIndex >= currentOffset,
                   pos.startIndex < utf16Count,
-                  pos.endIndex < utf16Count else { continue }
+                  pos.endIndex < utf16Count,
+                  pos.startIndex <= pos.endIndex else { continue }
 
             // エモート前のテキスト部分
             if pos.startIndex > currentOffset {
@@ -67,8 +68,8 @@ extension MessageSegment {
             currentOffset = pos.endIndex + 1
         }
 
-        // 残りのテキスト部分
-        if currentOffset <= utf16Count {
+        // 残りのテキスト部分（currentOffset が utf16Count 未満の場合のみ）
+        if currentOffset < utf16Count {
             let start = String.Index(utf16Offset: currentOffset, in: text)
             let remaining = String(text[start...])
             if !remaining.isEmpty {

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -113,10 +113,13 @@ final class EmoteImageCache: @unchecked Sendable {
     ///   - scale: 画像スケール（デフォルト: `"2.0"`。Retina ディスプレイ対応）
     /// - Returns: 画像取得用 URL
     static func emoteURL(emoteId: String, type: String = "default", scale: String = "2.0") -> URL {
-        // emoteId を URL パスコンポーネントとして安全にエンコード
-        let encodedId = emoteId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? emoteId
-        // Twitch の emoteId は常に数値文字列のため URL 構築は必ず成功する
-        return URL(string: "https://static-cdn.jtvnw.net/emoticons/v2/\(encodedId)/\(type)/dark/\(scale)")!
+        // URLComponents でパスコンポーネントを安全にパーセントエンコードする
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "static-cdn.jtvnw.net"
+        components.path = "/emoticons/v2/\(emoteId)/\(type)/dark/\(scale)"
+        // emoteId は数値文字列、type・scale は固定値のため URL 構築は常に成功する
+        return components.url!
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -10,6 +10,7 @@ import Foundation
 ///
 /// - アニメーション版 URL（`/animated/`）を先に試み、失敗時はスタティック版（`/default/`）にフォールバック
 /// - NSCache によるメモリキャッシュ（メモリプレッシャー時に自動解放）
+/// - 同一エモートへの並行リクエストを1回のダウンロードに集約する in-flight 管理
 /// - NSImage.size を `emoteDisplaySize` に設定してテキスト行高と一致させる
 /// - シングルトンで全 View 間でキャッシュを共有
 final class EmoteImageCache: @unchecked Sendable {
@@ -34,18 +35,24 @@ final class EmoteImageCache: @unchecked Sendable {
     /// アニメーション版が存在するエモートIDの集合
     private var animatedEmoteIds: Set<String> = []
 
-    /// animatedEmoteIds へのアクセスを保護するロック
+    /// 進行中のダウンロードタスク（キー: エモートID）
+    ///
+    /// 同一エモートへの並行リクエストを1回のダウンロードに集約し、重複ネットワーク通信を防ぐ。
+    private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
+
+    /// animatedEmoteIds / inFlightTasks へのアクセスを保護するロック
     private let lock = NSLock()
 
     private init() {}
 
     // MARK: - 画像取得
 
-    /// エモートIDから画像を取得する（キャッシュ優先）
+    /// エモートIDから画像を取得する（キャッシュ優先・並行重複排除付き）
     ///
-    /// キャッシュにある場合は即時返却。ない場合は以下の順で取得する:
-    /// 1. アニメーション版 URL（`/animated/`）を試みる
-    /// 2. 失敗した場合はスタティック版 URL（`/default/`）にフォールバック
+    /// 取得順序:
+    /// 1. キャッシュヒットなら即時返却
+    /// 2. 進行中タスクがあれば結果を待つ（重複ダウンロード回避）
+    /// 3. 新規タスクを作成: アニメーション版 → スタティック版の順でダウンロード
     ///
     /// - Parameter emoteId: Twitch エモートID（例: "25"）
     /// - Returns: ダウンロード済みの NSImage（`emoteDisplaySize` にリサイズ済み）。取得失敗時は nil
@@ -57,19 +64,32 @@ final class EmoteImageCache: @unchecked Sendable {
             return cached
         }
 
-        // アニメーション版を先に試みる
-        if let image = await download(emoteId: emoteId, type: "animated") {
-            store(image, for: emoteId, isAnimated: true)
-            return image
+        // 進行中タスクへの相乗り、または新規タスクの作成（排他制御）
+        let task: Task<NSImage?, Never> = lock.withLock {
+            if let existing = inFlightTasks[emoteId] {
+                return existing
+            }
+            let newTask = Task { [weak self] in
+                guard let self else { return nil as NSImage? }
+                defer { self.lock.withLock { self.inFlightTasks.removeValue(forKey: emoteId) } }
+
+                // アニメーション版を先に試みる
+                if let image = await self.download(emoteId: emoteId, type: "animated") {
+                    self.store(image, for: emoteId, isAnimated: true)
+                    return image
+                }
+                // スタティック版にフォールバック
+                if let image = await self.download(emoteId: emoteId, type: "default") {
+                    self.store(image, for: emoteId, isAnimated: false)
+                    return image
+                }
+                return nil
+            }
+            inFlightTasks[emoteId] = newTask
+            return newTask
         }
 
-        // スタティック版にフォールバック
-        if let image = await download(emoteId: emoteId, type: "default") {
-            store(image, for: emoteId, isAnimated: false)
-            return image
-        }
-
-        return nil
+        return await task.value
     }
 
     /// エモートがアニメーション版かどうかを返す
@@ -88,13 +108,15 @@ final class EmoteImageCache: @unchecked Sendable {
     /// `https://static-cdn.jtvnw.net/emoticons/v2/{id}/{type}/dark/{scale}`
     ///
     /// - Parameters:
-    ///   - emoteId: Twitch エモートID（例: "25"）
+    ///   - emoteId: Twitch エモートID（例: "25"）。URL パスコンポーネントとして percent-encode される
     ///   - type: 画像タイプ（`"default"` = スタティック PNG、`"animated"` = アニメーション GIF）
     ///   - scale: 画像スケール（デフォルト: `"2.0"`。Retina ディスプレイ対応）
     /// - Returns: 画像取得用 URL
     static func emoteURL(emoteId: String, type: String = "default", scale: String = "2.0") -> URL {
-        // URL は固定形式のため force unwrap は安全
-        URL(string: "https://static-cdn.jtvnw.net/emoticons/v2/\(emoteId)/\(type)/dark/\(scale)")!
+        // emoteId を URL パスコンポーネントとして安全にエンコード
+        let encodedId = emoteId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? emoteId
+        // Twitch の emoteId は常に数値文字列のため URL 構築は必ず成功する
+        return URL(string: "https://static-cdn.jtvnw.net/emoticons/v2/\(encodedId)/\(type)/dark/\(scale)")!
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -1,0 +1,133 @@
+// EmoteImageCache.swift
+// Twitch エモート画像のキャッシュと非同期読み込みを管理するサービス
+// NSCache ベースのメモリキャッシュで同一エモートの再ダウンロードを防ぐ
+// アニメーション版（GIF）を優先的に取得し、未対応エモートはスタティック版にフォールバックする
+
+import AppKit
+import Foundation
+
+/// Twitch エモート画像のキャッシュ管理クラス
+///
+/// - アニメーション版 URL（`/animated/`）を先に試み、失敗時はスタティック版（`/default/`）にフォールバック
+/// - NSCache によるメモリキャッシュ（メモリプレッシャー時に自動解放）
+/// - NSImage.size を `emoteDisplaySize` に設定してテキスト行高と一致させる
+/// - シングルトンで全 View 間でキャッシュを共有
+final class EmoteImageCache: @unchecked Sendable {
+
+    /// シングルトンインスタンス
+    static let shared = EmoteImageCache()
+
+    /// エモートの表示サイズ（ポイント）
+    ///
+    /// 13pt フォントの行高（~18pt）に合わせた値。
+    /// NSImage.size および AnimatedEmoteView のフレームサイズに使用する。
+    static let emoteDisplaySize: CGFloat = 20
+
+    /// エモート画像のメモリキャッシュ（キー: エモートID）
+    private let imageCache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        // よく使われるエモートは数十種類なので 500 件で十分
+        c.countLimit = 500
+        return c
+    }()
+
+    /// アニメーション版が存在するエモートIDの集合
+    private var animatedEmoteIds: Set<String> = []
+
+    /// animatedEmoteIds へのアクセスを保護するロック
+    private let lock = NSLock()
+
+    private init() {}
+
+    // MARK: - 画像取得
+
+    /// エモートIDから画像を取得する（キャッシュ優先）
+    ///
+    /// キャッシュにある場合は即時返却。ない場合は以下の順で取得する:
+    /// 1. アニメーション版 URL（`/animated/`）を試みる
+    /// 2. 失敗した場合はスタティック版 URL（`/default/`）にフォールバック
+    ///
+    /// - Parameter emoteId: Twitch エモートID（例: "25"）
+    /// - Returns: ダウンロード済みの NSImage（`emoteDisplaySize` にリサイズ済み）。取得失敗時は nil
+    func image(for emoteId: String) async -> NSImage? {
+        let cacheKey = emoteId as NSString
+
+        // キャッシュヒット: 即時返却
+        if let cached = imageCache.object(forKey: cacheKey) {
+            return cached
+        }
+
+        // アニメーション版を先に試みる
+        if let image = await download(emoteId: emoteId, type: "animated") {
+            store(image, for: emoteId, isAnimated: true)
+            return image
+        }
+
+        // スタティック版にフォールバック
+        if let image = await download(emoteId: emoteId, type: "default") {
+            store(image, for: emoteId, isAnimated: false)
+            return image
+        }
+
+        return nil
+    }
+
+    /// エモートがアニメーション版かどうかを返す
+    ///
+    /// - Parameter emoteId: Twitch エモートID
+    /// - Returns: アニメーション版が取得済みの場合 true
+    func isAnimated(emoteId: String) -> Bool {
+        lock.withLock { animatedEmoteIds.contains(emoteId) }
+    }
+
+    // MARK: - URL 生成
+
+    /// エモート画像の CDN URL を生成する
+    ///
+    /// Twitch CDN のエモート画像 URL 形式:
+    /// `https://static-cdn.jtvnw.net/emoticons/v2/{id}/{type}/dark/{scale}`
+    ///
+    /// - Parameters:
+    ///   - emoteId: Twitch エモートID（例: "25"）
+    ///   - type: 画像タイプ（`"default"` = スタティック PNG、`"animated"` = アニメーション GIF）
+    ///   - scale: 画像スケール（デフォルト: `"2.0"`。Retina ディスプレイ対応）
+    /// - Returns: 画像取得用 URL
+    static func emoteURL(emoteId: String, type: String = "default", scale: String = "2.0") -> URL {
+        // URL は固定形式のため force unwrap は安全
+        URL(string: "https://static-cdn.jtvnw.net/emoticons/v2/\(emoteId)/\(type)/dark/\(scale)")!
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// 指定タイプの画像を CDN からダウンロードする
+    ///
+    /// - Parameters:
+    ///   - emoteId: Twitch エモートID
+    ///   - type: 画像タイプ（`"default"` または `"animated"`）
+    /// - Returns: ダウンロード成功時は NSImage、HTTP 200 以外または解析失敗時は nil
+    private func download(emoteId: String, type: String) async -> NSImage? {
+        let url = Self.emoteURL(emoteId: emoteId, type: type)
+        guard let (data, response) = try? await URLSession.shared.data(from: url),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let image = NSImage(data: data) else { return nil }
+        return image
+    }
+
+    /// 画像をキャッシュに保存し、表示サイズを設定する
+    ///
+    /// NSImage.size を設定することで、`Text(Image(nsImage:))` でのインライン表示サイズを
+    /// `emoteDisplaySize` に揃える。ビットマップデータは変更しない。
+    ///
+    /// - Parameters:
+    ///   - image: 保存する NSImage
+    ///   - emoteId: Twitch エモートID
+    ///   - isAnimated: アニメーション版かどうか
+    private func store(_ image: NSImage, for emoteId: String, isAnimated: Bool) {
+        image.size = NSSize(width: Self.emoteDisplaySize, height: Self.emoteDisplaySize)
+        imageCache.setObject(image, forKey: emoteId as NSString)
+        if isAnimated {
+            lock.withLock { animatedEmoteIds.insert(emoteId) }
+        }
+    }
+}

--- a/Sources/TwitchChat/Services/EmoteParser.swift
+++ b/Sources/TwitchChat/Services/EmoteParser.swift
@@ -56,7 +56,8 @@ enum EmoteParser {
                 let range = position.split(separator: "-", maxSplits: 1)
                 guard range.count == 2,
                       let start = Int(range[0]),
-                      let end = Int(range[1]) else { continue }
+                      let end = Int(range[1]),
+                      start <= end else { continue }
 
                 result.append(EmotePosition(emoteId: emoteId, startIndex: start, endIndex: end))
             }

--- a/Sources/TwitchChat/Services/EmoteParser.swift
+++ b/Sources/TwitchChat/Services/EmoteParser.swift
@@ -57,6 +57,7 @@ enum EmoteParser {
                 guard range.count == 2,
                       let start = Int(range[0]),
                       let end = Int(range[1]),
+                      start >= 0, end >= 0,
                       start <= end else { continue }
 
                 result.append(EmotePosition(emoteId: emoteId, startIndex: start, endIndex: end))

--- a/Sources/TwitchChat/Services/EmoteParser.swift
+++ b/Sources/TwitchChat/Services/EmoteParser.swift
@@ -1,0 +1,68 @@
+// EmoteParser.swift
+// Twitch IRC の emotes タグをパースするユーティリティ
+// `emotes` タグ値からエモートIDとテキスト内の位置情報を抽出する
+
+import Foundation
+
+/// エモートのテキスト内位置情報
+///
+/// Twitch IRC の `emotes` タグ値（例: `25:0-4,12-16`）をパースした1エントリを表す。
+/// 位置は UTF-16 コードユニットベースのオフセット（0-based）。
+struct EmotePosition: Sendable, Equatable {
+    /// Twitch エモートの一意ID（例: "25", "1902"）
+    let emoteId: String
+
+    /// テキスト内の開始位置（UTF-16 オフセット、0-based）
+    let startIndex: Int
+
+    /// テキスト内の終了位置（UTF-16 オフセット、inclusive）
+    let endIndex: Int
+}
+
+/// Twitch IRC の emotes タグパーサー
+///
+/// emotes タグ形式: `emoteId:start-end,start-end/emoteId:start-end`
+/// - スラッシュ区切りで各エモートIDグループ
+/// - コロン後にカンマ区切りで位置範囲リスト
+/// - 位置は UTF-16 コードユニットベースのインデックス
+///
+/// - Note: 副作用なしの純粋関数で実装し、テスト容易性を確保する
+enum EmoteParser {
+
+    /// emotes タグ文字列をパースして EmotePosition の配列を返す
+    ///
+    /// - Parameter emotesTag: Twitch IRC の emotes タグ値（例: `"25:0-4,12-16/1902:6-10"`）
+    /// - Returns: startIndex 昇順にソートされた EmotePosition の配列。
+    ///   空文字列または不正形式の場合は空配列を返す。
+    static func parse(_ emotesTag: String) -> [EmotePosition] {
+        guard !emotesTag.isEmpty else { return [] }
+
+        var result: [EmotePosition] = []
+
+        // スラッシュ区切りで各エモートIDグループに分割
+        let emoteGroups = emotesTag.split(separator: "/", omittingEmptySubsequences: true)
+        for group in emoteGroups {
+            // コロンでエモートIDと位置リストに分割
+            let parts = group.split(separator: ":", maxSplits: 1)
+            guard parts.count == 2 else { continue }
+
+            let emoteId = String(parts[0])
+            let positionsString = String(parts[1])
+
+            // カンマ区切りで各位置範囲に分割
+            let positions = positionsString.split(separator: ",", omittingEmptySubsequences: true)
+            for position in positions {
+                // ハイフンで開始位置と終了位置に分割
+                let range = position.split(separator: "-", maxSplits: 1)
+                guard range.count == 2,
+                      let start = Int(range[0]),
+                      let end = Int(range[1]) else { continue }
+
+                result.append(EmotePosition(emoteId: emoteId, startIndex: start, endIndex: end))
+            }
+        }
+
+        // startIndex 昇順でソート
+        return result.sorted { $0.startIndex < $1.startIndex }
+    }
+}

--- a/Sources/TwitchChat/Views/AnimatedEmoteView.swift
+++ b/Sources/TwitchChat/Views/AnimatedEmoteView.swift
@@ -1,0 +1,43 @@
+// AnimatedEmoteView.swift
+// アニメーション対応のエモート画像ビュー
+// NSImageView をラップして GIF アニメーションを再生する SwiftUI ビュー
+
+import AppKit
+import SwiftUI
+
+/// アニメーション対応のエモート画像ビュー
+///
+/// `NSImageView` を `NSViewRepresentable` でラップし、GIF アニメーションを再生する。
+/// スタティック画像の場合は通常の静止画として表示する。
+///
+/// - Note: `Text(Image(nsImage:))` ではアニメーションが再生できないため、
+///   アニメーション版エモートにはこのビューを使用する
+struct AnimatedEmoteView: NSViewRepresentable {
+
+    /// 表示する NSImage（アニメーション GIF またはスタティック PNG）
+    let image: NSImage
+
+    /// アニメーションを再生するかどうか
+    let isAnimated: Bool
+
+    /// 表示サイズ（ポイント）。デフォルトは `EmoteImageCache.emoteDisplaySize`
+    var size: CGFloat = EmoteImageCache.emoteDisplaySize
+
+    func makeNSView(context: Context) -> NSImageView {
+        let imageView = NSImageView()
+        // 縦横比を保ちながらフレームに収める
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.imageAlignment = .alignCenter
+        return imageView
+    }
+
+    func updateNSView(_ imageView: NSImageView, context: Context) {
+        imageView.image = image
+        // アニメーション GIF の場合は自動再生を有効にする
+        imageView.animates = isAnimated
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSImageView, context: Context) -> CGSize? {
+        CGSize(width: size, height: size)
+    }
+}

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -39,7 +39,9 @@ struct ChatMessageView: View {
                     .fixedSize()
 
                 // メッセージ本文のセグメント
-                ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
+                // segments は message 生成後に変更されないため、インデックスを安定 ID として使用する
+                ForEach(message.segments.indices, id: \.self) { index in
+                    let segment = message.segments[index]
                     switch segment {
                     case .text(let str):
                         Text(str)
@@ -73,7 +75,7 @@ struct ChatMessageView: View {
         }
     }
 
-    /// 必要なエモート画像を非同期ダウンロードする
+    /// 必要なエモート画像を非同期ダウンロードし、@State を一括更新する
     private func loadEmoteImages() async {
         // ユニークなエモートIDを収集
         let emoteIds = Set(message.segments.compactMap { segment -> String? in
@@ -82,7 +84,9 @@ struct ChatMessageView: View {
         })
         guard !emoteIds.isEmpty else { return }
 
-        // 並行ダウンロード
+        // ローカル辞書に結果を集積してから @State を一括更新することで
+        // 不必要な View 再描画を抑制する
+        var downloaded: [String: NSImage] = [:]
         await withTaskGroup(of: (String, NSImage?).self) { group in
             for id in emoteIds {
                 group.addTask {
@@ -92,9 +96,14 @@ struct ChatMessageView: View {
             }
             for await (id, image) in group {
                 if let image {
-                    emoteImages[id] = image
+                    downloaded[id] = image
                 }
             }
+        }
+
+        // メインスレッドで @State を一括更新
+        await MainActor.run {
+            emoteImages.merge(downloaded) { _, new in new }
         }
     }
 

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -36,7 +36,7 @@ struct ChatMessageView: View {
                     .foregroundStyle(usernameColor)
                     + Text(": ")
                     .foregroundStyle(.secondary))
-                    .fixedSize()
+                    .fixedSize(horizontal: false, vertical: true)
 
                 // メッセージ本文のセグメント
                 // segments は message 生成後に変更されないため、インデックスを安定 ID として使用する

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -1,16 +1,23 @@
 // ChatMessageView.swift
 // チャットメッセージ 1 件を表示するビュー
-// ユーザー名（色付き）・バッジ・メッセージ本文を横並びで表示する
+// ユーザー名（色付き）・バッジ・メッセージ本文（アニメーションエモート含む）を横並びで表示する
 
+import AppKit
 import SwiftUI
 
 /// チャットメッセージ 1 件の表示ビュー
 ///
 /// - ユーザー名を Twitch 設定の色で表示
 /// - バッジを絵文字で表現（broadcaster: 📡、moderator: ⚔️、subscriber: ★）
-/// - メッセージ本文を通常テキストで表示
+/// - メッセージ本文を FlowLayout でレンダリングし、エモートを AnimatedEmoteView でインライン表示
+/// - アニメーション GIF エモートは `NSImageView.animates = true` で自動再生
+/// - エモート未読み込み時はエモート名をグレーテキストのプレースホルダとして表示
 struct ChatMessageView: View {
+
     let message: ChatMessage
+
+    /// ダウンロード済みエモート画像（キー: エモートID）
+    @State private var emoteImages: [String: NSImage] = [:]
 
     var body: some View {
         HStack(alignment: .top, spacing: 4) {
@@ -19,19 +26,76 @@ struct ChatMessageView: View {
                 badgesView
             }
 
-            // ユーザー名（Twitch 設定の色）
-            Text(message.displayName)
-                .fontWeight(.semibold)
-                .foregroundStyle(usernameColor)
-                + Text(": ")
-                .foregroundStyle(.secondary)
-                + Text(message.text)
-                .foregroundStyle(.primary)
+            // メッセージ全体を FlowLayout でレンダリング
+            // ユーザー名・コロン・メッセージ本文をすべてフロー内に配置することで
+            // テキストとエモート画像が自然に折り返す
+            FlowLayout(horizontalSpacing: 0, verticalSpacing: 2) {
+                // ユーザー名 + コロン（1つの Text ビューとして連結）
+                (Text(message.displayName)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(usernameColor)
+                    + Text(": ")
+                    .foregroundStyle(.secondary))
+                    .fixedSize()
+
+                // メッセージ本文のセグメント
+                ForEach(Array(message.segments.enumerated()), id: \.offset) { _, segment in
+                    switch segment {
+                    case .text(let str):
+                        Text(str)
+                            .foregroundStyle(.primary)
+                            // 長いテキストセグメントは幅に収まるよう折り返す
+                            .fixedSize(horizontal: false, vertical: true)
+
+                    case .emote(let id, let name):
+                        if let nsImage = emoteImages[id] {
+                            // 画像取得済み: AnimatedEmoteView でインライン表示（GIF 対応）
+                            AnimatedEmoteView(
+                                image: nsImage,
+                                isAnimated: EmoteImageCache.shared.isAnimated(emoteId: id)
+                            )
+                        } else {
+                            // 未取得: エモート名をプレースホルダとして表示
+                            Text(name)
+                                .foregroundStyle(.secondary)
+                                .fixedSize()
+                        }
+                    }
+                }
+            }
         }
         .font(.system(size: 13))
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 12)
         .padding(.vertical, 3)
+        .task(id: message.id) {
+            await loadEmoteImages()
+        }
+    }
+
+    /// 必要なエモート画像を非同期ダウンロードする
+    private func loadEmoteImages() async {
+        // ユニークなエモートIDを収集
+        let emoteIds = Set(message.segments.compactMap { segment -> String? in
+            if case .emote(let id, _) = segment { return id }
+            return nil
+        })
+        guard !emoteIds.isEmpty else { return }
+
+        // 並行ダウンロード
+        await withTaskGroup(of: (String, NSImage?).self) { group in
+            for id in emoteIds {
+                group.addTask {
+                    let image = await EmoteImageCache.shared.image(for: id)
+                    return (id, image)
+                }
+            }
+            for await (id, image) in group {
+                if let image {
+                    emoteImages[id] = image
+                }
+            }
+        }
     }
 
     /// バッジを絵文字で表示

--- a/Sources/TwitchChat/Views/FlowLayout.swift
+++ b/Sources/TwitchChat/Views/FlowLayout.swift
@@ -92,10 +92,15 @@ struct FlowLayout: Layout {
         var lineHeight: CGFloat = 0
         var currentRow = 0
         var rowHeights: [CGFloat] = []
+        // 実際に使用した最大幅（maxWidth が .infinity の場合の totalSize 計算に使用）
+        var maxUsedWidth: CGFloat = 0
 
         for subview in subviews {
-            // 子ビューの理想サイズを取得
-            let size = subview.sizeThatFits(.unspecified)
+            // 子ビューのサイズを取得（テキストが折り返せるよう利用可能幅を伝える）
+            let proposal = maxWidth.isInfinite
+                ? ProposedViewSize.unspecified
+                : ProposedViewSize(width: maxWidth, height: nil)
+            let size = subview.sizeThatFits(proposal)
 
             // 現在行にはみ出す場合、かつ行頭でない場合は改行
             if currentX > 0 && currentX + size.width > maxWidth {
@@ -111,6 +116,8 @@ struct FlowLayout: Layout {
             sizes.append(size)
             rowIndices.append(currentRow)
 
+            // 実際に使用した幅を追跡（trailing spacing は含めない）
+            maxUsedWidth = max(maxUsedWidth, currentX + size.width)
             currentX += size.width + horizontalSpacing
             lineHeight = max(lineHeight, size.height)
         }
@@ -119,7 +126,9 @@ struct FlowLayout: Layout {
         rowHeights.append(lineHeight)
 
         let totalHeight = currentY + lineHeight
-        let totalSize = CGSize(width: maxWidth, height: max(totalHeight, 0))
+        // maxWidth が .infinity の場合は実際の使用幅を返す（.infinity を返すと SwiftUI のレイアウトが壊れる）
+        let totalWidth = maxWidth.isInfinite ? maxUsedWidth : maxWidth
+        let totalSize = CGSize(width: max(totalWidth, 0), height: max(totalHeight, 0))
 
         return LayoutResult(
             origins: origins,

--- a/Sources/TwitchChat/Views/FlowLayout.swift
+++ b/Sources/TwitchChat/Views/FlowLayout.swift
@@ -1,0 +1,104 @@
+// FlowLayout.swift
+// 子ビューを横方向に並べ、はみ出した場合は次の行に折り返すカスタムレイアウト
+// チャットメッセージ本文のテキストとエモートを混在させるために使用する
+
+import SwiftUI
+
+/// 横方向に折り返すフローレイアウト
+///
+/// 各子ビューを左から右に並べ、コンテナ幅を超える場合は次の行に折り返す。
+/// テキストセグメントとエモート画像を自然に混在させるために使用する。
+///
+/// - Note: 各行内の子ビューは垂直方向の中央に揃える（テキストとエモートのベースラインを統一）
+struct FlowLayout: Layout {
+
+    /// 子ビュー間の水平スペース
+    var horizontalSpacing: CGFloat = 0
+
+    /// 行間の垂直スペース
+    var verticalSpacing: CGFloat = 2
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let result = computeLayout(subviews: subviews, maxWidth: maxWidth)
+        return result.totalSize
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
+        let result = computeLayout(subviews: subviews, maxWidth: bounds.width)
+        for (index, (origin, size)) in zip(result.origins, result.sizes).enumerated() {
+            // 行高に対して垂直中央揃え
+            let rowHeight = result.rowHeights[result.rowIndices[index]]
+            let centeredY = origin.y + (rowHeight - size.height) / 2
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + origin.x, y: bounds.minY + centeredY),
+                proposal: ProposedViewSize(size)
+            )
+        }
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// レイアウト計算結果
+    private struct LayoutResult {
+        /// 各子ビューの配置原点（ローカル座標）
+        var origins: [CGPoint]
+        /// 各子ビューのサイズ
+        var sizes: [CGSize]
+        /// 各子ビューが属する行インデックス
+        var rowIndices: [Int]
+        /// 各行の高さ
+        var rowHeights: [CGFloat]
+        /// レイアウト全体のサイズ
+        var totalSize: CGSize
+    }
+
+    /// 全子ビューのレイアウト位置とサイズを計算する
+    private func computeLayout(subviews: Subviews, maxWidth: CGFloat) -> LayoutResult {
+        var origins: [CGPoint] = []
+        var sizes: [CGSize] = []
+        var rowIndices: [Int] = []
+
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var currentRow = 0
+        var rowHeights: [CGFloat] = []
+
+        for subview in subviews {
+            // 子ビューの理想サイズを取得
+            let size = subview.sizeThatFits(.unspecified)
+
+            // 現在行にはみ出す場合、かつ行頭でない場合は改行
+            if currentX > 0 && currentX + size.width > maxWidth {
+                // 現行の行高を確定
+                rowHeights.append(lineHeight)
+                currentY += lineHeight + verticalSpacing
+                currentX = 0
+                lineHeight = 0
+                currentRow += 1
+            }
+
+            origins.append(CGPoint(x: currentX, y: currentY))
+            sizes.append(size)
+            rowIndices.append(currentRow)
+
+            currentX += size.width + horizontalSpacing
+            lineHeight = max(lineHeight, size.height)
+        }
+
+        // 最終行の高さを確定
+        rowHeights.append(lineHeight)
+
+        let totalHeight = currentY + lineHeight
+        let totalSize = CGSize(width: maxWidth, height: max(totalHeight, 0))
+
+        return LayoutResult(
+            origins: origins,
+            sizes: sizes,
+            rowIndices: rowIndices,
+            rowHeights: rowHeights,
+            totalSize: totalSize
+        )
+    }
+}

--- a/Sources/TwitchChat/Views/FlowLayout.swift
+++ b/Sources/TwitchChat/Views/FlowLayout.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// 各子ビューを左から右に並べ、コンテナ幅を超える場合は次の行に折り返す。
 /// テキストセグメントとエモート画像を自然に混在させるために使用する。
 ///
-/// - Note: 各行内の子ビューは垂直方向の中央に揃える（テキストとエモートのベースラインを統一）
+/// - Note: 各行内の子ビューは垂直方向の中央揃えで配置する（テキストとエモートの高さが揃う）
 struct FlowLayout: Layout {
 
     /// 子ビュー間の水平スペース
@@ -18,16 +18,44 @@ struct FlowLayout: Layout {
     /// 行間の垂直スペース
     var verticalSpacing: CGFloat = 2
 
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) -> CGSize {
+    // MARK: - Layout キャッシュ
+
+    /// レイアウト計算結果のキャッシュ
+    ///
+    /// `sizeThatFits` と `placeSubviews` が同じ幅で呼ばれる場合、計算を再利用する。
+    struct CacheData {
+        var result: LayoutResult
+        var maxWidth: CGFloat
+    }
+
+    func makeCache(subviews: Subviews) -> CacheData? { nil }
+
+    func updateCache(_ cache: inout CacheData?, subviews: Subviews) {
+        // サブビューが変わったらキャッシュを無効化する
+        cache = nil
+    }
+
+    // MARK: - Layout プロトコル
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData?) -> CGSize {
         let maxWidth = proposal.width ?? .infinity
         let result = computeLayout(subviews: subviews, maxWidth: maxWidth)
+        // 次の placeSubviews で再利用できるようキャッシュに保存
+        cache = CacheData(result: result, maxWidth: maxWidth)
         return result.totalSize
     }
 
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout Void) {
-        let result = computeLayout(subviews: subviews, maxWidth: bounds.width)
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData?) {
+        // 同じ幅ならキャッシュを再利用し、二重計算を避ける
+        let result: LayoutResult
+        if let cached = cache, cached.maxWidth == bounds.width {
+            result = cached.result
+        } else {
+            result = computeLayout(subviews: subviews, maxWidth: bounds.width)
+        }
+
         for (index, (origin, size)) in zip(result.origins, result.sizes).enumerated() {
-            // 行高に対して垂直中央揃え
+            // 行高に対して垂直中央揃え（テキストとエモートの高さが揃う）
             let rowHeight = result.rowHeights[result.rowIndices[index]]
             let centeredY = origin.y + (rowHeight - size.height) / 2
             subviews[index].place(
@@ -40,7 +68,7 @@ struct FlowLayout: Layout {
     // MARK: - プライベートメソッド
 
     /// レイアウト計算結果
-    private struct LayoutResult {
+    struct LayoutResult {
         /// 各子ビューの配置原点（ローカル座標）
         var origins: [CGPoint]
         /// 各子ビューのサイズ

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -124,12 +124,16 @@ struct ChatMessageTests {
             return
         }
         // 検証: エモート → テキストの2セグメントになる
-        let chatMessage = ChatMessage(from: ircMessage)
-        #expect(chatMessage?.emotes.count == 1)
-        #expect(chatMessage?.emotes.first?.emoteId == "25")
-        #expect(chatMessage?.segments.count == 2)
-        #expect(chatMessage?.segments[0] == .emote(id: "25", name: "Kappa"))
-        #expect(chatMessage?.segments[1] == .text(" 配信中"))
+        guard let chatMessage = ChatMessage(from: ircMessage) else {
+            Issue.record("ChatMessage への変換に失敗しました")
+            return
+        }
+        #expect(chatMessage.emotes.count == 1)
+        #expect(chatMessage.emotes.first?.emoteId == "25")
+        let segments = chatMessage.segments
+        #expect(segments.count == 2)
+        #expect(segments[0] == .emote(id: "25", name: "Kappa"))
+        #expect(segments[1] == .text(" 配信中"))
     }
 
     @Test("PRIVMSG のバッジタグが正しく ChatMessage に反映される")

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -98,6 +98,40 @@ struct ChatMessageTests {
         #expect(badges.isEmpty)
     }
 
+    // MARK: - エモートのパース
+
+    @Test("emotes タグが空の場合 segments はテキスト全体の1セグメントになる")
+    func emotesタグが空の場合segmentsはテキスト全体の1セグメントになる() {
+        // 前提: emotes タグが空（エモートなし）のメッセージ
+        let rawMessage = "@emotes=;id=abc-001 :ユーザー001!ユーザー001@ユーザー001.tmi.twitch.tv PRIVMSG #テストチャンネル :こんにちは！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+        // 検証: segments がテキスト全体の1セグメントになる
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.segments == [.text("こんにちは！")])
+        #expect(chatMessage?.emotes.isEmpty == true)
+    }
+
+    @Test("emotes タグがある場合 segments にエモートセグメントが含まれる")
+    func emotesタグがある場合segmentsにエモートセグメントが含まれる() {
+        // 前提: Kappa(0-4) を含むメッセージ
+        // "Kappa 配信中" — Kappa は K(0) a(1) p(2) p(3) a(4)
+        let rawMessage = "@emotes=25:0-4;id=abc-002 :はいしんしゃ!はいしんしゃ@はいしんしゃ.tmi.twitch.tv PRIVMSG #テストチャンネル :Kappa 配信中"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+        // 検証: エモート → テキストの2セグメントになる
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.emotes.count == 1)
+        #expect(chatMessage?.emotes.first?.emoteId == "25")
+        #expect(chatMessage?.segments.count == 2)
+        #expect(chatMessage?.segments[0] == .emote(id: "25", name: "Kappa"))
+        #expect(chatMessage?.segments[1] == .text(" 配信中"))
+    }
+
     @Test("PRIVMSG のバッジタグが正しく ChatMessage に反映される")
     func PRIVMSGのバッジタグが正しくChatMessageに反映される() {
         let rawMessage = "@badges=broadcaster/1,subscriber/12;color=#0000FF;display-name=配信者 :haishinsha!haishinsha@haishinsha.tmi.twitch.tv PRIVMSG #haishinsha :配信開始！"

--- a/Tests/TwitchChatTests/EmoteImageCacheTests.swift
+++ b/Tests/TwitchChatTests/EmoteImageCacheTests.swift
@@ -1,0 +1,64 @@
+// EmoteImageCacheTests.swift
+// EmoteImageCache の単体テスト
+// URL 生成ロジックとエモート表示サイズを検証する（画像ダウンロードは外部依存のためテスト対象外）
+
+import Testing
+@testable import TwitchChat
+
+/// EmoteImageCache のテストスイート
+@Suite("EmoteImageCache テスト")
+struct EmoteImageCacheTests {
+
+    // MARK: - スタティック URL 生成
+
+    @Test("デフォルト（スタティック）で正しいエモート URL を生成できる")
+    func デフォルトでスタティックエモートURLを生成できる() {
+        // 前提: エモートID "25"（Kappa）でデフォルト（スタティック）URL
+        let url = EmoteImageCache.emoteURL(emoteId: "25")
+        // 検証: Twitch CDN のスタティック URL が生成される
+        #expect(url.absoluteString == "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0")
+    }
+
+    @Test("スタティック・スケール 1.0 で正しいエモート URL を生成できる")
+    func スタティックスケール1でエモートURLを生成できる() {
+        // 前提: エモートID "1902"（LUL）でスタティック、スケール 1.0
+        let url = EmoteImageCache.emoteURL(emoteId: "1902", scale: "1.0")
+        // 検証: 指定スケールのスタティック URL が生成される
+        #expect(url.absoluteString == "https://static-cdn.jtvnw.net/emoticons/v2/1902/default/dark/1.0")
+    }
+
+    @Test("スタティック・スケール 3.0 で正しいエモート URL を生成できる")
+    func スタティックスケール3でエモートURLを生成できる() {
+        // 前提: 高解像度スケール 3.0 の指定
+        let url = EmoteImageCache.emoteURL(emoteId: "305954156", scale: "3.0")
+        // 検証: 3.0 スケールのスタティック URL が生成される
+        #expect(url.absoluteString == "https://static-cdn.jtvnw.net/emoticons/v2/305954156/default/dark/3.0")
+    }
+
+    // MARK: - アニメーション URL 生成
+
+    @Test("アニメーション URL を生成できる")
+    func アニメーションURLを生成できる() {
+        // 前提: エモートID "25" のアニメーション版
+        let url = EmoteImageCache.emoteURL(emoteId: "25", type: "animated")
+        // 検証: /animated/ パスの URL が生成される
+        #expect(url.absoluteString == "https://static-cdn.jtvnw.net/emoticons/v2/25/animated/dark/2.0")
+    }
+
+    @Test("アニメーション・スケール 1.0 で URL を生成できる")
+    func アニメーションスケール1でURLを生成できる() {
+        // 前提: アニメーション版、スケール 1.0
+        let url = EmoteImageCache.emoteURL(emoteId: "1902", type: "animated", scale: "1.0")
+        // 検証: /animated/ パスの 1.0 スケール URL が生成される
+        #expect(url.absoluteString == "https://static-cdn.jtvnw.net/emoticons/v2/1902/animated/dark/1.0")
+    }
+
+    // MARK: - 表示サイズ
+
+    @Test("エモート表示サイズが正の値である")
+    func エモート表示サイズが正の値である() {
+        // 前提: 13pt フォントに合わせたエモート表示サイズ
+        // 検証: 0 より大きい CGFloat 値が定義されている
+        #expect(EmoteImageCache.emoteDisplaySize > 0)
+    }
+}

--- a/Tests/TwitchChatTests/EmoteImageCacheTests.swift
+++ b/Tests/TwitchChatTests/EmoteImageCacheTests.swift
@@ -55,10 +55,10 @@ struct EmoteImageCacheTests {
 
     // MARK: - 表示サイズ
 
-    @Test("エモート表示サイズが正の値である")
-    func エモート表示サイズが正の値である() {
-        // 前提: 13pt フォントに合わせたエモート表示サイズ
-        // 検証: 0 より大きい CGFloat 値が定義されている
-        #expect(EmoteImageCache.emoteDisplaySize > 0)
+    @Test("エモート表示サイズが 20pt である")
+    func エモート表示サイズが20ptである() {
+        // 前提: 13pt フォントの行高に合わせてエモート表示サイズは 20pt と定義されている
+        // 検証: 定数が 20pt であることを確認（リグレッション防止）
+        #expect(EmoteImageCache.emoteDisplaySize == 20)
     }
 }

--- a/Tests/TwitchChatTests/EmoteParserTests.swift
+++ b/Tests/TwitchChatTests/EmoteParserTests.swift
@@ -55,8 +55,10 @@ struct EmoteParserTests {
         #expect(result.count == 2)
         #expect(result[0].emoteId == "25")
         #expect(result[0].startIndex == 0)
+        #expect(result[0].endIndex == 4)
         #expect(result[1].emoteId == "1902")
         #expect(result[1].startIndex == 6)
+        #expect(result[1].endIndex == 10)
     }
 
     @Test("startIndex 昇順でソートされる")
@@ -68,18 +70,23 @@ struct EmoteParserTests {
         #expect(result.count == 2)
         #expect(result[0].emoteId == "25")
         #expect(result[0].startIndex == 0)
+        #expect(result[0].endIndex == 4)
         #expect(result[1].emoteId == "1902")
         #expect(result[1].startIndex == 6)
+        #expect(result[1].endIndex == 10)
     }
 
     @Test("単一エモートが 3 箇所に登場する場合をパースできる")
     func 単一エモートが3箇所に登場する場合をパースできる() {
         // 前提: 同じエモートがメッセージ内に 3 回登場する
         let result = EmoteParser.parse("25:0-4,6-10,12-16")
-        // 検証: 3件の EmotePosition が startIndex 昇順で返る
+        // 検証: 3件の EmotePosition が startIndex 昇順で返り、emoteId も全て "25" になる
         #expect(result.count == 3)
+        #expect(result[0].emoteId == "25")
         #expect(result[0].startIndex == 0)
+        #expect(result[1].emoteId == "25")
         #expect(result[1].startIndex == 6)
+        #expect(result[2].emoteId == "25")
         #expect(result[2].startIndex == 12)
     }
 
@@ -116,5 +123,33 @@ struct EmoteParserTests {
         // 検証: 正常な1件のみ返る
         #expect(result.count == 1)
         #expect(result[0].emoteId == "25")
+    }
+
+    @Test("コロン後が空のレンジはスキップされる")
+    func コロン後が空のレンジはスキップされる() {
+        // 前提: エモートIDの後にコロンはあるが位置文字列が空
+        let result = EmoteParser.parse("25:")
+        // 検証: スキップされて空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("endIndex が startIndex より小さい逆転レンジはスキップされる")
+    func endIndexがstartIndexより小さい逆転レンジはスキップされる() {
+        // 前提: start(10) > end(4) の不正なレンジ
+        let result = EmoteParser.parse("25:10-4")
+        // 検証: 不正なレンジはスキップされて空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("非常に大きなインデックス値を処理できる")
+    func 非常に大きなインデックス値を処理できる() {
+        // 前提: Int に収まる大きなインデックス値
+        // 実際の Twitch メッセージで発生しうる範囲を超える値
+        let result = EmoteParser.parse("25:0-99999")
+        // 検証: パースは成功し、EmotePosition が生成される（範囲チェックは MessageSegment 側で行う）
+        #expect(result.count == 1)
+        #expect(result[0].emoteId == "25")
+        #expect(result[0].startIndex == 0)
+        #expect(result[0].endIndex == 99999)
     }
 }

--- a/Tests/TwitchChatTests/EmoteParserTests.swift
+++ b/Tests/TwitchChatTests/EmoteParserTests.swift
@@ -1,0 +1,120 @@
+// EmoteParserTests.swift
+// EmoteParser の単体テスト
+// Twitch IRC の emotes タグ文字列のパースを検証する
+
+import Testing
+@testable import TwitchChat
+
+/// EmoteParser のテストスイート
+@Suite("EmoteParser テスト")
+struct EmoteParserTests {
+
+    // MARK: - 基本パース
+
+    @Test("空文字列は空配列を返す")
+    func 空文字列は空配列を返す() {
+        // 前提: emotes タグが空（エモートなし）
+        let result = EmoteParser.parse("")
+        // 検証: 空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("単一エモート・単一位置をパースできる")
+    func 単一エモート単一位置をパースできる() {
+        // 前提: エモートID 25 がテキスト 0-4 の位置に存在
+        // 例: "Kappa" (5文字) が位置 0〜4
+        let result = EmoteParser.parse("25:0-4")
+        // 検証: 1件のエモート位置情報が返る
+        #expect(result.count == 1)
+        #expect(result[0].emoteId == "25")
+        #expect(result[0].startIndex == 0)
+        #expect(result[0].endIndex == 4)
+    }
+
+    @Test("単一エモート・複数位置をパースできる")
+    func 単一エモート複数位置をパースできる() {
+        // 前提: エモートID 25 が 2 箇所に存在
+        // 例: "Kappa test Kappa" → 位置 0-4 と 11-15
+        let result = EmoteParser.parse("25:0-4,11-15")
+        // 検証: 2件のエモート位置情報が返る
+        #expect(result.count == 2)
+        #expect(result[0].emoteId == "25")
+        #expect(result[0].startIndex == 0)
+        #expect(result[0].endIndex == 4)
+        #expect(result[1].emoteId == "25")
+        #expect(result[1].startIndex == 11)
+        #expect(result[1].endIndex == 15)
+    }
+
+    @Test("複数エモートをパースできる")
+    func 複数エモートをパースできる() {
+        // 前提: エモートID 25 が位置 0-4、エモートID 1902 が位置 6-10
+        // 例: "Kappa LUL" → Kappa=25 は 0-4、LUL=1902 は 6-10
+        let result = EmoteParser.parse("25:0-4/1902:6-10")
+        // 検証: 2件のエモート位置情報が startIndex 昇順で返る
+        #expect(result.count == 2)
+        #expect(result[0].emoteId == "25")
+        #expect(result[0].startIndex == 0)
+        #expect(result[1].emoteId == "1902")
+        #expect(result[1].startIndex == 6)
+    }
+
+    @Test("startIndex 昇順でソートされる")
+    func startIndex昇順でソートされる() {
+        // 前提: タグ内でエモートの順序が位置順でない場合がある
+        // 後に登場するエモートが先にタグに書かれているケース
+        let result = EmoteParser.parse("1902:6-10/25:0-4")
+        // 検証: startIndex 昇順（位置順）でソートされる
+        #expect(result.count == 2)
+        #expect(result[0].emoteId == "25")
+        #expect(result[0].startIndex == 0)
+        #expect(result[1].emoteId == "1902")
+        #expect(result[1].startIndex == 6)
+    }
+
+    @Test("単一エモートが 3 箇所に登場する場合をパースできる")
+    func 単一エモートが3箇所に登場する場合をパースできる() {
+        // 前提: 同じエモートがメッセージ内に 3 回登場する
+        let result = EmoteParser.parse("25:0-4,6-10,12-16")
+        // 検証: 3件の EmotePosition が startIndex 昇順で返る
+        #expect(result.count == 3)
+        #expect(result[0].startIndex == 0)
+        #expect(result[1].startIndex == 6)
+        #expect(result[2].startIndex == 12)
+    }
+
+    // MARK: - 不正入力の耐性
+
+    @Test("コロンがない不正形式はスキップされる")
+    func コロンがない不正形式はスキップされる() {
+        // 前提: エモートIDのみでコロンがない不正なタグ
+        let result = EmoteParser.parse("25")
+        // 検証: スキップされて空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("ハイフンがない不正な位置形式はスキップされる")
+    func ハイフンがない不正な位置形式はスキップされる() {
+        // 前提: 位置にハイフンがない不正なタグ
+        let result = EmoteParser.parse("25:04")
+        // 検証: スキップされて空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("数値以外の位置はスキップされる")
+    func 数値以外の位置はスキップされる() {
+        // 前提: 位置に数値以外が含まれる不正なタグ
+        let result = EmoteParser.parse("25:a-b")
+        // 検証: スキップされて空配列が返る
+        #expect(result.isEmpty)
+    }
+
+    @Test("正常なエモートと不正なエモートが混在する場合は正常なものだけ返す")
+    func 正常なエモートと不正なエモートが混在する場合は正常なものだけ返す() {
+        // 前提: 1件目は正常、2件目は不正（コロンなし）
+        let result = EmoteParser.parse("25:0-4/invalid")
+        // 検証: 正常な1件のみ返る
+        #expect(result.count == 1)
+        #expect(result[0].emoteId == "25")
+    }
+}

--- a/Tests/TwitchChatTests/MessageSegmentTests.swift
+++ b/Tests/TwitchChatTests/MessageSegmentTests.swift
@@ -110,8 +110,8 @@ struct MessageSegmentTests {
         #expect(result[2] == .emote(id: "25", name: "Kappa"))
     }
 
-    @Test("テキストのみのセグメントで全体がエモートの場合を分割できる")
-    func テキストのみのセグメントで全体がエモートの場合を分割できる() {
+    @Test("メッセージ全体がエモートのみの場合を分割できる")
+    func メッセージ全体がエモートのみの場合を分割できる() {
         // 前提: "Kappa" — メッセージ全体が1つのエモート
         let emotes = [EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4)]
         let result = MessageSegment.segments(from: "Kappa", emotePositions: emotes)

--- a/Tests/TwitchChatTests/MessageSegmentTests.swift
+++ b/Tests/TwitchChatTests/MessageSegmentTests.swift
@@ -1,0 +1,122 @@
+// MessageSegmentTests.swift
+// MessageSegment の単体テスト
+// テキストとエモートのセグメント分割ロジックを検証する
+
+import Testing
+@testable import TwitchChat
+
+/// MessageSegment のテストスイート
+@Suite("MessageSegment テスト")
+struct MessageSegmentTests {
+
+    // MARK: - エモートなし
+
+    @Test("エモートなしのテキストは単一の text セグメントになる")
+    func エモートなしのテキストは単一のtextセグメントになる() {
+        // 前提: エモートが一切ないメッセージ
+        let result = MessageSegment.segments(from: "こんにちは！", emotePositions: [])
+        // 検証: テキスト全体が1つの .text セグメントになる
+        #expect(result == [.text("こんにちは！")])
+    }
+
+    @Test("空文字列はエモートなしで単一の text セグメントになる")
+    func 空文字列はエモートなしで単一のtextセグメントになる() {
+        // 前提: 空のメッセージ
+        let result = MessageSegment.segments(from: "", emotePositions: [])
+        // 検証: 空テキストの1セグメント
+        #expect(result == [.text("")])
+    }
+
+    // MARK: - エモートの位置パターン
+
+    @Test("先頭にエモートがある場合を分割できる")
+    func 先頭にエモートがある場合を分割できる() {
+        // 前提: "Kappa テスト" — Kappa(0-4) がテキスト先頭
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4)]
+        let result = MessageSegment.segments(from: "Kappa テスト", emotePositions: emotes)
+        // 検証: エモート → テキストの2セグメント
+        #expect(result.count == 2)
+        #expect(result[0] == .emote(id: "25", name: "Kappa"))
+        #expect(result[1] == .text(" テスト"))
+    }
+
+    @Test("末尾にエモートがある場合を分割できる")
+    func 末尾にエモートがある場合を分割できる() {
+        // 前提: "テスト Kappa" — Kappa(4-8) がテキスト末尾
+        // テ(0) ス(1) ト(2) space(3) K(4) a(5) p(6) p(7) a(8)
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 4, endIndex: 8)]
+        let result = MessageSegment.segments(from: "テスト Kappa", emotePositions: emotes)
+        // 検証: テキスト → エモートの2セグメント
+        #expect(result.count == 2)
+        #expect(result[0] == .text("テスト "))
+        #expect(result[1] == .emote(id: "25", name: "Kappa"))
+    }
+
+    @Test("中間にエモートがある場合を分割できる")
+    func 中間にエモートがある場合を分割できる() {
+        // 前提: "テスト Kappa 配信" — Kappa(4-8) が中間
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 4, endIndex: 8)]
+        let result = MessageSegment.segments(from: "テスト Kappa 配信", emotePositions: emotes)
+        // 検証: テキスト → エモート → テキストの3セグメント
+        #expect(result.count == 3)
+        #expect(result[0] == .text("テスト "))
+        #expect(result[1] == .emote(id: "25", name: "Kappa"))
+        #expect(result[2] == .text(" 配信"))
+    }
+
+    @Test("複数エモートを含むメッセージを分割できる")
+    func 複数エモートを含むメッセージを分割できる() {
+        // 前提: "Kappa テスト LUL" — Kappa(0-4)=25、LUL(10-12)=1902
+        // K(0) a(1) p(2) p(3) a(4) space(5) テ(6) ス(7) ト(8) space(9) L(10) U(11) L(12)
+        let emotes = [
+            EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4),
+            EmotePosition(emoteId: "1902", startIndex: 10, endIndex: 12)
+        ]
+        let result = MessageSegment.segments(from: "Kappa テスト LUL", emotePositions: emotes)
+        // 検証: エモート → テキスト → エモートの3セグメント
+        #expect(result.count == 3)
+        #expect(result[0] == .emote(id: "25", name: "Kappa"))
+        #expect(result[1] == .text(" テスト "))
+        #expect(result[2] == .emote(id: "1902", name: "LUL"))
+    }
+
+    @Test("日本語テキストとエモートが混在する場合を正しく分割できる")
+    func 日本語テキストとエモートが混在する場合を正しく分割できる() {
+        // 前提: "配信中 Kappa おつかれ" — Kappa は UTF-16 オフセット 4-8
+        // 「配信中 」は4文字（各1 UTF-16 ユニット）→ オフセット 0-3
+        // 「Kappa」は5文字 → オフセット 4-8
+        // 「 おつかれ」は残り
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 4, endIndex: 8)]
+        let result = MessageSegment.segments(from: "配信中 Kappa おつかれ", emotePositions: emotes)
+        // 検証: 日本語テキストが正しい範囲で分割される
+        #expect(result.count == 3)
+        #expect(result[0] == .text("配信中 "))
+        #expect(result[1] == .emote(id: "25", name: "Kappa"))
+        #expect(result[2] == .text(" おつかれ"))
+    }
+
+    @Test("連続する2つのエモートを分割できる")
+    func 連続する2つのエモートを分割できる() {
+        // 前提: "Kappa Kappa" — 同じエモートが2つ（0-4、6-10）、間にスペース
+        let emotes = [
+            EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4),
+            EmotePosition(emoteId: "25", startIndex: 6, endIndex: 10)
+        ]
+        let result = MessageSegment.segments(from: "Kappa Kappa", emotePositions: emotes)
+        // 検証: エモート → テキスト(スペース) → エモートの3セグメント
+        #expect(result.count == 3)
+        #expect(result[0] == .emote(id: "25", name: "Kappa"))
+        #expect(result[1] == .text(" "))
+        #expect(result[2] == .emote(id: "25", name: "Kappa"))
+    }
+
+    @Test("テキストのみのセグメントで全体がエモートの場合を分割できる")
+    func テキストのみのセグメントで全体がエモートの場合を分割できる() {
+        // 前提: "Kappa" — メッセージ全体が1つのエモート
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4)]
+        let result = MessageSegment.segments(from: "Kappa", emotePositions: emotes)
+        // 検証: エモート1つのみ
+        #expect(result.count == 1)
+        #expect(result[0] == .emote(id: "25", name: "Kappa"))
+    }
+}


### PR DESCRIPTION
## Summary

- **エモートパーサー**: IRC の `emotes` タグ（例: `25:0-4/1902:6-10`）を `EmotePosition` 配列にパース（UTF-16 インデックス対応）
- **メッセージセグメント**: テキストとエモートをセグメント分割し、`FlowLayout` でインライン混在表示
- **アニメーション対応**: `/animated/` URL を先試行し、`NSImageView.animates = true` で GIF を自動再生。静止画エモートは `/default/` にフォールバック
- **画像サイズ**: `emoteDisplaySize = 20pt` で `NSImage.size` を統一し、13pt フォントの行高に一致させる
- **パフォーマンス**: `NSCache` による画像キャッシュ + in-flight 重複排除で並行リクエストを1回のダウンロードに集約

## New Files

| ファイル | 役割 |
|---------|------|
| `Sources/TwitchChat/Services/EmoteParser.swift` | `emotes` タグ → `[EmotePosition]` パーサー |
| `Sources/TwitchChat/Models/MessageSegment.swift` | テキスト/エモートのセグメント分割 |
| `Sources/TwitchChat/Services/EmoteImageCache.swift` | animated 優先ダウンロード + NSCache |
| `Sources/TwitchChat/Views/AnimatedEmoteView.swift` | `NSImageView` ラッパー（GIF 再生対応） |
| `Sources/TwitchChat/Views/FlowLayout.swift` | 折り返しフローレイアウト（Layout プロトコル） |

## Modified Files

- `ChatMessage.swift` — `emotes` / `segments` プロパティを追加
- `ChatMessageView.swift` — FlowLayout + AnimatedEmoteView でエモートをインライン表示

## Test plan

- [x] `swift test` — 全59テスト通過
- [x] `swift build` — 警告・エラーなし
- [ ] エモートが多いチャンネル（例: `#xqc`）に接続してエモート画像がインライン表示されることを手動確認
- [ ] アニメーションエモートが GIF として再生されることを確認
- [ ] エモートなしメッセージが従来通り表示されることを確認（リグレッション）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * チャットメッセージにおけるエモート画像表示機能を追加しました。
  * GIFアニメーション対応エモートに対応しました。
  * メッセージ内のテキストとエモートを自動的に整形・レイアウトするようになりました。

* **Tests**
  * エモート解析・キャッシング・メッセージセグメント化の各機能に対するテストを追加しました。

* **Chores**
  * バージョン管理から Xcode ユーザーデータを除外するよう設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->