### PR TITLE
feat: 接続中チャンネルにプロフィールアイコン＋接続状態ボーダーを表示

### DIFF
--- a/Sources/TwitchChat/Services/FollowedStreamStore.swift
+++ b/Sources/TwitchChat/Services/FollowedStreamStore.swift
@@ -28,6 +28,9 @@ final class FollowedStreamStore {
     /// フォロー中の配信中ストリーム一覧（API レスポンス順）
     private(set) var streams: [FollowedStream] = []
 
+    /// userLogin → FollowedStream の O(1) ルックアップ用ディクショナリ
+    private(set) var streamsByUserLogin: [String: FollowedStream] = [:]
+
     /// データ取得中フラグ
     private(set) var isLoading = false
 
@@ -84,11 +87,20 @@ final class FollowedStreamStore {
         }
     }
 
+    /// userLogin からストリームを O(1) で検索する
+    ///
+    /// - Parameter userLogin: チャンネルのログイン名（小文字英数字）
+    /// - Returns: 対応する `FollowedStream`（存在しない場合は `nil`）
+    func stream(forUserLogin userLogin: String) -> FollowedStream? {
+        streamsByUserLogin[userLogin]
+    }
+
     /// ストリーム一覧をクリアする
     ///
     /// ログアウト時など、データを消去したい場合に使用する
     func clear() {
         streams = []
+        streamsByUserLogin = [:]
         lastError = nil
     }
 
@@ -114,7 +126,9 @@ final class FollowedStreamStore {
                 queryItems: [URLQueryItem(name: "user_id", value: userId)]
             )
             // ドメインモデルに変換（パース失敗のストリームはスキップ）
-            streams = response.data.compactMap { $0.toFollowedStream() }
+            let fetched = response.data.compactMap { $0.toFollowedStream() }
+            streams = fetched
+            streamsByUserLogin = Dictionary(uniqueKeysWithValues: fetched.map { ($0.userLogin, $0) })
             lastError = nil
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はサイレントスキップ（エラー表示しない）

