### PR TITLE
feat: ログインユーザーとフォロー中配信者のプロフィールアイコンを表示する

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -15,16 +15,19 @@ struct TwitchChatApp: App {
     @State private var channelManager: ChannelManager?
     /// フォロー中ストリーム一覧ストア
     @State private var followedStreamStore: FollowedStreamStore?
+    /// ユーザープロフィール画像URLストア
+    @State private var profileImageStore: ProfileImageStore?
 
     var body: some Scene {
         WindowGroup {
-            // channelManager と followedStreamStore は authState に依存するため
+            // channelManager、followedStreamStore、profileImageStore は authState に依存するため
             // ContentView 内で遅延初期化する
-            if let channelManager, let followedStreamStore {
+            if let channelManager, let followedStreamStore, let profileImageStore {
                 ContentView(
                     authState: authState,
                     channelManager: channelManager,
-                    followedStreamStore: followedStreamStore
+                    followedStreamStore: followedStreamStore,
+                    profileImageStore: profileImageStore
                 )
                 .task {
                     await authState.restoreSession()
@@ -40,6 +43,7 @@ struct TwitchChatApp: App {
                     case .loggedOut:
                         followedStreamStore.stopAutoRefresh()
                         followedStreamStore.clear()
+                        profileImageStore.clear()
                         Task { await channelManager.disconnectAll() }
                     case .unknown:
                         break
@@ -54,6 +58,7 @@ struct TwitchChatApp: App {
                             apiClient: helixClient,
                             authState: authState
                         )
+                        profileImageStore = ProfileImageStore(apiClient: helixClient)
                     }
             }
         }

--- a/Sources/TwitchChat/Models/TwitchUser.swift
+++ b/Sources/TwitchChat/Models/TwitchUser.swift
@@ -1,0 +1,34 @@
+// TwitchUser.swift
+// Twitch ユーザー情報モデル
+// Twitch Helix API /helix/users レスポンスを格納し、プロフィール画像URLを提供する
+
+import Foundation
+
+// MARK: - Helix API レスポンスモデル
+
+/// Helix API /helix/users レスポンス
+struct HelixUsersResponse: Decodable, Sendable {
+    let data: [HelixUserData]
+}
+
+/// Helix API /helix/users の各ユーザーデータ（ドメインモデルとしても使用する）
+///
+/// `TwitchUser` と `HelixUserData` は同一のプロパティを持つため、
+/// `HelixUserData` をドメインモデルとして直接利用する。
+struct HelixUserData: Decodable, Sendable, Identifiable, Equatable {
+    /// Twitch ユーザーID
+    let id: String
+    /// ログイン名（英数字小文字）
+    let login: String
+    /// 表示名（日本語名なども含む）
+    let displayName: String
+    /// プロフィール画像 URL
+    let profileImageUrl: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case login
+        case displayName = "display_name"
+        case profileImageUrl = "profile_image_url"
+    }
+}

--- a/Sources/TwitchChat/Services/ProfileImageCache.swift
+++ b/Sources/TwitchChat/Services/ProfileImageCache.swift
@@ -1,0 +1,153 @@
+// ProfileImageCache.swift
+// Twitch ユーザーのプロフィール画像キャッシュと非同期読み込みを管理するサービス
+// NSCache ベースのメモリキャッシュで同一ユーザーの再ダウンロードを防ぐ
+
+import AppKit
+import Foundation
+import os
+
+/// Twitch ユーザープロフィール画像のキャッシュ管理クラス
+///
+/// - `ProfileImageStore` から画像 URL を解決し、CDN からダウンロード
+/// - NSCache によるメモリキャッシュ（メモリプレッシャー時に自動解放）
+/// - 同一ユーザーへの並行リクエストを1回のダウンロードに集約する in-flight 管理
+/// - シングルトンで全 View 間でキャッシュを共有
+///
+/// ## @unchecked Sendable について
+/// `imageCache`（NSCache）はスレッドセーフであり、`inFlightTasks` は `NSLock` で保護されている。
+/// このクラスのすべての可変プロパティはスレッドセーフに管理されているため @unchecked Sendable を付与している。
+/// 将来的に可変プロパティを追加する場合は、NSCache の利用または NSLock での保護が必要。
+final class ProfileImageCache: @unchecked Sendable {
+
+    /// シングルトンインスタンス
+    static let shared = ProfileImageCache()
+
+    /// プロフィール画像の表示サイズ（ポイント）
+    ///
+    /// サイドバーの行高に合わせた値
+    static let displaySize: CGFloat = 28
+
+    /// プロフィール画像のメモリキャッシュ（キー: userId）
+    private let imageCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.countLimit = 300
+        return cache
+    }()
+
+    /// 進行中のダウンロードタスク（キー: userId）
+    private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
+
+    /// inFlightTasks へのアクセスを保護するロック
+    private let lock = NSLock()
+
+    /// ダウンロード失敗時のログ出力に使用するロガー
+    private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "ProfileImageCache")
+
+    private init() {}
+
+    // MARK: - 画像取得
+
+    /// プロフィール画像を取得する（キャッシュ優先・並行重複排除付き）
+    ///
+    /// - Parameters:
+    ///   - userId: Twitch ユーザーID（キャッシュキーとして使用）
+    ///   - imageUrl: プロフィール画像 URL 文字列
+    /// - Returns: ダウンロード済みの NSImage（`displaySize` にリサイズ済み）。取得失敗時は nil
+    func image(for userId: String, imageUrl: String) async -> NSImage? {
+        let cacheKey = userId as NSString
+
+        // キャッシュヒット: 即時返却
+        if let cached = imageCache.object(forKey: cacheKey) {
+            return cached
+        }
+
+        guard let url = URL(string: imageUrl) else {
+            logger.warning("プロフィール画像の URL が不正: \(imageUrl)")
+            return nil
+        }
+
+        // 進行中タスクへの相乗り、または新規タスクの作成（排他制御）
+        let task: Task<NSImage?, Never> = lock.withLock {
+            if let existing = inFlightTasks[userId] {
+                return existing
+            }
+            let newTask = Task { [weak self] in
+                guard let self else { return nil as NSImage? }
+                defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: userId) } }
+
+                guard let image = await self.download(from: url) else { return nil }
+                self.store(image, for: userId)
+                return image
+            }
+            inFlightTasks[userId] = newTask
+            return newTask
+        }
+
+        return await task.value
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// 指定 URL から画像をダウンロードする
+    private func download(from url: URL) async -> NSImage? {
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                logger.warning("プロフィール画像レスポンスが HTTPURLResponse でない: \(url)")
+                return nil
+            }
+            guard httpResponse.statusCode == 200 else {
+                logger.warning("プロフィール画像取得 HTTP \(httpResponse.statusCode): \(url)")
+                return nil
+            }
+            guard let image = NSImage(data: data) else {
+                logger.warning("プロフィール画像データを NSImage に変換できない: \(url)")
+                return nil
+            }
+            return image
+        } catch {
+            logger.warning("プロフィール画像ダウンロード失敗: \(url) - \(error)")
+            return nil
+        }
+    }
+
+    /// 画像をピクセルレベルでリサイズしてキャッシュに保存する
+    ///
+    /// NSImage.size の変更は描画サイズのみ変わりピクセルデータは保持されるため、
+    /// ビットマップコンテキストに描画し直すことでメモリ使用量を削減する。
+    private func store(_ image: NSImage, for userId: String) {
+        let targetSize = NSSize(width: Self.displaySize, height: Self.displaySize)
+        let resized: NSImage
+        if let bitmapRep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int(targetSize.width),
+            pixelsHigh: Int(targetSize.height),
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) {
+            bitmapRep.size = targetSize
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmapRep)
+            image.draw(
+                in: NSRect(origin: .zero, size: targetSize),
+                from: .zero,
+                operation: .copy,
+                fraction: 1.0
+            )
+            NSGraphicsContext.restoreGraphicsState()
+            let small = NSImage(size: targetSize)
+            small.addRepresentation(bitmapRep)
+            resized = small
+        } else {
+            // ビットマップ作成失敗時はサイズ設定のみのフォールバック
+            image.size = targetSize
+            resized = image
+        }
+        imageCache.setObject(resized, forKey: userId as NSString)
+    }
+}

