### PR TITLE
feat: バッジ取得を Twitch Helix API（認証あり）に移行する

### DIFF
--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -211,6 +211,7 @@ public final class AuthState {
     // MARK: - プライベートメソッド
 
     /// リフレッシュトークンで新しいアクセストークンを取得する
+
     private func tryRefreshToken() async {
         guard let refreshTokenValue = await keychainStore.load(key: "refresh_token") else {
             // リフレッシュトークンがない場合は認証情報を破棄してログアウト
@@ -234,5 +235,21 @@ public final class AuthState {
             accessToken = nil
             status = .loggedOut
         }
+    }
+}
+
+// MARK: - BadgeAPITokenProvider 準拠
+
+extension AuthState: BadgeAPITokenProvider {
+    /// 現在の有効なアクセストークンを返す
+    ///
+    /// 期限切れの場合は自動リフレッシュを試みる。未ログインまたは復元不能な場合は `nil`
+    func accessToken() async -> String? {
+        await validAccessToken()
+    }
+
+    /// Twitch アプリの Client ID を返す
+    func clientID() async throws -> String {
+        try AuthConfig.clientID()
     }
 }

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -241,10 +241,11 @@ public final class AuthState {
 // MARK: - BadgeAPITokenProvider 準拠
 
 extension AuthState: BadgeAPITokenProvider {
-    /// 現在の有効なアクセストークンを返す
+    /// 現在の有効なアクセストークンを取得する
     ///
+    /// プロパティ `accessToken` との名前衝突を避けるため `fetchAccessToken` として定義。
     /// 期限切れの場合は自動リフレッシュを試みる。未ログインまたは復元不能な場合は `nil`
-    func accessToken() async -> String? {
+    func fetchAccessToken() async -> String? {
         await validAccessToken()
     }
 

--- a/Sources/TwitchChat/Models/BadgeDefinition.swift
+++ b/Sources/TwitchChat/Models/BadgeDefinition.swift
@@ -1,67 +1,57 @@
 // BadgeDefinition.swift
-// Twitch GQL バッジ定義APIのレスポンスモデル
-// gql.twitch.tv からバッジ画像URLを取得するためのDecodable構造体
+// Twitch Helix API バッジ定義レスポンスモデル
+// api.twitch.tv/helix/chat/badges からバッジ画像URLを取得するためのDecodable構造体
 
 import Foundation
 
-// MARK: - グローバルバッジレスポンス
+// MARK: - Helix バッジレスポンス
 
-/// GQL `{ badges }` クエリのレスポンス全体
-struct GQLBadgesResponse: Decodable, Sendable {
-    let data: GQLBadgesData
+/// Helix `GET /helix/chat/badges/global` および
+/// `GET /helix/chat/badges?broadcaster_id={id}` 共通レスポンス
+struct HelixBadgesResponse: Decodable, Sendable {
+    let data: [HelixBadgeSet]
 }
 
-/// GQL バッジデータ
-struct GQLBadgesData: Decodable, Sendable {
-    let badges: [GQLBadgeItem]
+/// Helix バッジセット（例: "subscriber", "broadcaster"）
+struct HelixBadgeSet: Decodable, Sendable {
+    /// バッジセット識別子（例: "subscriber", "broadcaster", "moderator"）
+    let setId: String
+
+    /// バッジの各バージョン（月数やレベルごとに異なる画像を持つ）
+    let versions: [HelixBadgeVersion]
+
+    enum CodingKeys: String, CodingKey {
+        case setId = "set_id"
+        case versions
+    }
 }
 
-// MARK: - チャンネルバッジレスポンス
-
-/// GQL `{ user(id:) { broadcastBadges } }` クエリのレスポンス全体
-struct GQLChannelBadgesResponse: Decodable, Sendable {
-    let data: GQLChannelBadgesData
-}
-
-/// GQL チャンネルバッジデータ
-///
-/// GQL の `user(id:)` フィールドは存在しないユーザーIDの場合に null を返すため Optional
-struct GQLChannelBadgesData: Decodable, Sendable {
-    let user: GQLUserBadges?
-}
-
-/// GQL ユーザーのバッジ情報
-struct GQLUserBadges: Decodable, Sendable {
-    let broadcastBadges: [GQLBadgeItem]
-}
-
-// MARK: - バッジアイテム
-
-/// GQL バッジアイテム
-///
-/// GQL のバッジIDは base64 エンコードされた `"{name};{version};"` または
-/// `"{name};{version};{channelId}"` の形式。
-struct GQLBadgeItem: Decodable, Sendable {
-    /// base64エンコードされたバッジ識別子
+/// Helix バッジバージョン（バッジの各レベル・月数に対応）
+struct HelixBadgeVersion: Decodable, Sendable {
+    /// バージョン識別子（例: "0", "1", "3", "6"）
     let id: String
+
+    /// バッジ画像 URL（1x スケール）
+    let imageUrl1x: String
+
+    /// バッジ画像 URL（2x スケール）
+    let imageUrl2x: String
+
+    /// バッジ画像 URL（4x スケール）
+    let imageUrl4x: String
 
     /// バッジのタイトル（例: "Broadcaster", "Moderator"）
     let title: String
 
-    /// バッジ画像の URL（2xスケール）
-    let imageURL: String
+    /// バッジの説明
+    let description: String
 
-    /// base64エンコードされた id からバッジ名とバージョンを取得する
-    ///
-    /// - Returns: (name, version) のタプル、デコード失敗時は nil
-    var parsedNameAndVersion: (name: String, version: String)? {
-        guard let decoded = Data(base64Encoded: id),
-              let str = String(data: decoded, encoding: .utf8) else { return nil }
-        // フォーマット: "name;version;" または "name;version;channelId"
-        let parts = str.split(separator: ";", omittingEmptySubsequences: false)
-        guard parts.count >= 2,
-              !parts[0].isEmpty,
-              !parts[1].isEmpty else { return nil }
-        return (name: String(parts[0]), version: String(parts[1]))
+    enum CodingKeys: String, CodingKey {
+        case id
+        case imageUrl1x = "image_url_1x"
+        case imageUrl2x = "image_url_2x"
+        case imageUrl4x = "image_url_4x"
+        case title
+        case description
     }
 }

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -191,13 +191,12 @@ actor BadgeStore {
         url: URL,
         queryItems: [URLQueryItem]?
     ) async throws -> HelixBadgesResponse {
-        // トークンまたは Client ID が取得できない場合はリクエストしない
+        // トークンが取得できない場合（未ログイン）はリクエストしない
         guard let token = await tokenProvider.fetchAccessToken() else {
             throw URLError(.userAuthenticationRequired)
         }
-        guard let clientId = try? await tokenProvider.clientID() else {
-            throw URLError(.userAuthenticationRequired)
-        }
+        // Client ID 未設定の場合は AuthConfigError.missingClientID をそのまま伝播する
+        let clientId = try await tokenProvider.clientID()
 
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             throw URLError(.badURL)

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -15,8 +15,8 @@ typealias BadgeURLMapping = [String: [String: String]]
 /// `BadgeStore`（actor）と `AuthState`（@MainActor クラス）の分離境界を吸収するため、
 /// 最小限のインターフェースとして切り出している。テスト時のモック差し替えも容易。
 protocol BadgeAPITokenProvider: Sendable {
-    /// 現在の有効なアクセストークンを返す。未ログインまたは取得失敗の場合は `nil`
-    func accessToken() async -> String?
+    /// 現在の有効なアクセストークンを取得する。未ログインまたは取得失敗の場合は `nil`
+    func fetchAccessToken() async -> String?
 
     /// Twitch アプリの Client ID を返す
     ///
@@ -192,17 +192,23 @@ actor BadgeStore {
         queryItems: [URLQueryItem]?
     ) async throws -> HelixBadgesResponse {
         // トークンまたは Client ID が取得できない場合はリクエストしない
-        guard let token = await tokenProvider.accessToken() else {
+        guard let token = await tokenProvider.fetchAccessToken() else {
             throw URLError(.userAuthenticationRequired)
         }
         guard let clientId = try? await tokenProvider.clientID() else {
             throw URLError(.userAuthenticationRequired)
         }
 
-        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw URLError(.badURL)
+        }
         components.queryItems = queryItems
 
-        var request = URLRequest(url: components.url!)
+        guard let safeURL = components.url else {
+            throw URLError(.badURL)
+        }
+
+        var request = URLRequest(url: safeURL)
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue(clientId, forHTTPHeaderField: "Client-Id")
         request.timeoutInterval = Self.requestTimeout

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -85,12 +85,18 @@ actor BadgeStore {
             return
         }
         let task = Task {
-            if let response = try? await self.fetchHelix(
-                url: Self.helixGlobalBadgesURL,
-                queryItems: nil
-            ) {
+            do {
+                let response = try await self.fetchHelix(
+                    url: Self.helixGlobalBadgesURL,
+                    queryItems: nil
+                )
                 self.globalBadges = Self.buildMapping(from: response.data)
                 self.isGlobalLoaded = true
+            } catch let error as URLError where error.code == .userAuthenticationRequired {
+                // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
+            } catch {
+                // 設定不備・サーバーエラー等の恒久エラーは診断できるよう記録する
+                assertionFailure("グローバルバッジフェッチ失敗: \(error)")
             }
         }
         globalBadgesTask = task
@@ -105,11 +111,18 @@ actor BadgeStore {
     func fetchChannelBadges(channelId: String) async {
         // Twitch の room-id は数字のみで構成される（URLパラメータインジェクション対策）
         guard !channelId.isEmpty, channelId.allSatisfy(\.isNumber) else { return }
-        guard let response = try? await fetchHelix(
-            url: Self.helixChannelBadgesURL,
-            queryItems: [URLQueryItem(name: "broadcaster_id", value: channelId)]
-        ) else { return }
-        channelBadges = Self.buildMapping(from: response.data)
+        do {
+            let response = try await fetchHelix(
+                url: Self.helixChannelBadgesURL,
+                queryItems: [URLQueryItem(name: "broadcaster_id", value: channelId)]
+            )
+            channelBadges = Self.buildMapping(from: response.data)
+        } catch let error as URLError where error.code == .userAuthenticationRequired {
+            // 未ログイン時はスキップ
+        } catch {
+            // 設定不備・サーバーエラー等の恒久エラーは診断できるよう記録する
+            assertionFailure("チャンネルバッジフェッチ失敗（channelId: \(channelId)）: \(error)")
+        }
     }
 
     /// バッジの画像 URL を解決する

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -1,6 +1,6 @@
 // BadgeStore.swift
 // Twitch バッジ定義の取得・管理サービス
-// Twitch GQL から グローバル・チャンネルバッジ定義をフェッチし、画像URLを解決する
+// Twitch Helix API からグローバル・チャンネルバッジ定義をフェッチし、画像URLを解決する
 
 import Foundation
 
@@ -8,23 +8,40 @@ import Foundation
 /// [バッジ名: [バージョン: 画像URLString]]
 typealias BadgeURLMapping = [String: [String: String]]
 
-/// Twitch バッジ定義の取得・管理を行うサービス
+// MARK: - トークンプロバイダープロトコル
+
+/// バッジ Helix API 呼び出しに必要な認証情報を提供するプロトコル
+///
+/// `BadgeStore`（actor）と `AuthState`（@MainActor クラス）の分離境界を吸収するため、
+/// 最小限のインターフェースとして切り出している。テスト時のモック差し替えも容易。
+protocol BadgeAPITokenProvider: Sendable {
+    /// 現在の有効なアクセストークンを返す。未ログインまたは取得失敗の場合は `nil`
+    func accessToken() async -> String?
+
+    /// Twitch アプリの Client ID を返す
+    ///
+    /// - Throws: `AuthConfigError.missingClientID` が未設定の場合
+    func clientID() async throws -> String
+}
+
+/// バッジ定義の取得・管理を行うサービス
 ///
 /// - グローバルバッジ（broadcaster, moderator, vip 等）は接続時に1回フェッチ
 /// - チャンネルバッジ（subscriber 等の独自アート）は room-id 取得後にフェッチ
 /// - imageURL(for:) はチャンネルバッジを優先し、なければグローバルにフォールバック
 /// - 並行フェッチの重複実行を Task-based deduplication で防止
+/// - トークン未設定（未ログイン）の場合はフェッチをスキップする
 actor BadgeStore {
 
     // MARK: - 定数
 
-    /// Twitch GQL エンドポイント
-    private static let gqlEndpoint = URL(string: "https://gql.twitch.tv/gql")!
+    /// Helix グローバルバッジエンドポイント
+    private static let helixGlobalBadgesURL = URL(string: "https://api.twitch.tv/helix/chat/badges/global")!
 
-    /// Twitch GQL Client-ID（公開クライアントID）
-    private static let gqlClientID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+    /// Helix チャンネルバッジエンドポイント
+    private static let helixChannelBadgesURL = URL(string: "https://api.twitch.tv/helix/chat/badges")!
 
-    /// GQL リクエストのタイムアウト秒数
+    /// リクエストのタイムアウト秒数
     private static let requestTimeout: TimeInterval = 10
 
     // MARK: - 状態
@@ -41,11 +58,25 @@ actor BadgeStore {
     /// 進行中のグローバルバッジフェッチタスク（並行重複排除用）
     private var globalBadgesTask: Task<Void, Never>?
 
+    /// 認証情報プロバイダー
+    private let tokenProvider: any BadgeAPITokenProvider
+
+    // MARK: - 初期化
+
+    /// BadgeStore を初期化する
+    ///
+    /// - Parameter tokenProvider: Helix API 認証情報プロバイダー
+    init(tokenProvider: any BadgeAPITokenProvider) {
+        self.tokenProvider = tokenProvider
+    }
+
     // MARK: - 公開メソッド
 
     /// グローバルバッジ定義をフェッチする
     ///
-    /// 並行して複数回呼ばれた場合でも、ネットワークリクエストは1回のみ実行される
+    /// 並行して複数回呼ばれた場合でも、ネットワークリクエストは1回のみ実行される。
+    /// トークン未設定（未ログイン）の場合はスキップし、次回接続時に再取得できるよう
+    /// `isGlobalLoaded` フラグを `true` にしない。
     func fetchGlobalBadges() async {
         guard !isGlobalLoaded else { return }
         // 進行中タスクがあれば完了を待って返す（TOCTOU 防止）
@@ -54,11 +85,11 @@ actor BadgeStore {
             return
         }
         let task = Task {
-            if let response = try? await self.fetchGQL(
-                query: "{ badges { id title imageURL(size: DOUBLE) } }",
-                responseType: GQLBadgesResponse.self
+            if let response = try? await self.fetchHelix(
+                url: Self.helixGlobalBadgesURL,
+                queryItems: nil
             ) {
-                self.globalBadges = Self.buildMapping(from: response.data.badges)
+                self.globalBadges = Self.buildMapping(from: response.data)
                 self.isGlobalLoaded = true
             }
         }
@@ -70,16 +101,15 @@ actor BadgeStore {
     /// チャンネルバッジ定義をフェッチする
     ///
     /// - Parameter channelId: Twitch チャンネルID（IRCの room-id タグの値、数字のみ）
+    /// トークン未設定（未ログイン）の場合はスキップする。
     func fetchChannelBadges(channelId: String) async {
-        // Twitch の room-id は数字のみで構成される（GQL injection 対策）
+        // Twitch の room-id は数字のみで構成される（URLパラメータインジェクション対策）
         guard !channelId.isEmpty, channelId.allSatisfy(\.isNumber) else { return }
-        let query = "{ user(id: \"\(channelId)\") { broadcastBadges { id title imageURL(size: DOUBLE) } } }"
-        guard let response = try? await fetchGQL(
-            query: query,
-            responseType: GQLChannelBadgesResponse.self
-        ),
-        let userBadges = response.data.user else { return }
-        channelBadges = Self.buildMapping(from: userBadges.broadcastBadges)
+        guard let response = try? await fetchHelix(
+            url: Self.helixChannelBadgesURL,
+            queryItems: [URLQueryItem(name: "broadcaster_id", value: channelId)]
+        ) else { return }
+        channelBadges = Self.buildMapping(from: response.data)
     }
 
     /// バッジの画像 URL を解決する
@@ -128,58 +158,60 @@ actor BadgeStore {
 
     // MARK: - 静的ユーティリティ
 
-    /// GQLBadgeItem の配列から URLマッピングを構築する
+    /// HelixBadgeSet の配列から URLマッピングを構築する
     ///
-    /// - Parameter items: GQL バッジアイテムの配列
+    /// 画像サイズは 2x（`imageUrl2x`）を使用する。
+    /// 現在の表示サイズ 18pt では Retina 対応として 2x 画像が適切。
+    ///
+    /// - Parameter badgeSets: Helix バッジセットの配列
     /// - Returns: [バッジ名: [バージョン: URLString]] のマッピング
-    static func buildMapping(from items: [GQLBadgeItem]) -> BadgeURLMapping {
+    static func buildMapping(from badgeSets: [HelixBadgeSet]) -> BadgeURLMapping {
         var mapping: BadgeURLMapping = [:]
-        for item in items {
-            guard let parsed = item.parsedNameAndVersion else { continue }
-            if mapping[parsed.name] == nil {
-                mapping[parsed.name] = [:]
+        for set in badgeSets {
+            var versions: [String: String] = [:]
+            for version in set.versions {
+                versions[version.id] = version.imageUrl2x
             }
-            mapping[parsed.name]?[parsed.version] = item.imageURL
+            mapping[set.setId] = versions
         }
         return mapping
     }
 
     // MARK: - プライベートメソッド
 
-    /// GQL レスポンスのエラー情報を保持する内部型
-    private struct GQLErrorContainer: Decodable {
-        struct GQLError: Decodable {
-            let message: String
-        }
-        let errors: [GQLError]?
-    }
-
-    /// GQL リクエストを送信して結果をデコードする
+    /// Helix API にリクエストを送信して結果をデコードする
     ///
-    /// - タイムアウト: `requestTimeout` 秒
-    /// - GQL レベルのエラーが含まれている場合は `URLError(.badServerResponse)` をスロー
-    private func fetchGQL<T: Decodable>(query: String, responseType: T.Type) async throws -> T {
-        var request = URLRequest(url: Self.gqlEndpoint)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(Self.gqlClientID, forHTTPHeaderField: "Client-Id")
-        request.timeoutInterval = Self.requestTimeout
+    /// - Parameters:
+    ///   - url: リクエスト先エンドポイント URL
+    ///   - queryItems: クエリパラメータ（nil の場合はなし）
+    /// - Returns: デコードされた `HelixBadgesResponse`
+    /// - Throws: トークン未設定時は `URLError(.userAuthenticationRequired)`、
+    ///           HTTP エラー時は `URLError(.badServerResponse)`
+    private func fetchHelix(
+        url: URL,
+        queryItems: [URLQueryItem]?
+    ) async throws -> HelixBadgesResponse {
+        // トークンまたは Client ID が取得できない場合はリクエストしない
+        guard let token = await tokenProvider.accessToken() else {
+            throw URLError(.userAuthenticationRequired)
+        }
+        guard let clientId = try? await tokenProvider.clientID() else {
+            throw URLError(.userAuthenticationRequired)
+        }
 
-        let body = ["query": query]
-        request.httpBody = try JSONEncoder().encode(body)
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = queryItems
+
+        var request = URLRequest(url: components.url!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue(clientId, forHTTPHeaderField: "Client-Id")
+        request.timeoutInterval = Self.requestTimeout
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200 else {
             throw URLError(.badServerResponse)
         }
-
-        // GQL レベルのエラーチェック（data フィールドが正常でも errors が含まれる場合がある）
-        if let errorContainer = try? JSONDecoder().decode(GQLErrorContainer.self, from: data),
-           let errors = errorContainer.errors, !errors.isEmpty {
-            throw URLError(.badServerResponse)
-        }
-
-        return try JSONDecoder().decode(T.self, from: data)
+        return try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
     }
 }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -61,7 +61,7 @@ final class ChatViewModel {
     private let authState: AuthState
 
     /// バッジ定義ストア（View からバッジ画像URLの解決に使用）
-    let badgeStore = BadgeStore()
+    let badgeStore: BadgeStore
 
     /// グローバルバッジフェッチタスク（切断時にキャンセル）
     private var globalBadgeFetchTask: Task<Void, Never>?
@@ -82,6 +82,7 @@ final class ChatViewModel {
     init(ircClient: any TwitchIRCClientProtocol = TwitchIRCClient(), authState: AuthState = AuthState()) {
         self.ircClient = ircClient
         self.authState = authState
+        self.badgeStore = BadgeStore(tokenProvider: authState)
     }
 
     // MARK: - 接続・切断

--- a/Tests/TwitchChatTests/BadgeDefinitionTests.swift
+++ b/Tests/TwitchChatTests/BadgeDefinitionTests.swift
@@ -1,5 +1,5 @@
 // BadgeDefinitionTests.swift
-// Twitch GQL バッジ定義レスポンスのデコードテスト
+// Twitch Helix API バッジ定義レスポンスのデコードテスト
 
 import Testing
 import Foundation
@@ -14,134 +14,176 @@ struct BadgeDefinitionTests {
     func testDecodeGlobalBadgesResponse() throws {
         let json = """
         {
-            "data": {
-                "badges": [
-                    {
-                        "id": "YnJvYWRjYXN0ZXI7MTs=",
-                        "title": "Broadcaster",
-                        "imageURL": "https://static-cdn.jtvnw.net/badges/v1/abc123/2"
-                    },
-                    {
-                        "id": "bW9kZXJhdG9yOzE7",
-                        "title": "Moderator",
-                        "imageURL": "https://static-cdn.jtvnw.net/badges/v1/def456/2"
-                    }
-                ]
-            }
+            "data": [
+                {
+                    "set_id": "broadcaster",
+                    "versions": [
+                        {
+                            "id": "1",
+                            "image_url_1x": "https://static-cdn.jtvnw.net/badges/v1/abc123/1",
+                            "image_url_2x": "https://static-cdn.jtvnw.net/badges/v1/abc123/2",
+                            "image_url_4x": "https://static-cdn.jtvnw.net/badges/v1/abc123/3",
+                            "title": "Broadcaster",
+                            "description": "放送者"
+                        }
+                    ]
+                },
+                {
+                    "set_id": "moderator",
+                    "versions": [
+                        {
+                            "id": "1",
+                            "image_url_1x": "https://static-cdn.jtvnw.net/badges/v1/def456/1",
+                            "image_url_2x": "https://static-cdn.jtvnw.net/badges/v1/def456/2",
+                            "image_url_4x": "https://static-cdn.jtvnw.net/badges/v1/def456/3",
+                            "title": "Moderator",
+                            "description": "モデレーター"
+                        }
+                    ]
+                }
+            ]
         }
         """
         let data = Data(json.utf8)
-        let response = try JSONDecoder().decode(GQLBadgesResponse.self, from: data)
+        let response = try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
 
-        #expect(response.data.badges.count == 2)
-        // id フィールドが正しくデコードされていることを確認
-        #expect(response.data.badges[0].id == "YnJvYWRjYXN0ZXI7MTs=")
-        #expect(response.data.badges[0].title == "Broadcaster")
-        #expect(response.data.badges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/abc123/2")
-        #expect(response.data.badges[1].id == "bW9kZXJhdG9yOzE7")
-        #expect(response.data.badges[1].title == "Moderator")
+        #expect(response.data.count == 2)
+        // set_id が正しくデコードされていること
+        #expect(response.data[0].setId == "broadcaster")
+        #expect(response.data[1].setId == "moderator")
+        // versions が正しくデコードされていること
+        #expect(response.data[0].versions.count == 1)
+        #expect(response.data[0].versions[0].id == "1")
+        #expect(response.data[0].versions[0].title == "Broadcaster")
+        #expect(response.data[0].versions[0].imageUrl2x == "https://static-cdn.jtvnw.net/badges/v1/abc123/2")
     }
-
-    @Test("GQLバッジのbase64 IDから名前とバージョンを抽出できる")
-    func testDecodeGQLBadgeID() {
-        // "broadcaster;1;" の base64
-        let broadcasterBadge = GQLBadgeItem(
-            id: "YnJvYWRjYXN0ZXI7MTs=",
-            title: "Broadcaster",
-            imageURL: "https://example.com/badge.png"
-        )
-        let parsed = broadcasterBadge.parsedNameAndVersion
-        #expect(parsed?.name == "broadcaster")
-        #expect(parsed?.version == "1")
-    }
-
-    @Test("チャンネル固有バッジのbase64 IDから名前とバージョンを抽出できる")
-    func testDecodeChannelBadgeID() {
-        // "subscriber;0;37402112" の base64
-        let subscriberBadge = GQLBadgeItem(
-            id: "c3Vic2NyaWJlcjswOzM3NDAyMTEy",
-            title: "Subscriber",
-            imageURL: "https://example.com/sub.png"
-        )
-        let parsed = subscriberBadge.parsedNameAndVersion
-        #expect(parsed?.name == "subscriber")
-        #expect(parsed?.version == "0")
-    }
-
-    @Test("不正なbase64 IDの場合はnilを返す")
-    func testInvalidBase64ID() {
-        let invalidBadge = GQLBadgeItem(
-            id: "not-valid-base64!!",
-            title: "Invalid",
-            imageURL: "https://example.com/badge.png"
-        )
-        #expect(invalidBadge.parsedNameAndVersion == nil)
-    }
-
-    @Test("バッジIDのデコード結果がセミコロン区切りでない場合はnilを返す")
-    func testMalformedDecodedID() {
-        // "malformed" の base64
-        let malformedBadge = GQLBadgeItem(
-            id: "bWFsZm9ybWVk",
-            title: "Malformed",
-            imageURL: "https://example.com/badge.png"
-        )
-        #expect(malformedBadge.parsedNameAndVersion == nil)
-    }
-
-    // MARK: - チャンネルバッジレスポンスのデコード
 
     @Test("チャンネルバッジレスポンスを正常にデコードできる")
     func testDecodeChannelBadgesResponse() throws {
         let json = """
         {
-            "data": {
-                "user": {
-                    "broadcastBadges": [
+            "data": [
+                {
+                    "set_id": "subscriber",
+                    "versions": [
                         {
-                            "id": "c3Vic2NyaWJlcjswOzM3NDAyMTEy",
+                            "id": "0",
+                            "image_url_1x": "https://static-cdn.jtvnw.net/badges/v1/xyz789/1",
+                            "image_url_2x": "https://static-cdn.jtvnw.net/badges/v1/xyz789/2",
+                            "image_url_4x": "https://static-cdn.jtvnw.net/badges/v1/xyz789/3",
                             "title": "サブスクライバー",
-                            "imageURL": "https://static-cdn.jtvnw.net/badges/v1/xyz789/2"
+                            "description": "チャンネルサブスクライバー"
+                        },
+                        {
+                            "id": "3",
+                            "image_url_1x": "https://static-cdn.jtvnw.net/badges/v1/xyz999/1",
+                            "image_url_2x": "https://static-cdn.jtvnw.net/badges/v1/xyz999/2",
+                            "image_url_4x": "https://static-cdn.jtvnw.net/badges/v1/xyz999/3",
+                            "title": "3ヶ月サブスクライバー",
+                            "description": "3ヶ月間サブスクライブ"
                         }
                     ]
                 }
-            }
+            ]
         }
         """
         let data = Data(json.utf8)
-        let response = try JSONDecoder().decode(GQLChannelBadgesResponse.self, from: data)
+        let response = try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
 
-        #expect(response.data.user?.broadcastBadges.count == 1)
-        #expect(response.data.user?.broadcastBadges[0].imageURL == "https://static-cdn.jtvnw.net/badges/v1/xyz789/2")
+        #expect(response.data.count == 1)
+        #expect(response.data[0].setId == "subscriber")
+        // 複数バージョンが正しくデコードされていること
+        #expect(response.data[0].versions.count == 2)
+        #expect(response.data[0].versions[0].id == "0")
+        #expect(response.data[0].versions[1].id == "3")
+        #expect(response.data[0].versions[0].imageUrl2x == "https://static-cdn.jtvnw.net/badges/v1/xyz789/2")
     }
 
-    @Test("user が null のチャンネルバッジレスポンスをデコードできる")
-    func testDecodeChannelBadgesResponseWithNullUser() throws {
-        let json = """
-        {
-            "data": {
-                "user": null
-            }
-        }
-        """
-        let data = Data(json.utf8)
-        let response = try JSONDecoder().decode(GQLChannelBadgesResponse.self, from: data)
-
-        #expect(response.data.user == nil)
-    }
-
-    @Test("バッジが0件のレスポンスをデコードできる")
+    @Test("data が空配列のレスポンスをデコードできる")
     func testDecodeEmptyBadgesResponse() throws {
         let json = """
         {
-            "data": {
-                "badges": []
-            }
+            "data": []
         }
         """
         let data = Data(json.utf8)
-        let response = try JSONDecoder().decode(GQLBadgesResponse.self, from: data)
+        let response = try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
 
-        #expect(response.data.badges.isEmpty)
+        #expect(response.data.isEmpty)
+    }
+
+    @Test("バージョンが複数のバッジセットをデコードできる")
+    func testDecodeMultipleVersions() throws {
+        let json = """
+        {
+            "data": [
+                {
+                    "set_id": "subscriber",
+                    "versions": [
+                        {
+                            "id": "0",
+                            "image_url_1x": "https://example.com/sub0/1",
+                            "image_url_2x": "https://example.com/sub0/2",
+                            "image_url_4x": "https://example.com/sub0/3",
+                            "title": "初月サブスクライバー",
+                            "description": "1ヶ月サブスクライブ"
+                        },
+                        {
+                            "id": "6",
+                            "image_url_1x": "https://example.com/sub6/1",
+                            "image_url_2x": "https://example.com/sub6/2",
+                            "image_url_4x": "https://example.com/sub6/3",
+                            "title": "6ヶ月サブスクライバー",
+                            "description": "6ヶ月間サブスクライブ"
+                        }
+                    ]
+                }
+            ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
+
+        let subscriberSet = response.data[0]
+        #expect(subscriberSet.setId == "subscriber")
+        #expect(subscriberSet.versions[0].id == "0")
+        #expect(subscriberSet.versions[0].imageUrl1x == "https://example.com/sub0/1")
+        #expect(subscriberSet.versions[0].imageUrl4x == "https://example.com/sub0/3")
+        #expect(subscriberSet.versions[1].id == "6")
+        #expect(subscriberSet.versions[1].imageUrl2x == "https://example.com/sub6/2")
+    }
+
+    @Test("スネークケースの JSON キーが正しくデコードされる")
+    func testSnakeCaseCodingKeys() throws {
+        let json = """
+        {
+            "data": [
+                {
+                    "set_id": "vip",
+                    "versions": [
+                        {
+                            "id": "1",
+                            "image_url_1x": "https://example.com/vip/1",
+                            "image_url_2x": "https://example.com/vip/2",
+                            "image_url_4x": "https://example.com/vip/3",
+                            "title": "VIP",
+                            "description": "VIPメンバー"
+                        }
+                    ]
+                }
+            ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixBadgesResponse.self, from: data)
+
+        // set_id → setId のスネークケース変換が正しく機能すること
+        #expect(response.data[0].setId == "vip")
+        // image_url_1x → imageUrl1x のスネークケース変換が正しく機能すること
+        #expect(response.data[0].versions[0].imageUrl1x == "https://example.com/vip/1")
+        // image_url_2x → imageUrl2x のスネークケース変換が正しく機能すること
+        #expect(response.data[0].versions[0].imageUrl2x == "https://example.com/vip/2")
+        // image_url_4x → imageUrl4x のスネークケース変換が正しく機能すること
+        #expect(response.data[0].versions[0].imageUrl4x == "https://example.com/vip/3")
     }
 }

--- a/Tests/TwitchChatTests/BadgeStoreTests.swift
+++ b/Tests/TwitchChatTests/BadgeStoreTests.swift
@@ -14,7 +14,7 @@ struct MockBadgeAPITokenProvider: BadgeAPITokenProvider {
     /// 返すクライアントID
     var clientId: String
 
-    func accessToken() async -> String? { token }
+    func fetchAccessToken() async -> String? { token }
     func clientID() async throws -> String { clientId }
 }
 

--- a/Tests/TwitchChatTests/BadgeStoreTests.swift
+++ b/Tests/TwitchChatTests/BadgeStoreTests.swift
@@ -5,6 +5,19 @@ import Testing
 import Foundation
 @testable import TwitchChat
 
+// MARK: - テスト用モック
+
+/// BadgeAPITokenProvider のテスト用モック
+struct MockBadgeAPITokenProvider: BadgeAPITokenProvider {
+    /// 返すアクセストークン（nil の場合は未ログイン状態をシミュレート）
+    var token: String?
+    /// 返すクライアントID
+    var clientId: String
+
+    func accessToken() async -> String? { token }
+    func clientID() async throws -> String { clientId }
+}
+
 @Suite("BadgeStoreTests")
 struct BadgeStoreTests {
 
@@ -12,7 +25,7 @@ struct BadgeStoreTests {
 
     @Test("グローバルバッジのURLを正しく解決できる")
     func testResolveGlobalBadgeURL() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
 
         // グローバルバッジ定義を直接設定（テスト用）
         let broadcasterURL = "https://static-cdn.jtvnw.net/badges/v1/abc/2"
@@ -27,7 +40,7 @@ struct BadgeStoreTests {
 
     @Test("チャンネルバッジがグローバルバッジより優先される")
     func testChannelBadgeOverridesGlobal() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
 
         let globalURL = "https://static-cdn.jtvnw.net/badges/v1/global-sub/2"
         let channelURL = "https://static-cdn.jtvnw.net/badges/v1/channel-sub/2"
@@ -46,7 +59,7 @@ struct BadgeStoreTests {
 
     @Test("チャンネルバッジにないバッジはグローバルにフォールバックする")
     func testFallbackToGlobalWhenNotInChannel() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
 
         let globalURL = "https://static-cdn.jtvnw.net/badges/v1/broadcaster/2"
         await store.setGlobalBadges([
@@ -63,19 +76,19 @@ struct BadgeStoreTests {
 
     @Test("存在しないバッジ名の場合はnilを返す")
     func testUnknownBadgeReturnsNil() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         await store.setGlobalBadges([
             "broadcaster": ["1": "https://example.com/badge.png"]
         ])
 
-        let badge = Badge(name: "unknown-badge", version: "1")
+        let badge = Badge(name: "未登録バッジ", version: "1")
         let url = await store.imageURL(for: badge)
         #expect(url == nil)
     }
 
     @Test("存在しないバッジバージョンの場合はnilを返す")
     func testUnknownVersionReturnsNil() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         await store.setGlobalBadges([
             "subscriber": ["0": "https://example.com/sub.png"]
         ])
@@ -85,28 +98,64 @@ struct BadgeStoreTests {
         #expect(url == nil)
     }
 
-    @Test("GQLバッジレスポンスからURLマッピングを構築できる")
-    func testBuildMappingFromGQLResponse() {
-        let items = [
-            GQLBadgeItem(id: "YnJvYWRjYXN0ZXI7MTs=", title: "Broadcaster",
-                         imageURL: "https://example.com/broadcaster.png"),
-            GQLBadgeItem(id: "bW9kZXJhdG9yOzE7", title: "Moderator",
-                         imageURL: "https://example.com/moderator.png"),
-            // 不正なIDは無視される
-            GQLBadgeItem(id: "invalid!!!", title: "Invalid",
-                         imageURL: "https://example.com/invalid.png")
-        ]
+    @Test("Helixバッジセットからショートマッピングを構築できる")
+    func testBuildMappingFromHelixBadgeSets() {
+        // broadcaster バッジセット（バージョン 1）
+        let broadcasterSet = HelixBadgeSet(
+            setId: "broadcaster",
+            versions: [
+                HelixBadgeVersion(
+                    id: "1",
+                    imageUrl1x: "https://example.com/broadcaster/1",
+                    imageUrl2x: "https://example.com/broadcaster/2",
+                    imageUrl4x: "https://example.com/broadcaster/3",
+                    title: "Broadcaster",
+                    description: "放送者"
+                )
+            ]
+        )
+        // subscriber バッジセット（バージョン 0 と 3）
+        let subscriberSet = HelixBadgeSet(
+            setId: "subscriber",
+            versions: [
+                HelixBadgeVersion(
+                    id: "0",
+                    imageUrl1x: "https://example.com/sub0/1",
+                    imageUrl2x: "https://example.com/sub0/2",
+                    imageUrl4x: "https://example.com/sub0/3",
+                    title: "サブスクライバー",
+                    description: "初月サブスクライブ"
+                ),
+                HelixBadgeVersion(
+                    id: "3",
+                    imageUrl1x: "https://example.com/sub3/1",
+                    imageUrl2x: "https://example.com/sub3/2",
+                    imageUrl4x: "https://example.com/sub3/3",
+                    title: "3ヶ月サブスクライバー",
+                    description: "3ヶ月間サブスクライブ"
+                )
+            ]
+        )
 
-        let mapping = BadgeStore.buildMapping(from: items)
+        let mapping = BadgeStore.buildMapping(from: [broadcasterSet, subscriberSet])
 
-        #expect(mapping["broadcaster"]?["1"] == "https://example.com/broadcaster.png")
-        #expect(mapping["moderator"]?["1"] == "https://example.com/moderator.png")
-        #expect(mapping["invalid"] == nil)
+        // broadcaster バッジの 2x 画像 URL が正しくマッピングされること
+        #expect(mapping["broadcaster"]?["1"] == "https://example.com/broadcaster/2")
+        // subscriber バッジのバージョン 0 の 2x 画像 URL が正しくマッピングされること
+        #expect(mapping["subscriber"]?["0"] == "https://example.com/sub0/2")
+        // subscriber バッジのバージョン 3 の 2x 画像 URL が正しくマッピングされること
+        #expect(mapping["subscriber"]?["3"] == "https://example.com/sub3/2")
+    }
+
+    @Test("空のバッジセット配列からは空マッピングを構築する")
+    func testBuildMappingFromEmptyBadgeSets() {
+        let mapping = BadgeStore.buildMapping(from: [])
+        #expect(mapping.isEmpty)
     }
 
     @Test("バッジ定義が未設定の場合はnilを返す")
     func testImageURLReturnsNilWhenNoBadgesSet() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         // setGlobalBadges/setChannelBadges を呼ばない状態
         let badge = Badge(name: "broadcaster", version: "1")
         let url = await store.imageURL(for: badge)
@@ -115,7 +164,7 @@ struct BadgeStoreTests {
 
     @Test("空のバッジ名でも安全にnilを返す")
     func testEmptyBadgeNameReturnsNil() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         await store.setGlobalBadges(["broadcaster": ["1": "https://example.com/badge.png"]])
         let emptyNameBadge = Badge(name: "", version: "1")
         let url = await store.imageURL(for: emptyNameBadge)
@@ -124,7 +173,7 @@ struct BadgeStoreTests {
 
     @Test("空のバージョンでも安全にnilを返す")
     func testEmptyVersionReturnsNil() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         await store.setGlobalBadges(["broadcaster": ["1": "https://example.com/badge.png"]])
         let emptyVersionBadge = Badge(name: "broadcaster", version: "")
         let url = await store.imageURL(for: emptyVersionBadge)
@@ -133,7 +182,7 @@ struct BadgeStoreTests {
 
     @Test("並行アクセスしても安全に動作する")
     func testConcurrentAccessIsSafe() async {
-        let store = BadgeStore()
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: "テストトークン", clientId: "テストクライアントID"))
         // 複数タスクが並行して読み書きしてもクラッシュしないことを確認
         await withTaskGroup(of: Void.self) { group in
             for i in 0..<10 {
@@ -150,5 +199,31 @@ struct BadgeStoreTests {
         // 全タスク完了後に結果が一貫していることを確認
         let url = await store.imageURL(for: Badge(name: "broadcaster", version: "1"))
         #expect(url != nil)
+    }
+
+    @Test("トークンが未設定の場合はグローバルバッジフェッチをスキップする")
+    func testFetchGlobalBadgesSkippedWhenNoToken() async {
+        // トークン nil = 未ログイン状態をシミュレート
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: nil, clientId: "テストクライアントID"))
+
+        await store.fetchGlobalBadges()
+
+        // トークン未取得の場合はバッジが空のままで、次回接続時に再取得できること
+        let badge = Badge(name: "broadcaster", version: "1")
+        let url = await store.imageURL(for: badge)
+        #expect(url == nil)
+    }
+
+    @Test("トークンが未設定の場合はチャンネルバッジフェッチをスキップする")
+    func testFetchChannelBadgesSkippedWhenNoToken() async {
+        // トークン nil = 未ログイン状態をシミュレート
+        let store = BadgeStore(tokenProvider: MockBadgeAPITokenProvider(token: nil, clientId: "テストクライアントID"))
+
+        await store.fetchChannelBadges(channelId: "12345678")
+
+        // トークン未取得の場合はバッジが空のままであること
+        let badge = Badge(name: "subscriber", version: "0")
+        let url = await store.imageURL(for: badge)
+        #expect(url == nil)
     }
 }


### PR DESCRIPTION
## Summary

- Twitch 非公式 GQL API (`gql.twitch.tv`) を廃止し、公式 Helix API に移行
- `BadgeAPITokenProvider` プロトコルで `AuthState`（`@MainActor`）と `BadgeStore`（`actor`）の境界を分離し、テスト時のモック差し替えを容易にした
- トークン未設定（未ログイン）時はバッジフェッチをスキップし、`isGlobalLoaded` を更新しないため次回接続時に再取得される

## Changes

| ファイル | 内容 |
|---|---|
| `Models/BadgeDefinition.swift` | GQL モデル全削除 → `HelixBadgesResponse` / `HelixBadgeSet` / `HelixBadgeVersion` 追加 |
| `Services/BadgeStore.swift` | `BadgeAPITokenProvider` プロトコル追加、`init(tokenProvider:)` DI、`fetchHelix` 実装、`buildMapping` 更新、GQL コード削除 |
| `Auth/AuthState.swift` | `BadgeAPITokenProvider` 準拠 extension 追加 |
| `ViewModels/ChatViewModel.swift` | `BadgeStore` 生成を `BadgeStore(tokenProvider: authState)` に変更 |
| テストファイル | Helix モデルデコードテスト追加、GQL テスト削除、`MockBadgeAPITokenProvider` 追加 |

## Test plan

- [x] `swift test` — 104 テスト全件パス
- [x] `swift build` — ビルド成功
- [x] GQL 残留コードなし（`grep -r "gql\|GQL" Sources/` で空）
- [ ] ログイン後に実際のチャンネルに接続してバッジ表示を目視確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * バッジAPI を GraphQL から Helix に移行し、より信頼性の高い取得メカニズムを実装しました。
  * 認証状態をバッジサービスに統合し、トークンプロバイダーの抽象化を導入しました。

* **Tests**
  * バッジ定義と取得ロジックのテストカバレッジを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->