--- a/Sources/TwitchChat/Services/FollowedStreamStore.swift
+++ b/Sources/TwitchChat/Services/FollowedStreamStore.swift
@@ -92,7 +92,8 @@ final class FollowedStreamStore {
     /// - Parameter userLogin: チャンネルのログイン名（小文字英数字）
     /// - Returns: 対応する `FollowedStream`（存在しない場合は `nil`）
     func stream(forUserLogin userLogin: String) -> FollowedStream? {
-        streamsByUserLogin[userLogin]
+        // ChannelManager がチャンネル名を小文字正規化するため、同様に正規化してルックアップする
+        streamsByUserLogin[userLogin.lowercased()]
     }
 
     /// ストリーム一覧をクリアする
@@ -128,7 +129,8 @@ final class FollowedStreamStore {
             // ドメインモデルに変換（パース失敗のストリームはスキップ）
             let fetched = response.data.compactMap { $0.toFollowedStream() }
             streams = fetched
-            streamsByUserLogin = Dictionary(uniqueKeysWithValues: fetched.map { ($0.userLogin, $0) })
+            // uniquingKeysWith: API レスポンスに重複 userLogin が含まれても最初の値を採用してクラッシュを防ぐ
+            streamsByUserLogin = Dictionary(fetched.map { ($0.userLogin, $0) }, uniquingKeysWith: { first, _ in first })
             lastError = nil
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はサイレントスキップ（エラー表示しない）

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -64,7 +64,9 @@ struct SidebarView: View {
                         .padding(.vertical, 4)
                 } else {
                     // 接続中チャンネルはライブリストから除外（接続中セクションに移動済みのため）
-                    ForEach(followedStreamStore.streams.filter { !channelManager.channelOrder.contains($0.userLogin) }) { stream in
+                    // Set を事前構築して O(n*m) → O(n) に最適化
+                    let connectedChannels = Set(channelManager.channelOrder)
+                    ForEach(followedStreamStore.streams.filter { !connectedChannels.contains($0.userLogin.lowercased()) }) { stream in
                         StreamRow(stream: stream, profileImageStore: profileImageStore)
                             .tag(stream.userLogin)
                     }
@@ -111,17 +113,33 @@ struct SidebarView: View {
     private func connectedChannelRow(channel: String) -> some View {
         let vm = channelManager.channels[channel]
         let stream = followedStreamStore.stream(forUserLogin: channel)
-        let userId = stream?.userId
+        let connectionColor = connectionColor(for: vm?.connectionState ?? .disconnected)
         HStack(spacing: 8) {
             // プロフィールアイコン + 接続状態ボーダー
-            ProfileImageView(
-                userId: userId ?? channel,
-                imageUrl: userId.flatMap { profileImageStore.profileImageUrl(for: $0) }
-            )
-            .overlay(
+            // userId が nil（フォロー外チャンネル）の場合は ProfileImageCache を汚染しないようプレースホルダーを直接描画する
+            if let userId = stream?.userId {
+                ProfileImageView(
+                    userId: userId,
+                    imageUrl: profileImageStore.profileImageUrl(for: userId)
+                )
+                .overlay(
+                    Circle()
+                        .strokeBorder(connectionColor, lineWidth: 2)
+                )
+            } else {
                 Circle()
-                    .stroke(connectionColor(for: vm?.connectionState ?? .disconnected), lineWidth: 2)
-            )
+                    .fill(Color.secondary.opacity(0.3))
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: ProfileImageCache.displaySize * 0.5))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: ProfileImageCache.displaySize, height: ProfileImageCache.displaySize)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(connectionColor, lineWidth: 2)
+                    )
+            }
             Text(stream?.userName ?? channel)
                 .font(.body)
                 .lineLimit(1)

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -63,7 +63,8 @@ struct SidebarView: View {
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
                 } else {
-                    ForEach(followedStreamStore.streams) { stream in
+                    // 接続中チャンネルはライブリストから除外（接続中セクションに移動済みのため）
+                    ForEach(followedStreamStore.streams.filter { !channelManager.channelOrder.contains($0.userLogin) }) { stream in
                         StreamRow(stream: stream, profileImageStore: profileImageStore)
                             .tag(stream.userLogin)
                     }
@@ -103,18 +104,30 @@ struct SidebarView: View {
     }
 
     /// 接続中チャンネルの行（コンテキストメニューで切断可能）
+    ///
+    /// FollowedStreamStore からプロフィール情報を引き、プロフィールアイコン＋接続状態ボーダーで表示する。
+    /// フォロー外のチャンネルの場合はプレースホルダーアイコンを表示する。
     @ViewBuilder
     private func connectedChannelRow(channel: String) -> some View {
-        HStack {
-            // 接続状態インジケーター
-            let vm = channelManager.channels[channel]
-            Circle()
-                .fill(connectionColor(for: vm?.connectionState ?? .disconnected))
-                .frame(width: 8, height: 8)
-            Text(channel)
+        let vm = channelManager.channels[channel]
+        let stream = followedStreamStore.stream(forUserLogin: channel)
+        let userId = stream?.userId
+        HStack(spacing: 8) {
+            // プロフィールアイコン + 接続状態ボーダー
+            ProfileImageView(
+                userId: userId ?? channel,
+                imageUrl: userId.flatMap { profileImageStore.profileImageUrl(for: $0) }
+            )
+            .overlay(
+                Circle()
+                    .stroke(connectionColor(for: vm?.connectionState ?? .disconnected), lineWidth: 2)
+            )
+            Text(stream?.userName ?? channel)
                 .font(.body)
+                .lineLimit(1)
             Spacer()
         }
+        .padding(.vertical, 2)
         .contextMenu {
             Button("切断", role: .destructive) {
                 Task { await channelManager.leaveChannel(channel) }

--- a/Tests/TwitchChatTests/FollowedStreamStoreTests.swift
+++ b/Tests/TwitchChatTests/FollowedStreamStoreTests.swift
@@ -125,6 +125,61 @@ struct FollowedStreamStoreTests {
         #expect(store.lastError == nil)
     }
 
+    // MARK: - O(1) ルックアップ
+
+    @Test("refresh後にstream(forUserLogin:)でO(1)検索できる")
+    func testStreamForUserLoginAfterRefresh() async {
+        let mockClient = MockFollowedStreamAPIClient()
+        let store = FollowedStreamStore(apiClient: mockClient, userId: "123456")
+
+        await mockClient.updateStreams([
+            makeHelixStream(userId: "111111", userLogin: "たぬき配信者", userName: "タヌキ配信者"),
+            makeHelixStream(userId: "222222", userLogin: "きつね配信者", userName: "キツネ配信者")
+        ])
+        await store.refresh()
+
+        // userLogin で正しく引けること
+        let result = store.stream(forUserLogin: "たぬき配信者")
+        #expect(result?.userId == "111111")
+        #expect(result?.userName == "タヌキ配信者")
+
+        // 存在しない userLogin は nil を返すこと
+        let missing = store.stream(forUserLogin: "存在しない配信者")
+        #expect(missing == nil)
+    }
+
+    @Test("stream(forUserLogin:)は大文字小文字を区別しない")
+    func testStreamForUserLoginIsCaseInsensitive() async {
+        let mockClient = MockFollowedStreamAPIClient()
+        let store = FollowedStreamStore(apiClient: mockClient, userId: "123456")
+
+        // Twitch API は userLogin を小文字で返すが、念のため大文字入力でも一致すること
+        await mockClient.updateStreams([
+            makeHelixStream(userId: "333333", userLogin: "streamer1", userName: "Streamer1")
+        ])
+        await store.refresh()
+
+        let result = store.stream(forUserLogin: "STREAMER1")
+        #expect(result?.userId == "333333")
+    }
+
+    @Test("clear後はstream(forUserLogin:)がnilを返す")
+    func testStreamForUserLoginClearedAfterClear() async {
+        let mockClient = MockFollowedStreamAPIClient()
+        let store = FollowedStreamStore(apiClient: mockClient, userId: "123456")
+
+        await mockClient.updateStreams([
+            makeHelixStream(userId: "444444", userLogin: "ライオン配信者", userName: "ライオン配信者")
+        ])
+        await store.refresh()
+        #expect(store.stream(forUserLogin: "ライオン配信者") != nil)
+
+        // clear後はルックアップ辞書もリセットされること
+        store.clear()
+        #expect(store.stream(forUserLogin: "ライオン配信者") == nil)
+        #expect(store.streamsByUserLogin.isEmpty)
+    }
+
     @Test("取得したストリームが FollowedStream モデルに正しく変換される")
     func testStreamDataConvertedCorrectly() async {
         let mockClient = MockFollowedStreamAPIClient()


### PR DESCRIPTION
## Summary

- **接続中セクションのUI刷新**: 緑丸(8pt) + テキストから `ProfileImageView` + 接続状態色の円形ボーダー(lineWidth: 2)に変更し、ライブセクションと統一感のある見た目に
- **ライブリストからの「移動」体験**: 接続中チャンネルをライブセクションからフィルタ除外し、クリックした配信者がライブ→接続中に移動するUXを実現
- **O(1)ルックアップの追加**: `FollowedStreamStore` に `streamsByUserLogin` ディクショナリと `stream(forUserLogin:)` ヘルパーを追加し、`SidebarView` での O(n) linear scan を排除

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `Sources/TwitchChat/Views/SidebarView.swift` | `connectedChannelRow` のUI刷新・ライブリストフィルタ追加 |
| `Sources/TwitchChat/Services/FollowedStreamStore.swift` | `streamsByUserLogin` ディクショナリ・`stream(forUserLogin:)` メソッド追加 |

## Test plan

- [ ] `swift build` でビルド成功を確認
- [ ] `swift test` で 134 テスト全通過を確認
- [ ] アプリ起動後、ライブリストの配信者をクリック → ライブリストから消え、接続中セクションにプロフィールアイコン＋緑枠で表示される
- [ ] 切断（コンテキストメニュー）→ 接続中から消え、ライブリストに戻る
- [ ] 接続中/接続待ち/エラー時のボーダー色（緑/黄/赤）が正しく変わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォロー中のストリームをユーザーログインで検索できるようになりました。

* **バグ修正**
  * 「ライブ」セクションが既に接続中のチャネルを表示しないよう修正されました。

* **改善**
  * 接続中のチャネル行にプロフィール画像とユーザー名が表示されるようになり、ビジュアルが向上しました。
  * 接続状態インジケーターの表示位置がプロフィール画像上に移動しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->