--- a/Sources/TwitchChat/Services/ProfileImageCache.swift
+++ b/Sources/TwitchChat/Services/ProfileImageCache.swift
@@ -111,40 +111,36 @@ final class ProfileImageCache: @unchecked Sendable {
         }
     }
 
-    /// 画像をピクセルレベルでリサイズしてキャッシュに保存する
+    /// 画像を CoreGraphics でピクセルレベルにリサイズしてキャッシュに保存する
     ///
-    /// NSImage.size の変更は描画サイズのみ変わりピクセルデータは保持されるため、
-    /// ビットマップコンテキストに描画し直すことでメモリ使用量を削減する。
+    /// NSGraphicsContext はメインスレッド以外での使用が未定義動作のため、
+    /// CoreGraphics ベースの CGContext でリサイズする（バックグラウンドスレッドセーフ）。
     private func store(_ image: NSImage, for userId: String) {
         let targetSize = NSSize(width: Self.displaySize, height: Self.displaySize)
         let resized: NSImage
-        if let bitmapRep = NSBitmapImageRep(
-            bitmapDataPlanes: nil,
-            pixelsWide: Int(targetSize.width),
-            pixelsHigh: Int(targetSize.height),
-            bitsPerSample: 8,
-            samplesPerPixel: 4,
-            hasAlpha: true,
-            isPlanar: false,
-            colorSpaceName: .deviceRGB,
-            bytesPerRow: 0,
-            bitsPerPixel: 0
-        ) {
-            bitmapRep.size = targetSize
-            NSGraphicsContext.saveGraphicsState()
-            NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmapRep)
-            image.draw(
-                in: NSRect(origin: .zero, size: targetSize),
-                from: .zero,
-                operation: .copy,
-                fraction: 1.0
-            )
-            NSGraphicsContext.restoreGraphicsState()
-            let small = NSImage(size: targetSize)
-            small.addRepresentation(bitmapRep)
-            resized = small
+        // CGImage を取得して CoreGraphics コンテキストでリサイズ描画する
+        if let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+            let colorSpace = CGColorSpaceCreateDeviceRGB()
+            let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+            let pixelSize = Int(targetSize.width)
+            if let cgContext = CGContext(
+                data: nil,
+                width: pixelSize,
+                height: pixelSize,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo.rawValue
+            ),
+            let scaledCGImage = { cgContext.draw(cgImage, in: CGRect(origin: .zero, size: targetSize)); return cgContext.makeImage() }() {
+                resized = NSImage(cgImage: scaledCGImage, size: targetSize)
+            } else {
+                // CGContext 作成失敗時はサイズ設定のみのフォールバック
+                image.size = targetSize
+                resized = image
+            }
         } else {
-            // ビットマップ作成失敗時はサイズ設定のみのフォールバック
+            // CGImage 変換失敗時はサイズ設定のみのフォールバック
             image.size = targetSize
             resized = image
         }

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -1,0 +1,127 @@
+// ProfileImageStore.swift
+// Twitch ユーザーのプロフィール画像URL取得・管理サービス
+// Helix API /helix/users を呼び出し、userId → profileImageUrl のマッピングをキャッシュする
+
+import Foundation
+import Observation
+import os
+
+/// Twitch ユーザーのプロフィール画像URL を管理するストア
+///
+/// - `fetchUsers(userIds:)` で複数ユーザーのプロフィール画像URLを一括取得する
+/// - 取得済みユーザーは再取得しない（キャッシュ済みとして扱う）
+/// - Helix API の制限（1リクエスト100件）を超える場合は自動的にチャンク分割する
+/// - キャッシュエントリ数は `maxCacheEntries` を上限とする（上限超過時に全消去）
+/// - `clear()` でキャッシュをクリアする（ログアウト時など）
+@Observable
+@MainActor
+final class ProfileImageStore {
+
+    // MARK: - 定数
+
+    /// Helix API エンドポイント
+    private static let usersURL = URL(string: "https://api.twitch.tv/helix/users")!
+
+    /// 1リクエストあたりの最大ユーザーID数（Twitch Helix API の制限）
+    private static let maxIdsPerRequest = 100
+
+    /// キャッシュの最大エントリ数（超過時に全消去してメモリ増大を防ぐ）
+    private static let maxCacheEntries = 1000
+
+    // MARK: - プライベートプロパティ
+
+    /// userId → profileImageUrl のキャッシュ
+    private var profileImageUrls: [String: String] = [:]
+
+    private let apiClient: any HelixAPIClientProtocol
+
+    private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "ProfileImageStore")
+
+    // MARK: - 初期化
+
+    /// ProfileImageStore を初期化する
+    ///
+    /// - Parameter apiClient: Helix API クライアント
+    init(apiClient: any HelixAPIClientProtocol) {
+        self.apiClient = apiClient
+    }
+
+    // MARK: - 公開メソッド
+
+    /// 指定ユーザーIDのプロフィール画像URLを取得する
+    ///
+    /// - Parameter userId: Twitch ユーザーID
+    /// - Returns: プロフィール画像URL（未取得またはユーザーが存在しない場合は `nil`）
+    func profileImageUrl(for userId: String) -> String? {
+        profileImageUrls[userId]
+    }
+
+    /// 複数ユーザーのプロフィール画像URLを一括取得する
+    ///
+    /// - Parameter userIds: 取得対象の Twitch ユーザーID 一覧
+    /// - Note: 取得済みユーザーは API を呼ばない。100件超の場合は自動チャンク分割。
+    ///         認証エラーはサイレントスキップ（プロフィール画像は必須ではないため）。
+    func fetchUsers(userIds: [String]) async {
+        // 未取得のユーザーのみ対象にする
+        let newUserIds = userIds.filter { profileImageUrls[$0] == nil }
+        guard !newUserIds.isEmpty else { return }
+
+        // Helix API の100件制限に合わせてチャンク分割してリクエスト
+        let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
+        for chunk in chunks {
+            await fetchChunk(userIds: chunk)
+        }
+    }
+
+    /// プロフィール画像URLキャッシュをクリアする
+    ///
+    /// ログアウト時など、データを消去したい場合に使用する
+    func clear() {
+        profileImageUrls = [:]
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// ユーザーIDのチャンク（100件以下）に対してAPIを呼び出す
+    private func fetchChunk(userIds: [String]) async {
+        let queryItems = userIds.map { URLQueryItem(name: "id", value: $0) }
+
+        do {
+            let response: HelixUsersResponse = try await apiClient.get(
+                url: Self.usersURL,
+                queryItems: queryItems
+            )
+            // キャッシュ上限超過時は全消去してメモリ増大を防ぐ
+            if profileImageUrls.count + response.data.count > Self.maxCacheEntries {
+                profileImageUrls.removeAll()
+            }
+            for userData in response.data {
+                profileImageUrls[userData.id] = userData.profileImageUrl
+            }
+        } catch let error as URLError where error.code == .userAuthenticationRequired {
+            // 未ログイン時はサイレントスキップ
+            #if DEBUG
+            logger.debug("プロフィール画像取得スキップ: 未認証 userIds=\(userIds)")
+            #endif
+        } catch {
+            // その他のエラーもサイレントスキップ（プロフィール画像は必須ではないため）
+            #if DEBUG
+            logger.debug("プロフィール画像取得失敗: \(error.localizedDescription) userIds=\(userIds)")
+            #endif
+        }
+    }
+}
+
+// MARK: - Array チャンク分割ユーティリティ
+
+private extension Array {
+    /// 配列を指定サイズのチャンクに分割する
+    ///
+    /// - Parameter size: 1チャンクの最大要素数
+    /// - Returns: 分割されたチャンクの配列
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
+    }
+}

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -33,6 +33,11 @@ final class ProfileImageStore {
     /// userId → profileImageUrl のキャッシュ
     private var profileImageUrls: [String: String] = [:]
 
+    /// 現在フェッチ中の userId セット
+    ///
+    /// `@MainActor` の await サスペンション中に別タスクが同じ userId を重複リクエストするのを防ぐ
+    private var inFlightUserIds: Set<String> = []
+
     private let apiClient: any HelixAPIClientProtocol
 
     private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "ProfileImageStore")
