### PR TITLE
feat: Twitchバッジを公式画像で正確に表示する

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/TwitchChat.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/TwitchChat.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TwitchChat"
+               BuildableName = "TwitchChat"
+               BlueprintName = "TwitchChat"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TwitchChatTests"
+               BuildableName = "TwitchChatTests"
+               BlueprintName = "TwitchChatTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "TwitchChat"
+            BuildableName = "TwitchChat"
+            BlueprintName = "TwitchChat"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "TwitchChat"
+            BuildableName = "TwitchChat"
+            BlueprintName = "TwitchChat"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/TwitchChat/Models/BadgeDefinition.swift
+++ b/Sources/TwitchChat/Models/BadgeDefinition.swift
@@ -24,8 +24,10 @@ struct GQLChannelBadgesResponse: Decodable, Sendable {
 }
 
 /// GQL チャンネルバッジデータ
+///
+/// GQL の `user(id:)` フィールドは存在しないユーザーIDの場合に null を返すため Optional
 struct GQLChannelBadgesData: Decodable, Sendable {
-    let user: GQLUserBadges
+    let user: GQLUserBadges?
 }
 
 /// GQL ユーザーのバッジ情報

--- a/Sources/TwitchChat/Models/BadgeDefinition.swift
+++ b/Sources/TwitchChat/Models/BadgeDefinition.swift
@@ -1,0 +1,65 @@
+// BadgeDefinition.swift
+// Twitch GQL バッジ定義APIのレスポンスモデル
+// gql.twitch.tv からバッジ画像URLを取得するためのDecodable構造体
+
+import Foundation
+
+// MARK: - グローバルバッジレスポンス
+
+/// GQL `{ badges }` クエリのレスポンス全体
+struct GQLBadgesResponse: Decodable, Sendable {
+    let data: GQLBadgesData
+}
+
+/// GQL バッジデータ
+struct GQLBadgesData: Decodable, Sendable {
+    let badges: [GQLBadgeItem]
+}
+
+// MARK: - チャンネルバッジレスポンス
+
+/// GQL `{ user(id:) { broadcastBadges } }` クエリのレスポンス全体
+struct GQLChannelBadgesResponse: Decodable, Sendable {
+    let data: GQLChannelBadgesData
+}
+
+/// GQL チャンネルバッジデータ
+struct GQLChannelBadgesData: Decodable, Sendable {
+    let user: GQLUserBadges
+}
+
+/// GQL ユーザーのバッジ情報
+struct GQLUserBadges: Decodable, Sendable {
+    let broadcastBadges: [GQLBadgeItem]
+}
+
+// MARK: - バッジアイテム
+
+/// GQL バッジアイテム
+///
+/// GQL のバッジIDは base64 エンコードされた `"{name};{version};"` または
+/// `"{name};{version};{channelId}"` の形式。
+struct GQLBadgeItem: Decodable, Sendable {
+    /// base64エンコードされたバッジ識別子
+    let id: String
+
+    /// バッジのタイトル（例: "Broadcaster", "Moderator"）
+    let title: String
+
+    /// バッジ画像の URL（2xスケール）
+    let imageURL: String
+
+    /// base64エンコードされた id からバッジ名とバージョンを取得する
+    ///
+    /// - Returns: (name, version) のタプル、デコード失敗時は nil
+    var parsedNameAndVersion: (name: String, version: String)? {
+        guard let decoded = Data(base64Encoded: id),
+              let str = String(data: decoded, encoding: .utf8) else { return nil }
+        // フォーマット: "name;version;" または "name;version;channelId"
+        let parts = str.split(separator: ";", omittingEmptySubsequences: false)
+        guard parts.count >= 2,
+              !parts[0].isEmpty,
+              !parts[1].isEmpty else { return nil }
+        return (name: String(parts[0]), version: String(parts[1]))
+    }
+}

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -86,9 +86,9 @@ struct ChatMessage: Sendable, Identifiable {
             ? ircMessage.tags["display-name"]!
             : username
         self.text = text
-        self.colorHex = ircMessage.tags["color"]?.isEmpty == false ? ircMessage.tags["color"] : nil
+        self.colorHex = ircMessage.tags["color"].flatMap { $0.isEmpty ? nil : $0 }
         self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
-        self.roomId = ircMessage.tags["room-id"]?.isEmpty == false ? ircMessage.tags["room-id"] : nil
+        self.roomId = ircMessage.tags["room-id"].flatMap { $0.isEmpty ? nil : $0 }
         let parsedEmotes = EmoteParser.parse(ircMessage.tags["emotes"] ?? "")
         self.emotes = parsedEmotes
         self.segments = MessageSegment.segments(from: text, emotePositions: parsedEmotes)

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -58,6 +58,11 @@ struct ChatMessage: Sendable, Identifiable {
     /// メッセージのセグメント分割結果（テキストとエモートの交互配列）
     let segments: [MessageSegment]
 
+    /// チャンネルの Twitch ユーザーID（IRCの room-id タグ）
+    ///
+    /// チャンネル固有バッジ（subscriber 等）のフェッチに使用する
+    let roomId: String?
+
     /// メッセージの受信時刻
     let receivedAt: Date
 
@@ -83,6 +88,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.text = text
         self.colorHex = ircMessage.tags["color"]?.isEmpty == false ? ircMessage.tags["color"] : nil
         self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
+        self.roomId = ircMessage.tags["room-id"]?.isEmpty == false ? ircMessage.tags["room-id"] : nil
         let parsedEmotes = EmoteParser.parse(ircMessage.tags["emotes"] ?? "")
         self.emotes = parsedEmotes
         self.segments = MessageSegment.segments(from: text, emotePositions: parsedEmotes)

--- a/Sources/TwitchChat/Services/BadgeImageCache.swift
+++ b/Sources/TwitchChat/Services/BadgeImageCache.swift
@@ -4,6 +4,7 @@
 
 import AppKit
 import Foundation
+import os
 
 /// Twitch バッジ画像のキャッシュ管理クラス
 ///
@@ -33,6 +34,9 @@ final class BadgeImageCache: @unchecked Sendable {
 
     /// inFlightTasks へのアクセスを保護するロック
     private let lock = NSLock()
+
+    /// バッジ画像取得失敗時のログ出力に使用するロガー
+    private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "BadgeImageCache")
 
     private init() {}
 
@@ -89,11 +93,25 @@ final class BadgeImageCache: @unchecked Sendable {
 
     /// 指定 URL から画像をダウンロードする
     private func download(from url: URL) async -> NSImage? {
-        guard let (data, response) = try? await URLSession.shared.data(from: url),
-              let httpResponse = response as? HTTPURLResponse,
-              httpResponse.statusCode == 200,
-              let image = NSImage(data: data) else { return nil }
-        return image
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.warning("バッジ画像レスポンスが HTTPURLResponse でない: \(url)")
+                return nil
+            }
+            guard httpResponse.statusCode == 200 else {
+                logger.warning("バッジ画像取得 HTTP \(httpResponse.statusCode): \(url)")
+                return nil
+            }
+            guard let image = NSImage(data: data) else {
+                logger.warning("バッジ画像データを NSImage に変換できない: \(url)")
+                return nil
+            }
+            return image
+        } catch {
+            logger.warning("バッジ画像ダウンロード失敗: \(url) - \(error)")
+            return nil
+        }
     }
 
     /// 画像をキャッシュに保存し、表示サイズを設定する

--- a/Sources/TwitchChat/Services/BadgeImageCache.swift
+++ b/Sources/TwitchChat/Services/BadgeImageCache.swift
@@ -1,0 +1,104 @@
+// BadgeImageCache.swift
+// Twitch バッジ画像のキャッシュと非同期読み込みを管理するサービス
+// NSCache ベースのメモリキャッシュで同一バッジの再ダウンロードを防ぐ
+
+import AppKit
+import Foundation
+
+/// Twitch バッジ画像のキャッシュ管理クラス
+///
+/// - `BadgeStore` から画像 URL を解決し、CDN からダウンロード
+/// - NSCache によるメモリキャッシュ（メモリプレッシャー時に自動解放）
+/// - 同一バッジへの並行リクエストを1回のダウンロードに集約する in-flight 管理
+/// - シングルトンで全 View 間でキャッシュを共有
+final class BadgeImageCache: @unchecked Sendable {
+
+    /// シングルトンインスタンス
+    static let shared = BadgeImageCache()
+
+    /// バッジの表示サイズ（ポイント）
+    ///
+    /// テキスト行高に合わせた値。NSImage.size および BadgeImageView のフレームサイズに使用する。
+    static let badgeDisplaySize: CGFloat = 18
+
+    /// バッジ画像のメモリキャッシュ（キー: "badgeName/version"）
+    private let imageCache: NSCache<NSString, NSImage> = {
+        let c = NSCache<NSString, NSImage>()
+        c.countLimit = 200
+        return c
+    }()
+
+    /// 進行中のダウンロードタスク（キー: "badgeName/version"）
+    private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
+
+    /// inFlightTasks へのアクセスを保護するロック
+    private let lock = NSLock()
+
+    private init() {}
+
+    // MARK: - 画像取得
+
+    /// バッジ画像を取得する（キャッシュ優先・並行重複排除付き）
+    ///
+    /// - Parameters:
+    ///   - badge: 表示対象のバッジ
+    ///   - store: バッジ定義ストア（URL解決に使用）
+    /// - Returns: ダウンロード済みの NSImage（`badgeDisplaySize` にリサイズ済み）。取得失敗時は nil
+    func image(for badge: Badge, store: BadgeStore) async -> NSImage? {
+        let key = Self.cacheKey(for: badge)
+        let cacheKey = key as NSString
+
+        // キャッシュヒット: 即時返却
+        if let cached = imageCache.object(forKey: cacheKey) {
+            return cached
+        }
+
+        // 進行中タスクへの相乗り、または新規タスクの作成（排他制御）
+        let task: Task<NSImage?, Never> = lock.withLock {
+            if let existing = inFlightTasks[key] {
+                return existing
+            }
+            let newTask = Task { [weak self] in
+                guard let self else { return nil as NSImage? }
+                defer { self.lock.withLock { self.inFlightTasks.removeValue(forKey: key) } }
+
+                // BadgeStore から URL を解決してダウンロード
+                guard let url = await store.imageURL(for: badge),
+                      let image = await self.download(from: url) else { return nil }
+                self.store(image, for: key)
+                return image
+            }
+            inFlightTasks[key] = newTask
+            return newTask
+        }
+
+        return await task.value
+    }
+
+    // MARK: - 静的ユーティリティ
+
+    /// バッジのキャッシュキーを生成する
+    ///
+    /// - Parameter badge: 対象のバッジ
+    /// - Returns: "badgeName/version" 形式のキー文字列
+    static func cacheKey(for badge: Badge) -> String {
+        "\(badge.name)/\(badge.version)"
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// 指定 URL から画像をダウンロードする
+    private func download(from url: URL) async -> NSImage? {
+        guard let (data, response) = try? await URLSession.shared.data(from: url),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let image = NSImage(data: data) else { return nil }
+        return image
+    }
+
+    /// 画像をキャッシュに保存し、表示サイズを設定する
+    private func store(_ image: NSImage, for key: String) {
+        image.size = NSSize(width: Self.badgeDisplaySize, height: Self.badgeDisplaySize)
+        imageCache.setObject(image, forKey: key as NSString)
+    }
+}

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -13,6 +13,7 @@ typealias BadgeURLMapping = [String: [String: String]]
 /// - グローバルバッジ（broadcaster, moderator, vip 等）は接続時に1回フェッチ
 /// - チャンネルバッジ（subscriber 等の独自アート）は room-id 取得後にフェッチ
 /// - imageURL(for:) はチャンネルバッジを優先し、なければグローバルにフォールバック
+/// - 並行フェッチの重複実行を Task-based deduplication で防止
 actor BadgeStore {
 
     // MARK: - 定数
@@ -22,6 +23,9 @@ actor BadgeStore {
 
     /// Twitch GQL Client-ID（公開クライアントID）
     private static let gqlClientID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+
+    /// GQL リクエストのタイムアウト秒数
+    private static let requestTimeout: TimeInterval = 10
 
     // MARK: - 状態
 
@@ -34,31 +38,48 @@ actor BadgeStore {
     /// グローバルバッジ取得済みフラグ
     private var isGlobalLoaded = false
 
+    /// 進行中のグローバルバッジフェッチタスク（並行重複排除用）
+    private var globalBadgesTask: Task<Void, Never>?
+
     // MARK: - 公開メソッド
 
     /// グローバルバッジ定義をフェッチする
     ///
-    /// 二重フェッチを防止するため、取得済みの場合はスキップする
+    /// 並行して複数回呼ばれた場合でも、ネットワークリクエストは1回のみ実行される
     func fetchGlobalBadges() async {
         guard !isGlobalLoaded else { return }
-        guard let response = try? await fetchGQL(
-            query: "{ badges { id title imageURL(size: DOUBLE) } }",
-            responseType: GQLBadgesResponse.self
-        ) else { return }
-        globalBadges = Self.buildMapping(from: response.data.badges)
-        isGlobalLoaded = true
+        // 進行中タスクがあれば完了を待って返す（TOCTOU 防止）
+        if let existing = globalBadgesTask {
+            await existing.value
+            return
+        }
+        let task = Task {
+            if let response = try? await self.fetchGQL(
+                query: "{ badges { id title imageURL(size: DOUBLE) } }",
+                responseType: GQLBadgesResponse.self
+            ) {
+                self.globalBadges = Self.buildMapping(from: response.data.badges)
+                self.isGlobalLoaded = true
+            }
+        }
+        globalBadgesTask = task
+        await task.value
+        globalBadgesTask = nil
     }
 
     /// チャンネルバッジ定義をフェッチする
     ///
-    /// - Parameter channelId: Twitch チャンネルID（IRCの room-id タグの値）
+    /// - Parameter channelId: Twitch チャンネルID（IRCの room-id タグの値、数字のみ）
     func fetchChannelBadges(channelId: String) async {
+        // Twitch の room-id は数字のみで構成される（GQL injection 対策）
+        guard !channelId.isEmpty, channelId.allSatisfy(\.isNumber) else { return }
         let query = "{ user(id: \"\(channelId)\") { broadcastBadges { id title imageURL(size: DOUBLE) } } }"
         guard let response = try? await fetchGQL(
             query: query,
             responseType: GQLChannelBadgesResponse.self
-        ) else { return }
-        channelBadges = Self.buildMapping(from: response.data.user.broadcastBadges)
+        ),
+        let userBadges = response.data.user else { return }
+        channelBadges = Self.buildMapping(from: userBadges.broadcastBadges)
     }
 
     /// バッジの画像 URL を解決する
@@ -76,6 +97,7 @@ actor BadgeStore {
 
     // MARK: - テスト用メソッド
 
+#if DEBUG
     /// グローバルバッジのURLマッピングを直接設定する（テスト用）
     func setGlobalBadges(_ mapping: BadgeURLMapping) {
         globalBadges = mapping
@@ -86,6 +108,7 @@ actor BadgeStore {
     func setChannelBadges(_ mapping: BadgeURLMapping) {
         channelBadges = mapping
     }
+#endif
 
     // MARK: - 静的ユーティリティ
 
@@ -107,12 +130,24 @@ actor BadgeStore {
 
     // MARK: - プライベートメソッド
 
+    /// GQL レスポンスのエラー情報を保持する内部型
+    private struct GQLErrorContainer: Decodable {
+        struct GQLError: Decodable {
+            let message: String
+        }
+        let errors: [GQLError]?
+    }
+
     /// GQL リクエストを送信して結果をデコードする
+    ///
+    /// - タイムアウト: `requestTimeout` 秒
+    /// - GQL レベルのエラーが含まれている場合は `URLError(.badServerResponse)` をスロー
     private func fetchGQL<T: Decodable>(query: String, responseType: T.Type) async throws -> T {
         var request = URLRequest(url: Self.gqlEndpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(Self.gqlClientID, forHTTPHeaderField: "Client-Id")
+        request.timeoutInterval = Self.requestTimeout
 
         let body = ["query": query]
         request.httpBody = try JSONEncoder().encode(body)
@@ -122,6 +157,13 @@ actor BadgeStore {
               httpResponse.statusCode == 200 else {
             throw URLError(.badServerResponse)
         }
+
+        // GQL レベルのエラーチェック（data フィールドが正常でも errors が含まれる場合がある）
+        if let errorContainer = try? JSONDecoder().decode(GQLErrorContainer.self, from: data),
+           let errors = errorContainer.errors, !errors.isEmpty {
+            throw URLError(.badServerResponse)
+        }
+
         return try JSONDecoder().decode(T.self, from: data)
     }
 }

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -95,6 +95,22 @@ actor BadgeStore {
         return URL(string: urlString)
     }
 
+    /// チャンネルバッジのマッピングをクリアする
+    ///
+    /// チャンネル切替時（connect 呼び出し前）に呼び出すことで、
+    /// 前チャンネルのチャンネルバッジが新チャンネルのメッセージに誤解決されるのを防ぐ
+    func resetChannelBadges() {
+        channelBadges = [:]
+    }
+
+    /// 進行中のグローバルバッジフェッチタスクをキャンセルする
+    ///
+    /// disconnect 時に呼び出すことで、不要なネットワークリクエストを中断できる
+    func cancelGlobalFetch() {
+        globalBadgesTask?.cancel()
+        globalBadgesTask = nil
+    }
+
     // MARK: - テスト用メソッド
 
 #if DEBUG

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -1,0 +1,127 @@
+// BadgeStore.swift
+// Twitch バッジ定義の取得・管理サービス
+// Twitch GQL から グローバル・チャンネルバッジ定義をフェッチし、画像URLを解決する
+
+import Foundation
+
+/// バッジ定義の URL マッピング型
+/// [バッジ名: [バージョン: 画像URLString]]
+typealias BadgeURLMapping = [String: [String: String]]
+
+/// Twitch バッジ定義の取得・管理を行うサービス
+///
+/// - グローバルバッジ（broadcaster, moderator, vip 等）は接続時に1回フェッチ
+/// - チャンネルバッジ（subscriber 等の独自アート）は room-id 取得後にフェッチ
+/// - imageURL(for:) はチャンネルバッジを優先し、なければグローバルにフォールバック
+actor BadgeStore {
+
+    // MARK: - 定数
+
+    /// Twitch GQL エンドポイント
+    private static let gqlEndpoint = URL(string: "https://gql.twitch.tv/gql")!
+
+    /// Twitch GQL Client-ID（公開クライアントID）
+    private static let gqlClientID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+
+    // MARK: - 状態
+
+    /// グローバルバッジのURLマッピング
+    private var globalBadges: BadgeURLMapping = [:]
+
+    /// チャンネルバッジのURLマッピング
+    private var channelBadges: BadgeURLMapping = [:]
+
+    /// グローバルバッジ取得済みフラグ
+    private var isGlobalLoaded = false
+
+    // MARK: - 公開メソッド
+
+    /// グローバルバッジ定義をフェッチする
+    ///
+    /// 二重フェッチを防止するため、取得済みの場合はスキップする
+    func fetchGlobalBadges() async {
+        guard !isGlobalLoaded else { return }
+        guard let response = try? await fetchGQL(
+            query: "{ badges { id title imageURL(size: DOUBLE) } }",
+            responseType: GQLBadgesResponse.self
+        ) else { return }
+        globalBadges = Self.buildMapping(from: response.data.badges)
+        isGlobalLoaded = true
+    }
+
+    /// チャンネルバッジ定義をフェッチする
+    ///
+    /// - Parameter channelId: Twitch チャンネルID（IRCの room-id タグの値）
+    func fetchChannelBadges(channelId: String) async {
+        let query = "{ user(id: \"\(channelId)\") { broadcastBadges { id title imageURL(size: DOUBLE) } } }"
+        guard let response = try? await fetchGQL(
+            query: query,
+            responseType: GQLChannelBadgesResponse.self
+        ) else { return }
+        channelBadges = Self.buildMapping(from: response.data.user.broadcastBadges)
+    }
+
+    /// バッジの画像 URL を解決する
+    ///
+    /// チャンネルバッジを優先し、見つからない場合はグローバルバッジにフォールバックする
+    ///
+    /// - Parameter badge: IRC から取得した Badge
+    /// - Returns: バッジ画像の URL、未登録の場合は nil
+    func imageURL(for badge: Badge) -> URL? {
+        let urlString = channelBadges[badge.name]?[badge.version]
+            ?? globalBadges[badge.name]?[badge.version]
+        guard let urlString else { return nil }
+        return URL(string: urlString)
+    }
+
+    // MARK: - テスト用メソッド
+
+    /// グローバルバッジのURLマッピングを直接設定する（テスト用）
+    func setGlobalBadges(_ mapping: BadgeURLMapping) {
+        globalBadges = mapping
+        isGlobalLoaded = true
+    }
+
+    /// チャンネルバッジのURLマッピングを直接設定する（テスト用）
+    func setChannelBadges(_ mapping: BadgeURLMapping) {
+        channelBadges = mapping
+    }
+
+    // MARK: - 静的ユーティリティ
+
+    /// GQLBadgeItem の配列から URLマッピングを構築する
+    ///
+    /// - Parameter items: GQL バッジアイテムの配列
+    /// - Returns: [バッジ名: [バージョン: URLString]] のマッピング
+    static func buildMapping(from items: [GQLBadgeItem]) -> BadgeURLMapping {
+        var mapping: BadgeURLMapping = [:]
+        for item in items {
+            guard let parsed = item.parsedNameAndVersion else { continue }
+            if mapping[parsed.name] == nil {
+                mapping[parsed.name] = [:]
+            }
+            mapping[parsed.name]?[parsed.version] = item.imageURL
+        }
+        return mapping
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// GQL リクエストを送信して結果をデコードする
+    private func fetchGQL<T: Decodable>(query: String, responseType: T.Type) async throws -> T {
+        var request = URLRequest(url: Self.gqlEndpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(Self.gqlClientID, forHTTPHeaderField: "Client-Id")
+
+        let body = ["query": query]
+        request.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -91,6 +91,9 @@ final class ChatViewModel {
         messages = []
         channelBadgesFetched = false
 
+        // チャンネル切替時に前チャンネルのバッジが誤解決されないようクリア
+        await badgeStore.resetChannelBadges()
+
         // グローバルバッジ定義を並行フェッチ（切断時にキャンセルできるよう保持）
         globalBadgeFetchTask = Task { await badgeStore.fetchGlobalBadges() }
 
@@ -119,6 +122,8 @@ final class ChatViewModel {
         receiveTask?.cancel()
         globalBadgeFetchTask?.cancel()
         channelBadgeFetchTask?.cancel()
+        // BadgeStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
+        await badgeStore.cancelGlobalFetch()
         await ircClient.disconnect()
         connectionState = .disconnected
     }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -60,6 +60,12 @@ final class ChatViewModel {
     /// バッジ定義ストア（View からバッジ画像URLの解決に使用）
     let badgeStore = BadgeStore()
 
+    /// グローバルバッジフェッチタスク（切断時にキャンセル）
+    private var globalBadgeFetchTask: Task<Void, Never>?
+
+    /// チャンネルバッジフェッチタスク（切断時にキャンセル）
+    private var channelBadgeFetchTask: Task<Void, Never>?
+
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false
 
@@ -85,8 +91,8 @@ final class ChatViewModel {
         messages = []
         channelBadgesFetched = false
 
-        // グローバルバッジ定義を並行フェッチ
-        Task { await badgeStore.fetchGlobalBadges() }
+        // グローバルバッジ定義を並行フェッチ（切断時にキャンセルできるよう保持）
+        globalBadgeFetchTask = Task { await badgeStore.fetchGlobalBadges() }
 
         receiveTask = Task { [weak self] in
             // メッセージ受信ループを別タスクで開始
@@ -111,6 +117,8 @@ final class ChatViewModel {
     /// チャンネルから切断する
     func disconnect() async {
         receiveTask?.cancel()
+        globalBadgeFetchTask?.cancel()
+        channelBadgeFetchTask?.cancel()
         await ircClient.disconnect()
         connectionState = .disconnected
     }
@@ -119,10 +127,10 @@ final class ChatViewModel {
 
     /// メッセージをリストに追加し、上限を超えた場合は古いものを削除する
     private func appendMessage(_ message: ChatMessage) {
-        // 最初の room-id 取得時にチャンネルバッジをフェッチ
+        // 最初の room-id 取得時にチャンネルバッジをフェッチ（切断時にキャンセルできるよう保持）
         if !channelBadgesFetched, let roomId = message.roomId {
             channelBadgesFetched = true
-            Task { await badgeStore.fetchChannelBadges(channelId: roomId) }
+            channelBadgeFetchTask = Task { await badgeStore.fetchChannelBadges(channelId: roomId) }
         }
         messages.append(message)
         if messages.count > Self.maxMessages {

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -57,6 +57,12 @@ final class ChatViewModel {
     private let ircClient: any TwitchIRCClientProtocol
     private var receiveTask: Task<Void, Never>?
 
+    /// バッジ定義ストア（View からバッジ画像URLの解決に使用）
+    let badgeStore = BadgeStore()
+
+    /// チャンネルバッジ取得済みフラグ
+    private var channelBadgesFetched = false
+
     // MARK: - 初期化
 
     /// ChatViewModel を初期化する
@@ -77,6 +83,10 @@ final class ChatViewModel {
         channelName = channel
         connectionState = .connecting
         messages = []
+        channelBadgesFetched = false
+
+        // グローバルバッジ定義を並行フェッチ
+        Task { await badgeStore.fetchGlobalBadges() }
 
         receiveTask = Task { [weak self] in
             // メッセージ受信ループを別タスクで開始
@@ -109,6 +119,11 @@ final class ChatViewModel {
 
     /// メッセージをリストに追加し、上限を超えた場合は古いものを削除する
     private func appendMessage(_ message: ChatMessage) {
+        // 最初の room-id 取得時にチャンネルバッジをフェッチ
+        if !channelBadgesFetched, let roomId = message.roomId {
+            channelBadgesFetched = true
+            Task { await badgeStore.fetchChannelBadges(channelId: roomId) }
+        }
         messages.append(message)
         if messages.count > Self.maxMessages {
             messages.removeFirst(messages.count - Self.maxMessages)

--- a/Sources/TwitchChat/Views/BadgeImageView.swift
+++ b/Sources/TwitchChat/Views/BadgeImageView.swift
@@ -1,0 +1,51 @@
+// BadgeImageView.swift
+// バッジ1件を画像で表示するビュー
+// 画像未取得時は絵文字フォールバック表示
+
+import AppKit
+import SwiftUI
+
+/// Twitch バッジ1件を画像で表示するビュー
+///
+/// - `BadgeImageCache` を通じて非同期で画像を取得・表示する
+/// - 画像取得前または取得失敗時は絵文字フォールバックで表示する
+struct BadgeImageView: View {
+
+    let badge: Badge
+    let store: BadgeStore
+
+    @State private var badgeImage: NSImage?
+
+    var body: some View {
+        Group {
+            if let image = badgeImage {
+                Image(nsImage: image)
+                    .resizable()
+                    .frame(
+                        width: BadgeImageCache.badgeDisplaySize,
+                        height: BadgeImageCache.badgeDisplaySize
+                    )
+            } else {
+                // 画像未取得時の絵文字フォールバック
+                Text(fallbackEmoji(for: badge.name))
+                    .font(.system(size: 11))
+            }
+        }
+        .task(id: badge.name + "/" + badge.version) {
+            badgeImage = await BadgeImageCache.shared.image(for: badge, store: store)
+        }
+    }
+
+    /// バッジ名に対応する絵文字フォールバックを返す
+    private func fallbackEmoji(for badgeName: String) -> String {
+        switch badgeName {
+        case "broadcaster": return "📡"
+        case "moderator": return "⚔️"
+        case "subscriber": return "★"
+        case "vip": return "💎"
+        case "partner": return "✓"
+        case "staff": return "🔧"
+        default: return "•"
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/BadgeImageView.swift
+++ b/Sources/TwitchChat/Views/BadgeImageView.swift
@@ -32,6 +32,8 @@ struct BadgeImageView: View {
             }
         }
         .task(id: badge.name + "/" + badge.version) {
+            // タスク再実行時に古い画像をクリアしてフォールバックを表示してから再取得する
+            badgeImage = nil
             badgeImage = await BadgeImageCache.shared.image(for: badge, store: store)
         }
     }

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// チャットメッセージ 1 件の表示ビュー
 ///
 /// - ユーザー名を Twitch 設定の色で表示
-/// - バッジを絵文字で表現（broadcaster: 📡、moderator: ⚔️、subscriber: ★）
+/// - バッジを画像で表示（BadgeImageCache でキャッシュ、未取得時は絵文字フォールバック）
 /// - メッセージ本文を FlowLayout でレンダリングし、エモートを AnimatedEmoteView でインライン表示
 /// - アニメーション GIF エモートは `NSImageView.animates = true` で自動再生
 /// - エモート未読み込み時はエモート名をグレーテキストのプレースホルダとして表示

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -16,6 +16,9 @@ struct ChatMessageView: View {
 
     let message: ChatMessage
 
+    /// バッジ定義ストア（BadgeImageView のURL解決に使用）
+    let badgeStore: BadgeStore
+
     /// ダウンロード済みエモート画像（キー: エモートID）
     @State private var emoteImages: [String: NSImage] = [:]
 
@@ -107,26 +110,12 @@ struct ChatMessageView: View {
         }
     }
 
-    /// バッジを絵文字で表示
+    /// バッジを画像で表示（未取得時は絵文字フォールバック）
     private var badgesView: some View {
         HStack(spacing: 2) {
             ForEach(message.badges, id: \.name) { badge in
-                Text(badgeEmoji(for: badge.name))
-                    .font(.system(size: 11))
+                BadgeImageView(badge: badge, store: badgeStore)
             }
-        }
-    }
-
-    /// バッジ名に対応する絵文字を返す
-    private func badgeEmoji(for badgeName: String) -> String {
-        switch badgeName {
-        case "broadcaster": return "📡"
-        case "moderator": return "⚔️"
-        case "subscriber": return "★"
-        case "vip": return "💎"
-        case "partner": return "✓"
-        case "staff": return "🔧"
-        default: return "•"
         }
     }
 

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -54,7 +54,7 @@ struct ContentView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(viewModel.messages) { message in
-                        ChatMessageView(message: message)
+                        ChatMessageView(message: message, badgeStore: viewModel.badgeStore)
                             .id(message.id)
                     }
                 }

--- a/Tests/TwitchChatTests/BadgeDefinitionTests.swift
+++ b/Tests/TwitchChatTests/BadgeDefinitionTests.swift
@@ -1,0 +1,129 @@
+// BadgeDefinitionTests.swift
+// Twitch GQL バッジ定義レスポンスのデコードテスト
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("BadgeDefinitionTests")
+struct BadgeDefinitionTests {
+
+    // MARK: - グローバルバッジレスポンスのデコード
+
+    @Test("グローバルバッジレスポンスを正常にデコードできる")
+    func testDecodeGlobalBadgesResponse() throws {
+        let json = """
+        {
+            "data": {
+                "badges": [
+                    {
+                        "id": "YnJvYWRjYXN0ZXI7MTs=",
+                        "title": "Broadcaster",
+                        "imageURL": "https://static-cdn.jtvnw.net/badges/v1/abc123/2"
+                    },
+                    {
+                        "id": "bW9kZXJhdG9yOzE7",
+                        "title": "Moderator",
+                        "imageURL": "https://static-cdn.jtvnw.net/badges/v1/def456/2"
+                    }
+                ]
+            }
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(GQLBadgesResponse.self, from: data)
+
+        #expect(response.data.badges.count == 2)
+        #expect(response.data.badges[0].title == "Broadcaster")
+        #expect(response.data.badges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/abc123/2")
+        #expect(response.data.badges[1].title == "Moderator")
+    }
+
+    @Test("GQLバッジのbase64 IDから名前とバージョンを抽出できる")
+    func testDecodeGQLBadgeID() throws {
+        // "broadcaster;1;" の base64
+        let broadcasterBadge = GQLBadgeItem(
+            id: "YnJvYWRjYXN0ZXI7MTs=",
+            title: "Broadcaster",
+            imageURL: "https://example.com/badge.png"
+        )
+        let parsed = broadcasterBadge.parsedNameAndVersion
+        #expect(parsed?.name == "broadcaster")
+        #expect(parsed?.version == "1")
+    }
+
+    @Test("チャンネル固有バッジのbase64 IDから名前とバージョンを抽出できる")
+    func testDecodeChannelBadgeID() throws {
+        // "subscriber;0;37402112" の base64
+        let subscriberBadge = GQLBadgeItem(
+            id: "c3Vic2NyaWJlcjswOzM3NDAyMTEy",
+            title: "Subscriber",
+            imageURL: "https://example.com/sub.png"
+        )
+        let parsed = subscriberBadge.parsedNameAndVersion
+        #expect(parsed?.name == "subscriber")
+        #expect(parsed?.version == "0")
+    }
+
+    @Test("不正なbase64 IDの場合はnilを返す")
+    func testInvalidBase64ID() {
+        let invalidBadge = GQLBadgeItem(
+            id: "not-valid-base64!!",
+            title: "Invalid",
+            imageURL: "https://example.com/badge.png"
+        )
+        #expect(invalidBadge.parsedNameAndVersion == nil)
+    }
+
+    @Test("バッジIDのデコード結果がセミコロン区切りでない場合はnilを返す")
+    func testMalformedDecodedID() {
+        // "malformed" の base64
+        let malformedBadge = GQLBadgeItem(
+            id: "bWFsZm9ybWVk",
+            title: "Malformed",
+            imageURL: "https://example.com/badge.png"
+        )
+        #expect(malformedBadge.parsedNameAndVersion == nil)
+    }
+
+    // MARK: - チャンネルバッジレスポンスのデコード
+
+    @Test("チャンネルバッジレスポンスを正常にデコードできる")
+    func testDecodeChannelBadgesResponse() throws {
+        let json = """
+        {
+            "data": {
+                "user": {
+                    "broadcastBadges": [
+                        {
+                            "id": "c3Vic2NyaWJlcjswOzM3NDAyMTEy",
+                            "title": "サブスクライバー",
+                            "imageURL": "https://static-cdn.jtvnw.net/badges/v1/xyz789/2"
+                        }
+                    ]
+                }
+            }
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(GQLChannelBadgesResponse.self, from: data)
+
+        #expect(response.data.user.broadcastBadges.count == 1)
+        #expect(response.data.user.broadcastBadges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/xyz789/2")
+    }
+
+    @Test("バッジが0件のレスポンスをデコードできる")
+    func testDecodeEmptyBadgesResponse() throws {
+        let json = """
+        {
+            "data": {
+                "badges": []
+            }
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(GQLBadgesResponse.self, from: data)
+
+        #expect(response.data.badges.isEmpty)
+    }
+}

--- a/Tests/TwitchChatTests/BadgeDefinitionTests.swift
+++ b/Tests/TwitchChatTests/BadgeDefinitionTests.swift
@@ -34,13 +34,16 @@ struct BadgeDefinitionTests {
         let response = try JSONDecoder().decode(GQLBadgesResponse.self, from: data)
 
         #expect(response.data.badges.count == 2)
+        // id フィールドが正しくデコードされていることを確認
+        #expect(response.data.badges[0].id == "YnJvYWRjYXN0ZXI7MTs=")
         #expect(response.data.badges[0].title == "Broadcaster")
         #expect(response.data.badges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/abc123/2")
+        #expect(response.data.badges[1].id == "bW9kZXJhdG9yOzE7")
         #expect(response.data.badges[1].title == "Moderator")
     }
 
     @Test("GQLバッジのbase64 IDから名前とバージョンを抽出できる")
-    func testDecodeGQLBadgeID() throws {
+    func testDecodeGQLBadgeID() {
         // "broadcaster;1;" の base64
         let broadcasterBadge = GQLBadgeItem(
             id: "YnJvYWRjYXN0ZXI7MTs=",
@@ -53,7 +56,7 @@ struct BadgeDefinitionTests {
     }
 
     @Test("チャンネル固有バッジのbase64 IDから名前とバージョンを抽出できる")
-    func testDecodeChannelBadgeID() throws {
+    func testDecodeChannelBadgeID() {
         // "subscriber;0;37402112" の base64
         let subscriberBadge = GQLBadgeItem(
             id: "c3Vic2NyaWJlcjswOzM3NDAyMTEy",
@@ -108,8 +111,23 @@ struct BadgeDefinitionTests {
         let data = Data(json.utf8)
         let response = try JSONDecoder().decode(GQLChannelBadgesResponse.self, from: data)
 
-        #expect(response.data.user.broadcastBadges.count == 1)
-        #expect(response.data.user.broadcastBadges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/xyz789/2")
+        #expect(response.data.user?.broadcastBadges.count == 1)
+        #expect(response.data.user?.broadcastBadges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/xyz789/2")
+    }
+
+    @Test("user が null のチャンネルバッジレスポンスをデコードできる")
+    func testDecodeChannelBadgesResponseWithNullUser() throws {
+        let json = """
+        {
+            "data": {
+                "user": null
+            }
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(GQLChannelBadgesResponse.self, from: data)
+
+        #expect(response.data.user == nil)
     }
 
     @Test("バッジが0件のレスポンスをデコードできる")

--- a/Tests/TwitchChatTests/BadgeImageCacheTests.swift
+++ b/Tests/TwitchChatTests/BadgeImageCacheTests.swift
@@ -1,0 +1,36 @@
+// BadgeImageCacheTests.swift
+// BadgeImageCache のキャッシュキーと表示サイズのテスト
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("BadgeImageCacheTests")
+struct BadgeImageCacheTests {
+
+    @Test("バッジの表示サイズが18ptである")
+    func testBadgeDisplaySize() {
+        #expect(BadgeImageCache.badgeDisplaySize == 18.0)
+    }
+
+    @Test("キャッシュキーが badgeName/version の形式である")
+    func testCacheKey() {
+        let badge = Badge(name: "subscriber", version: "12")
+        let key = BadgeImageCache.cacheKey(for: badge)
+        #expect(key == "subscriber/12")
+    }
+
+    @Test("broadcaster バッジのキャッシュキーが正しい")
+    func testBroadcasterCacheKey() {
+        let badge = Badge(name: "broadcaster", version: "1")
+        let key = BadgeImageCache.cacheKey(for: badge)
+        #expect(key == "broadcaster/1")
+    }
+
+    @Test("バッジ名にスラッシュが含まれない通常バッジのキーが正しい")
+    func testVipCacheKey() {
+        let badge = Badge(name: "vip", version: "1")
+        let key = BadgeImageCache.cacheKey(for: badge)
+        #expect(key == "vip/1")
+    }
+}

--- a/Tests/TwitchChatTests/BadgeImageCacheTests.swift
+++ b/Tests/TwitchChatTests/BadgeImageCacheTests.swift
@@ -13,24 +13,15 @@ struct BadgeImageCacheTests {
         #expect(BadgeImageCache.badgeDisplaySize == 18.0)
     }
 
-    @Test("キャッシュキーが badgeName/version の形式である")
-    func testCacheKey() {
-        let badge = Badge(name: "subscriber", version: "12")
+    @Test("キャッシュキーが badgeName/version の形式である", arguments: [
+        (Badge(name: "subscriber", version: "12"), "subscriber/12"),
+        (Badge(name: "broadcaster", version: "1"), "broadcaster/1"),
+        (Badge(name: "vip", version: "1"), "vip/1"),
+        (Badge(name: "moderator", version: "1"), "moderator/1"),
+        (Badge(name: "partner", version: "1"), "partner/1")
+    ])
+    func testCacheKey(badge: Badge, expectedKey: String) {
         let key = BadgeImageCache.cacheKey(for: badge)
-        #expect(key == "subscriber/12")
-    }
-
-    @Test("broadcaster バッジのキャッシュキーが正しい")
-    func testBroadcasterCacheKey() {
-        let badge = Badge(name: "broadcaster", version: "1")
-        let key = BadgeImageCache.cacheKey(for: badge)
-        #expect(key == "broadcaster/1")
-    }
-
-    @Test("バッジ名にスラッシュが含まれない通常バッジのキーが正しい")
-    func testVipCacheKey() {
-        let badge = Badge(name: "vip", version: "1")
-        let key = BadgeImageCache.cacheKey(for: badge)
-        #expect(key == "vip/1")
+        #expect(key == expectedKey)
     }
 }

--- a/Tests/TwitchChatTests/BadgeStoreTests.swift
+++ b/Tests/TwitchChatTests/BadgeStoreTests.swift
@@ -1,0 +1,106 @@
+// BadgeStoreTests.swift
+// BadgeStore の URL解決ロジックテスト
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("BadgeStoreTests")
+struct BadgeStoreTests {
+
+    // MARK: - URL解決ロジック（BadgeStore のファクトリメソッドを直接テスト）
+
+    @Test("グローバルバッジのURLを正しく解決できる")
+    func testResolveGlobalBadgeURL() async {
+        let store = BadgeStore()
+
+        // グローバルバッジ定義を直接設定（テスト用）
+        let broadcasterURL = "https://static-cdn.jtvnw.net/badges/v1/abc/2"
+        await store.setGlobalBadges([
+            "broadcaster": ["1": broadcasterURL]
+        ])
+
+        let badge = Badge(name: "broadcaster", version: "1")
+        let url = await store.imageURL(for: badge)
+        #expect(url?.absoluteString == broadcasterURL)
+    }
+
+    @Test("チャンネルバッジがグローバルバッジより優先される")
+    func testChannelBadgeOverridesGlobal() async {
+        let store = BadgeStore()
+
+        let globalURL = "https://static-cdn.jtvnw.net/badges/v1/global-sub/2"
+        let channelURL = "https://static-cdn.jtvnw.net/badges/v1/channel-sub/2"
+
+        await store.setGlobalBadges([
+            "subscriber": ["0": globalURL]
+        ])
+        await store.setChannelBadges([
+            "subscriber": ["0": channelURL]
+        ])
+
+        let badge = Badge(name: "subscriber", version: "0")
+        let url = await store.imageURL(for: badge)
+        #expect(url?.absoluteString == channelURL)
+    }
+
+    @Test("チャンネルバッジにないバッジはグローバルにフォールバックする")
+    func testFallbackToGlobalWhenNotInChannel() async {
+        let store = BadgeStore()
+
+        let globalURL = "https://static-cdn.jtvnw.net/badges/v1/broadcaster/2"
+        await store.setGlobalBadges([
+            "broadcaster": ["1": globalURL]
+        ])
+        await store.setChannelBadges([
+            "subscriber": ["0": "https://example.com/sub.png"]
+        ])
+
+        let badge = Badge(name: "broadcaster", version: "1")
+        let url = await store.imageURL(for: badge)
+        #expect(url?.absoluteString == globalURL)
+    }
+
+    @Test("存在しないバッジ名の場合はnilを返す")
+    func testUnknownBadgeReturnsNil() async {
+        let store = BadgeStore()
+        await store.setGlobalBadges([
+            "broadcaster": ["1": "https://example.com/badge.png"]
+        ])
+
+        let badge = Badge(name: "unknown-badge", version: "1")
+        let url = await store.imageURL(for: badge)
+        #expect(url == nil)
+    }
+
+    @Test("存在しないバッジバージョンの場合はnilを返す")
+    func testUnknownVersionReturnsNil() async {
+        let store = BadgeStore()
+        await store.setGlobalBadges([
+            "subscriber": ["0": "https://example.com/sub.png"]
+        ])
+
+        let badge = Badge(name: "subscriber", version: "99999")
+        let url = await store.imageURL(for: badge)
+        #expect(url == nil)
+    }
+
+    @Test("GQLバッジレスポンスからURLマッピングを構築できる")
+    func testBuildMappingFromGQLResponse() {
+        let items = [
+            GQLBadgeItem(id: "YnJvYWRjYXN0ZXI7MTs=", title: "Broadcaster",
+                         imageURL: "https://example.com/broadcaster.png"),
+            GQLBadgeItem(id: "bW9kZXJhdG9yOzE7", title: "Moderator",
+                         imageURL: "https://example.com/moderator.png"),
+            // 不正なIDは無視される
+            GQLBadgeItem(id: "invalid!!!", title: "Invalid",
+                         imageURL: "https://example.com/invalid.png")
+        ]
+
+        let mapping = BadgeStore.buildMapping(from: items)
+
+        #expect(mapping["broadcaster"]?["1"] == "https://example.com/broadcaster.png")
+        #expect(mapping["moderator"]?["1"] == "https://example.com/moderator.png")
+        #expect(mapping["invalid"] == nil)
+    }
+}

--- a/Tests/TwitchChatTests/BadgeStoreTests.swift
+++ b/Tests/TwitchChatTests/BadgeStoreTests.swift
@@ -103,4 +103,52 @@ struct BadgeStoreTests {
         #expect(mapping["moderator"]?["1"] == "https://example.com/moderator.png")
         #expect(mapping["invalid"] == nil)
     }
+
+    @Test("バッジ定義が未設定の場合はnilを返す")
+    func testImageURLReturnsNilWhenNoBadgesSet() async {
+        let store = BadgeStore()
+        // setGlobalBadges/setChannelBadges を呼ばない状態
+        let badge = Badge(name: "broadcaster", version: "1")
+        let url = await store.imageURL(for: badge)
+        #expect(url == nil)
+    }
+
+    @Test("空のバッジ名でも安全にnilを返す")
+    func testEmptyBadgeNameReturnsNil() async {
+        let store = BadgeStore()
+        await store.setGlobalBadges(["broadcaster": ["1": "https://example.com/badge.png"]])
+        let emptyNameBadge = Badge(name: "", version: "1")
+        let url = await store.imageURL(for: emptyNameBadge)
+        #expect(url == nil)
+    }
+
+    @Test("空のバージョンでも安全にnilを返す")
+    func testEmptyVersionReturnsNil() async {
+        let store = BadgeStore()
+        await store.setGlobalBadges(["broadcaster": ["1": "https://example.com/badge.png"]])
+        let emptyVersionBadge = Badge(name: "broadcaster", version: "")
+        let url = await store.imageURL(for: emptyVersionBadge)
+        #expect(url == nil)
+    }
+
+    @Test("並行アクセスしても安全に動作する")
+    func testConcurrentAccessIsSafe() async {
+        let store = BadgeStore()
+        // 複数タスクが並行して読み書きしてもクラッシュしないことを確認
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<10 {
+                group.addTask {
+                    await store.setGlobalBadges(
+                        ["broadcaster": ["1": "https://example.com/badge-\(i).png"]]
+                    )
+                }
+                group.addTask {
+                    _ = await store.imageURL(for: Badge(name: "broadcaster", version: "1"))
+                }
+            }
+        }
+        // 全タスク完了後に結果が一貫していることを確認
+        let url = await store.imageURL(for: Badge(name: "broadcaster", version: "1"))
+        #expect(url != nil)
+    }
 }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -174,4 +174,16 @@ struct ChatMessageTests {
         let chatMessage = ChatMessage(from: ircMessage)
         #expect(chatMessage?.roomId == nil)
     }
+
+    @Test("room-id タグが空文字の場合は roomId が nil になる")
+    func roomIdタグが空文字の場合はnilになる() {
+        let rawMessage = "@room-id=;display-name=視聴者 :viewer!viewer@viewer.tmi.twitch.tv PRIVMSG #haishinsha :こんにちは！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.roomId == nil)
+    }
 }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -150,4 +150,28 @@ struct ChatMessageTests {
         #expect(chatMessage?.badges[1].name == "subscriber")
         #expect(chatMessage?.colorHex == "#0000FF")
     }
+
+    @Test("PRIVMSG の room-id タグが roomId プロパティに反映される")
+    func PRIVMSGのroomIdタグがroomIdプロパティに反映される() {
+        let rawMessage = "@room-id=12345678;display-name=視聴者;color=#FF0000 :viewer!viewer@viewer.tmi.twitch.tv PRIVMSG #haishinsha :こんにちは！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.roomId == "12345678")
+    }
+
+    @Test("room-id タグがない場合は roomId が nil になる")
+    func roomIdタグがない場合はnilになる() {
+        let rawMessage = "@display-name=視聴者;color=#FF0000 :viewer!viewer@viewer.tmi.twitch.tv PRIVMSG #haishinsha :こんにちは！"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        let chatMessage = ChatMessage(from: ircMessage)
+        #expect(chatMessage?.roomId == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- 絵文字プレースホルダ（📡⚔️★等）を Twitch 公式バッジ画像に置き換え
- Twitch GQL API（認証不要）でグローバル・チャンネル両方のバッジ定義を取得
- `EmoteImageCache` と同パターンの `BadgeImageCache` で画像をメモリキャッシュ
- 画像未取得時は絵文字フォールバック表示を維持

## 変更内容

| ファイル | 変更 |
|---------|------|
| `Models/BadgeDefinition.swift` | GQL レスポンスの Decodable モデル（base64 バッジ ID 解析） |
| `Services/BadgeStore.swift` | GQL 経由でバッジ定義取得・URL 解決（actor、Task-based dedup） |
| `Services/BadgeImageCache.swift` | NSCache + in-flight 重複排除のバッジ画像キャッシュ |
| `Views/BadgeImageView.swift` | バッジ1件を画像表示するビュー |
| `Models/ChatMessage.swift` | `roomId: String?` 追加（チャンネルバッジフェッチに使用） |
| `ViewModels/ChatViewModel.swift` | バッジフェッチ Task の管理・切断時キャンセル |
| `Views/ChatMessageView.swift` | `badgesView` を `BadgeImageView` に置換 |

## 技術的補足

バッジ取得に使用する Twitch GQL（`gql.twitch.tv`）は公式 Helix API の代替として採用。
正式な移行は #3 で対応予定。

## Test plan

- [x] `swift test` — 82 テスト全通過
- [x] `swift build` — ビルド成功
- [ ] アプリ起動 → 任意のチャンネルに接続 → バッジが公式画像で表示されることを目視確認
- [ ] broadcaster, moderator, subscriber, vip 等の主要バッジが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャットのバッジ表示を追加しました。バッジ画像はキャッシュされ、同一リクエストは重複を避け効率的に読み込まれます。画像が無い場合は決定論的な絵文字で代替表示します。
  * メッセージモデルがルームIDを保持するようになり、チャンネル固有バッジの取得が遅延実行されます。

* **テスト**
  * バッジ関連の単体テスト群を追加しました（デコード・パース・キャッシュ挙動・優先順位など）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->