@@ -62,9 +67,14 @@ final class ProfileImageStore {
     /// - Note: 取得済みユーザーは API を呼ばない。100件超の場合は自動チャンク分割。
     ///         認証エラーはサイレントスキップ（プロフィール画像は必須ではないため）。
     func fetchUsers(userIds: [String]) async {
-        // 未取得のユーザーのみ対象にする
-        let newUserIds = userIds.filter { profileImageUrls[$0] == nil }
+        // 未取得かつフェッチ中でないユーザーのみ対象にする
+        // （@MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ）
+        let newUserIds = userIds.filter { profileImageUrls[$0] == nil && !inFlightUserIds.contains($0) }
         guard !newUserIds.isEmpty else { return }
+
+        // フェッチ中フラグを設定し、完了後に必ず解除する
+        inFlightUserIds.formUnion(newUserIds)
+        defer { inFlightUserIds.subtract(newUserIds) }
 
         // Helix API の100件制限に合わせてチャンク分割してリクエスト
         let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
@@ -78,6 +88,7 @@ final class ProfileImageStore {
     /// ログアウト時など、データを消去したい場合に使用する
     func clear() {
         profileImageUrls = [:]
+        inFlightUserIds = []
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -14,13 +14,15 @@ struct ContentView: View {
     var authState: AuthState
     var channelManager: ChannelManager
     var followedStreamStore: FollowedStreamStore
+    var profileImageStore: ProfileImageStore
 
     var body: some View {
         NavigationSplitView {
             SidebarView(
                 authState: authState,
                 channelManager: channelManager,
-                followedStreamStore: followedStreamStore
+                followedStreamStore: followedStreamStore,
+                profileImageStore: profileImageStore
             )
             .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
         } detail: {

--- a/Sources/TwitchChat/Views/LoginView.swift
+++ b/Sources/TwitchChat/Views/LoginView.swift
@@ -8,11 +8,13 @@ import SwiftUI
 ///
 /// - ログアウト状態: 「Twitch でログイン」ボタンを表示
 /// - Device Code Flow 認証中: ユーザーコードとキャンセルボタンを表示
-/// - ログイン状態: ユーザー名と「ログアウト」ボタンを表示
+/// - ログイン状態: プロフィール画像・ユーザー名と「ログアウト」ボタンを表示
 /// - `.unknown` 状態（起動直後）: ローディングインジケータを表示
 struct LoginView: View {
     /// 認証状態
     var authState: AuthState
+    /// プロフィール画像URLストア
+    var profileImageStore: ProfileImageStore
 
     var body: some View {
         VStack(spacing: 2) {
@@ -40,10 +42,16 @@ struct LoginView: View {
                         .controlSize(.small)
 
                     case .loggedIn(let userLogin):
-                        // ログイン状態: ユーザー名 + ログアウトボタン
-                        Label(userLogin, systemImage: "person.crop.circle.fill")
+                        // ログイン状態: プロフィール画像 + ユーザー名 + ログアウトボタン
+                        ProfileImageView(
+                            userId: authState.userId ?? "",
+                            imageUrl: authState.userId.flatMap { profileImageStore.profileImageUrl(for: $0) },
+                            size: 20
+                        )
+                        Text(userLogin)
                             .font(.caption)
                             .foregroundStyle(.primary)
+                        Spacer()
                         Button(action: handleLogout) {
                             Text("ログアウト")
                                 .font(.caption)

--- a/Sources/TwitchChat/Views/ProfileImageView.swift
+++ b/Sources/TwitchChat/Views/ProfileImageView.swift
@@ -1,0 +1,68 @@
+// ProfileImageView.swift
+// Twitch ユーザープロフィール画像の円形アイコン表示ビュー
+// ProfileImageCache 経由で非同期に画像を取得し、円形クリッピングで表示する
+
+import SwiftUI
+
+/// Twitch ユーザーのプロフィール画像を円形で表示するビュー
+///
+/// - 画像取得中・取得失敗時はグレー円形 + person アイコンのプレースホルダーを表示する
+/// - `ProfileImageCache.shared` でキャッシュを共有し、同一ユーザーの重複ダウンロードを防ぐ
+struct ProfileImageView: View {
+
+    /// Twitch ユーザーID（キャッシュキーとして使用）
+    let userId: String
+    /// プロフィール画像 URL 文字列
+    let imageUrl: String?
+    /// 表示サイズ（ポイント）
+    var size: CGFloat = ProfileImageCache.displaySize
+
+    /// 取得済み画像（nil の間はプレースホルダーを表示）
+    @State private var image: NSImage?
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                // プレースホルダー: グレー円 + person アイコン
+                Circle()
+                    .fill(Color.secondary.opacity(0.3))
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: size * 0.5))
+                            .foregroundStyle(.secondary)
+                    }
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        // userId または imageUrl のどちらが変わっても再取得する
+        .task(id: userId + (imageUrl ?? "")) {
+            await loadImage()
+        }
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// プロフィール画像を非同期で読み込む
+    ///
+    /// タスクがキャンセルされた場合や imageUrl が変わった場合は代入しない。
+    private func loadImage() async {
+        guard let imageUrl else {
+            image = nil
+            return
+        }
+        // ローカル変数にキャプチャして、await後に変化していないか確認する
+        let capturedUserId = userId
+        let capturedImageUrl = imageUrl
+        let loaded = await ProfileImageCache.shared.image(for: capturedUserId, imageUrl: capturedImageUrl)
+        // タスクキャンセル済み、またはプロパティが変更されている場合は代入しない
+        guard !Task.isCancelled,
+              userId == capturedUserId,
+              imageUrl == capturedImageUrl else { return }
+        image = loaded
+    }
+}

--- a/Sources/TwitchChat/Views/ProfileImageView.swift
+++ b/Sources/TwitchChat/Views/ProfileImageView.swift
@@ -2,6 +2,7 @@
 // Twitch ユーザープロフィール画像の円形アイコン表示ビュー
 // ProfileImageCache 経由で非同期に画像を取得し、円形クリッピングで表示する
 
+import AppKit
 import SwiftUI
 
 /// Twitch ユーザーのプロフィール画像を円形で表示するビュー
@@ -40,7 +41,8 @@ struct ProfileImageView: View {
         .frame(width: size, height: size)
         .clipShape(Circle())
         // userId または imageUrl のどちらが変わっても再取得する
-        .task(id: userId + (imageUrl ?? "")) {
+        // セパレータ（":"）を使用して userId + imageUrl の文字列衝突を防ぐ
+        .task(id: userId + ":" + (imageUrl ?? "")) {
             await loadImage()
         }
     }
@@ -49,12 +51,12 @@ struct ProfileImageView: View {
 
     /// プロフィール画像を非同期で読み込む
     ///
-    /// タスクがキャンセルされた場合や imageUrl が変わった場合は代入しない。
+    /// - userId/imageUrl 変化時はまず nil でプレースホルダーを表示し、ロード完了後に更新する
+    /// - タスクがキャンセルされた場合やプロパティが変わった場合は代入しない
     private func loadImage() async {
-        guard let imageUrl else {
-            image = nil
-            return
-        }
+        // 新しい画像を取得し始める前にプレースホルダーを表示する
+        image = nil
+        guard let imageUrl else { return }
         // ローカル変数にキャプチャして、await後に変化していないか確認する
         let capturedUserId = userId
         let capturedImageUrl = imageUrl

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -14,6 +14,7 @@ struct SidebarView: View {
     var authState: AuthState
     var channelManager: ChannelManager
     var followedStreamStore: FollowedStreamStore
+    var profileImageStore: ProfileImageStore
 
     var body: some View {
         List(selection: Binding(
@@ -25,7 +26,7 @@ struct SidebarView: View {
             }
         )) {
             // ログイン状態ヘッダー
-            LoginView(authState: authState)
+            LoginView(authState: authState, profileImageStore: profileImageStore)
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
 
@@ -63,7 +64,7 @@ struct SidebarView: View {
                         .padding(.vertical, 4)
                 } else {
                     ForEach(followedStreamStore.streams) { stream in
-                        StreamRow(stream: stream)
+                        StreamRow(stream: stream, profileImageStore: profileImageStore)
                             .tag(stream.userLogin)
                     }
                 }
@@ -82,6 +83,23 @@ struct SidebarView: View {
             }
         }
         .listStyle(.sidebar)
+        // ストリーム一覧が更新されたら新しい配信者のプロフィール画像を取得する
+        // （fetchUsers は取得済みユーザーを内部でフィルタリングするため重複APIコールは発生しない）
+        .onChange(of: followedStreamStore.streams) { _, streams in
+            let userIds = streams.map(\.userId)
+            Task { await profileImageStore.fetchUsers(userIds: userIds) }
+        }
+        // ログイン時に自分自身のプロフィール画像を取得する
+        .onChange(of: authState.userId) { _, userId in
+            guard let userId else { return }
+            Task { await profileImageStore.fetchUsers(userIds: [userId]) }
+        }
+        // 起動時にすでにログイン済みの場合のプロフィール画像取得
+        .task {
+            if let userId = authState.userId {
+                await profileImageStore.fetchUsers(userIds: [userId])
+            }
+        }
     }
 
     /// 接続中チャンネルの行（コンテキストメニューで切断可能）

--- a/Sources/TwitchChat/Views/StreamRow.swift
+++ b/Sources/TwitchChat/Views/StreamRow.swift
@@ -1,6 +1,6 @@
 // StreamRow.swift
 // サイドバーのフォロー中ストリーマー1行表示
-// ストリーマー名・ゲーム名・視聴者数をコンパクトに表示する
+// プロフィール画像・ストリーマー名・ゲーム名・視聴者数をコンパクトに表示する
 
 import SwiftUI
 
@@ -9,22 +9,31 @@ import SwiftUI
 /// サイドバーの「ライブ」セクションで使用する
 struct StreamRow: View {
     let stream: FollowedStream
+    let profileImageStore: ProfileImageStore
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(stream.userName)
-                .font(.body)
-                .lineLimit(1)
-            HStack(spacing: 4) {
-                Text(stream.gameName)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        HStack(spacing: 8) {
+            // プロフィール画像（円形アイコン）
+            ProfileImageView(
+                userId: stream.userId,
+                imageUrl: profileImageStore.profileImageUrl(for: stream.userId)
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(stream.userName)
+                    .font(.body)
                     .lineLimit(1)
-                Spacer()
-                // 視聴者数（1000以上はK表示）
-                Text(formatViewerCount(stream.viewerCount))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack(spacing: 4) {
+                    Text(stream.gameName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer()
+                    // 視聴者数（1000以上はK表示）
+                    Text(formatViewerCount(stream.viewerCount))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .padding(.vertical, 2)

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -1,0 +1,177 @@
+// ProfileImageStoreTests.swift
+// ProfileImageStore の単体テスト
+// MockHelixAPIClient を使ってネットワーク通信なしでストア振る舞いを検証する
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// HelixUsersResponse を返す Helix API クライアントモック
+actor MockProfileImageAPIClient: HelixAPIClientProtocol {
+    /// 返すユーザーデータ
+    var usersToReturn: [HelixUserData] = []
+    /// true の場合、URLError.userAuthenticationRequired を throw する
+    var shouldThrowAuthError: Bool = false
+    /// get() が呼ばれた回数（呼び出し検証用）
+    private(set) var callCount = 0
+    /// 最後に渡されたクエリパラメータ
+    private(set) var lastQueryItems: [URLQueryItem]?
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        callCount += 1
+        lastQueryItems = queryItems
+        if shouldThrowAuthError {
+            throw URLError(.userAuthenticationRequired)
+        }
+        if T.self == HelixUsersResponse.self {
+            // リクエストされた id にマッチするユーザーのみを返す（実際の API の挙動を再現）
+            let requestedIds = queryItems?.filter { $0.name == "id" }.compactMap { $0.value } ?? []
+            let filtered = usersToReturn.filter { requestedIds.contains($0.id) }
+            let response = HelixUsersResponse(data: filtered)
+            return response as! T  // swiftlint:disable:this force_cast
+        }
+        throw URLError(.badServerResponse)
+    }
+
+    func setUsers(_ users: [HelixUserData]) {
+        usersToReturn = users
+    }
+
+    func setAuthError(_ value: Bool) {
+        shouldThrowAuthError = value
+    }
+}
+
+// MARK: - テストデータファクトリ
+
+/// テスト用ユーザーデータを生成する
+private func makeHelixUser(
+    id: String = "111111",
+    login: String = "テスト配信者",
+    displayName: String = "テスト配信者の表示名",
+    profileImageUrl: String = "https://example.com/profile.png"
+) -> HelixUserData {
+    HelixUserData(
+        id: id,
+        login: login,
+        displayName: displayName,
+        profileImageUrl: profileImageUrl
+    )
+}
+
+// MARK: - テスト
+
+@Suite("ProfileImageStore テスト")
+@MainActor
+struct ProfileImageStoreTests {
+
+    // MARK: - 初期状態
+
+    @Test("初期状態はユーザー情報が空")
+    func testInitialState() {
+        let mockClient = MockProfileImageAPIClient()
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        #expect(store.profileImageUrl(for: "999999") == nil)
+    }
+
+    // MARK: - ユーザー取得
+
+    @Test("ユーザーIDを指定してプロフィール画像URLを取得できる")
+    func testFetchProfileImageUrls() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png"),
+            makeHelixUser(id: "222222", profileImageUrl: "https://example.com/user2.png")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["111111", "222222"])
+
+        #expect(store.profileImageUrl(for: "111111") == "https://example.com/user1.png")
+        #expect(store.profileImageUrl(for: "222222") == "https://example.com/user2.png")
+    }
+
+    @Test("ユーザーIDが空の場合は API を呼ばない")
+    func testFetchSkipsWhenEmptyUserIds() async {
+        let mockClient = MockProfileImageAPIClient()
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: [])
+
+        let callCount = await mockClient.callCount
+        #expect(callCount == 0)
+    }
+
+    @Test("認証エラーの場合はサイレントスキップする")
+    func testFetchSilentlySkipsOnAuthError() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setAuthError(true)
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["111111"])
+
+        // エラーがスローされずプロフィール画像URLも nil のまま
+        #expect(store.profileImageUrl(for: "111111") == nil)
+    }
+
+    @Test("既に取得済みのユーザーは再取得しない")
+    func testDoesNotRefetchExistingUsers() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        // 1回目のフェッチ
+        await store.fetchUsers(userIds: ["111111"])
+        // 2回目は同じユーザーID（再取得不要）
+        await store.fetchUsers(userIds: ["111111"])
+
+        // API は1回しか呼ばれていないこと
+        let callCount = await mockClient.callCount
+        #expect(callCount == 1)
+    }
+
+    @Test("未取得のユーザーのみ API を呼ぶ")
+    func testFetchesOnlyNewUsers() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png"),
+            makeHelixUser(id: "333333", profileImageUrl: "https://example.com/user3.png")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        // 1回目: 111111 を取得
+        await store.fetchUsers(userIds: ["111111"])
+        // 2回目: 111111（取得済み）+ 333333（未取得）
+        await store.fetchUsers(userIds: ["111111", "333333"])
+
+        // API は2回呼ばれているが、2回目のリクエストには 111111 が含まれないこと
+        let callCount = await mockClient.callCount
+        #expect(callCount == 2)
+        let lastQueryItems = await mockClient.lastQueryItems
+        // URLQueryItem.value は String? のため compactMap で nil を除外する
+        let requestedIds = lastQueryItems?.filter { $0.name == "id" }.compactMap { $0.value } ?? []
+        #expect(!requestedIds.contains("111111"))
+        #expect(requestedIds.contains("333333"))
+    }
+
+    @Test("ストアをクリアするとユーザー情報がリセットされる")
+    func testClearResetsUsers() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["111111"])
+        #expect(store.profileImageUrl(for: "111111") != nil)
+
+        store.clear()
+
+        #expect(store.profileImageUrl(for: "111111") == nil)
+    }
+}

--- a/Tests/TwitchChatTests/TwitchUserTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserTests.swift
@@ -1,0 +1,204 @@
+// TwitchUserTests.swift
+// TwitchUser モデルのデコードテスト
+// Twitch Helix API /helix/users レスポンスが正しくデコードされるかを検証する
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("TwitchUser モデルテスト")
+struct TwitchUserTests {
+
+    // MARK: - HelixUsersResponse デコードテスト
+
+    @Test("HelixUsersResponse が正しくデコードされる")
+    func testHelixUsersResponseDecoding() throws {
+        // Twitch Helix API /helix/users の実際のレスポンス形式
+        let jsonData = """
+        {
+            "data": [
+                {
+                    "id": "141981764",
+                    "login": "twitchdev",
+                    "display_name": "TwitchDev",
+                    "type": "",
+                    "broadcaster_type": "partner",
+                    "description": "Twitch公式開発アカウント",
+                    "profile_image_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/twitchdev-profile.png",
+                    "offline_image_url": "https://static-cdn.jtvnw.net/jtv_user_pictures/twitchdev-offline.png",
+                    "view_count": 5980557,
+                    "created_at": "2016-12-14T20:32:28Z"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(HelixUsersResponse.self, from: jsonData)
+
+        #expect(response.data.count == 1)
+        let userData = response.data[0]
+        #expect(userData.id == "141981764")
+        #expect(userData.login == "twitchdev")
+        #expect(userData.displayName == "TwitchDev")
+        #expect(userData.profileImageUrl == "https://static-cdn.jtvnw.net/jtv_user_pictures/twitchdev-profile.png")
+    }
+
+    @Test("複数ユーザーの HelixUsersResponse が正しくデコードされる")
+    func testHelixUsersResponseDecodingMultipleUsers() throws {
+        // Twitch の login は ASCII 小文字英数字/アンダースコアのみ（display_name は日本語可）
+        let jsonData = """
+        {
+            "data": [
+                {
+                    "id": "111111",
+                    "login": "streamer_a",
+                    "display_name": "配信者あ表示名",
+                    "type": "",
+                    "broadcaster_type": "",
+                    "description": "",
+                    "profile_image_url": "https://example.com/ah.png",
+                    "offline_image_url": "",
+                    "view_count": 1000,
+                    "created_at": "2020-01-01T00:00:00Z"
+                },
+                {
+                    "id": "222222",
+                    "login": "streamer_b",
+                    "display_name": "配信者い表示名",
+                    "type": "",
+                    "broadcaster_type": "",
+                    "description": "",
+                    "profile_image_url": "https://example.com/i.png",
+                    "offline_image_url": "",
+                    "view_count": 2000,
+                    "created_at": "2020-02-01T00:00:00Z"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(HelixUsersResponse.self, from: jsonData)
+
+        #expect(response.data.count == 2)
+        #expect(response.data[0].id == "111111")
+        #expect(response.data[0].login == "streamer_a")
+        #expect(response.data[0].displayName == "配信者あ表示名")
+        #expect(response.data[0].profileImageUrl == "https://example.com/ah.png")
+        #expect(response.data[1].id == "222222")
+        #expect(response.data[1].login == "streamer_b")
+        #expect(response.data[1].profileImageUrl == "https://example.com/i.png")
+    }
+
+    // MARK: - デコード失敗テスト
+
+    @Test("必須フィールドが欠けている場合はデコードエラーになる")
+    func testHelixUsersResponseDecodingMissingRequiredField() {
+        // "id" フィールドが欠けているため DecodingError が発生する
+        let jsonData = """
+        {
+            "data": [
+                {
+                    "login": "test_streamer",
+                    "display_name": "テスト配信者",
+                    "type": "",
+                    "broadcaster_type": "",
+                    "description": "",
+                    "profile_image_url": "https://example.com/profile.png",
+                    "offline_image_url": "",
+                    "view_count": 100,
+                    "created_at": "2020-01-01T00:00:00Z"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(HelixUsersResponse.self, from: jsonData)
+        }
+    }
+
+    @Test("不正な JSON は デコードエラーになる")
+    func testHelixUsersResponseDecodingMalformedJSON() {
+        // JSON として無効な文字列
+        let invalidJsonData = "{ invalid json }".data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(HelixUsersResponse.self, from: invalidJsonData)
+        }
+    }
+
+    @Test("data キーが欠けている JSON はデコードエラーになる")
+    func testHelixUsersResponseDecodingMissingDataKey() {
+        // "data" キーが存在しない
+        let jsonData = """
+        {
+            "total": 1
+        }
+        """.data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(HelixUsersResponse.self, from: jsonData)
+        }
+    }
+
+    @Test("フィールドの型が不一致の場合はデコードエラーになる")
+    func testHelixUsersResponseDecodingTypeMismatch() {
+        // "id" が文字列ではなく数値になっている
+        let jsonData = """
+        {
+            "data": [
+                {
+                    "id": 12345,
+                    "login": "test_streamer",
+                    "display_name": "テスト配信者",
+                    "type": "",
+                    "broadcaster_type": "",
+                    "description": "",
+                    "profile_image_url": "https://example.com/profile.png",
+                    "offline_image_url": "",
+                    "view_count": 100,
+                    "created_at": "2020-01-01T00:00:00Z"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        #expect(throws: (any Error).self) {
+            try JSONDecoder().decode(HelixUsersResponse.self, from: jsonData)
+        }
+    }
+
+    // MARK: - HelixUserData のプロパティテスト
+
+    @Test("HelixUserData のプロパティが正しく設定される")
+    func testHelixUserDataProperties() {
+        // TwitchUser と HelixUserData を統合したため、HelixUserData をドメインモデルとして直接利用する
+        let userData = HelixUserData(
+            id: "987654",
+            login: "test_streamer",
+            displayName: "テスト配信者の表示名",
+            profileImageUrl: "https://example.com/profile.png"
+        )
+
+        #expect(userData.id == "987654")
+        #expect(userData.login == "test_streamer")
+        #expect(userData.displayName == "テスト配信者の表示名")
+        #expect(userData.profileImageUrl == "https://example.com/profile.png")
+    }
+
+    @Test("空のデータ配列の HelixUsersResponse が正しくデコードされる")
+    func testHelixUsersResponseDecodingEmptyData() throws {
+        let jsonData = """
+        {
+            "data": []
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(HelixUsersResponse.self, from: jsonData)
+
+        #expect(response.data.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- Twitch Helix API `/helix/users` を使ってプロフィール画像URLを取得・管理する `ProfileImageStore` を追加
- `NSCache` + in-flight タスクパターンによるメモリキャッシュ `ProfileImageCache` を追加（既存の `BadgeImageCache` と同パターン）
- 円形プロフィールアイコン表示用の `ProfileImageView` を追加（プレースホルダー付き）
- サイドバーの `StreamRow` に配信者のプロフィールアイコン（28pt）を追加
- `LoginView` のシステムアイコンをログインユーザーの実際のプロフィール画像（20pt）に変更
- 100件超ユーザー取得時の自動チャンク分割（Helix API 制限対応）実装
- キャッシュ最大1000エントリ制限でメモリ増大を防止

## Test plan

- [x] `swift test` で全134テスト通過
- [x] `swift build` でビルドエラーなし
- [x] `TwitchUserTests` でデコードテスト8件（正常系4件・異常系4件）
- [x] `ProfileImageStoreTests` でストア振る舞いテスト7件

## 関連

- mtane0412/swift-twitch#8 (`profileImageUrl` の `URL?` 型変換のTech Debt issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザープロフィール画像がアプリ全体で表示されるようになりました。ログイン画面やストリーム一覧でプロフィール画像を確認できます。
  * プロフィール画像はメモリ内にキャッシュされ、アプリのパフォーマンスが向上しています。

* **テスト**
  * 新機能の包括的な単体テストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->