### PR TITLE
refactor: profileImageUrl の型を String から URL? に変更する

### DIFF
--- a/Sources/TwitchChat/Models/TwitchUser.swift
+++ b/Sources/TwitchChat/Models/TwitchUser.swift
@@ -22,13 +22,33 @@ struct HelixUserData: Decodable, Sendable, Identifiable, Equatable {
     let login: String
     /// 表示名（日本語名なども含む）
     let displayName: String
-    /// プロフィール画像 URL
-    let profileImageUrl: String
+    /// プロフィール画像 URL（空文字列・不正URLの場合は nil）
+    let profileImageUrl: URL?
 
     enum CodingKeys: String, CodingKey {
         case id
         case login
         case displayName = "display_name"
         case profileImageUrl = "profile_image_url"
+    }
+
+    /// カスタムデコードイニシャライザ
+    ///
+    /// - `profile_image_url` が空文字列または不正URLの場合、`profileImageUrl` を `nil` にする
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        login = try container.decode(String.self, forKey: .login)
+        displayName = try container.decode(String.self, forKey: .displayName)
+        let urlString = try container.decode(String.self, forKey: .profileImageUrl)
+        profileImageUrl = URL(string: urlString)
+    }
+
+    /// テスト用メンバーワイズイニシャライザ
+    init(id: String, login: String, displayName: String, profileImageUrl: URL?) {
+        self.id = id
+        self.login = login
+        self.displayName = displayName
+        self.profileImageUrl = profileImageUrl
     }
 }

--- a/Sources/TwitchChat/Services/ProfileImageCache.swift
+++ b/Sources/TwitchChat/Services/ProfileImageCache.swift
@@ -51,9 +51,9 @@ final class ProfileImageCache: @unchecked Sendable {
     ///
     /// - Parameters:
     ///   - userId: Twitch ユーザーID（キャッシュキーとして使用）
-    ///   - imageUrl: プロフィール画像 URL 文字列
+    ///   - imageUrl: プロフィール画像 URL
     /// - Returns: ダウンロード済みの NSImage（`displaySize` にリサイズ済み）。取得失敗時は nil
-    func image(for userId: String, imageUrl: String) async -> NSImage? {
+    func image(for userId: String, imageUrl: URL) async -> NSImage? {
         let cacheKey = userId as NSString
 
         // キャッシュヒット: 即時返却
@@ -61,10 +61,7 @@ final class ProfileImageCache: @unchecked Sendable {
             return cached
         }
 
-        guard let url = URL(string: imageUrl) else {
-            logger.warning("プロフィール画像の URL が不正: \(imageUrl)")
-            return nil
-        }
+        let url = imageUrl
 
         // 進行中タスクへの相乗り、または新規タスクの作成（排他制御）
         let task: Task<NSImage?, Never> = lock.withLock {

--- a/Sources/TwitchChat/Services/ProfileImageCache.swift
+++ b/Sources/TwitchChat/Services/ProfileImageCache.swift
@@ -61,8 +61,6 @@ final class ProfileImageCache: @unchecked Sendable {
             return cached
         }
 
-        let url = imageUrl
-
         // 進行中タスクへの相乗り、または新規タスクの作成（排他制御）
         let task: Task<NSImage?, Never> = lock.withLock {
             if let existing = inFlightTasks[userId] {
@@ -72,7 +70,7 @@ final class ProfileImageCache: @unchecked Sendable {
                 guard let self else { return nil as NSImage? }
                 defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: userId) } }
 
-                guard let image = await self.download(from: url) else { return nil }
+                guard let image = await self.download(from: imageUrl) else { return nil }
                 self.store(image, for: userId)
                 return image
             }

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -110,8 +110,10 @@ final class ProfileImageStore {
                 queryItems: queryItems
             )
             // キャッシュ上限超過時は全消去してメモリ増大を防ぐ
+            // fetchedUserIds も同時にクリアしないと上限超過後に再取得されなくなるため一緒にリセットする
             if profileImageUrls.count + response.data.count > Self.maxCacheEntries {
                 profileImageUrls.removeAll()
+                fetchedUserIds.removeAll()
             }
             for userData in response.data {
                 // レスポンスを受信したユーザーはフェッチ済みとしてマーク（URL が nil でも再取得しない）

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -31,7 +31,7 @@ final class ProfileImageStore {
     // MARK: - プライベートプロパティ
 
     /// userId → profileImageUrl のキャッシュ
-    private var profileImageUrls: [String: String] = [:]
+    private var profileImageUrls: [String: URL] = [:]
 
     /// 現在フェッチ中の userId セット
     ///
@@ -57,7 +57,7 @@ final class ProfileImageStore {
     ///
     /// - Parameter userId: Twitch ユーザーID
     /// - Returns: プロフィール画像URL（未取得またはユーザーが存在しない場合は `nil`）
-    func profileImageUrl(for userId: String) -> String? {
+    func profileImageUrl(for userId: String) -> URL? {
         profileImageUrls[userId]
     }
 
@@ -107,7 +107,10 @@ final class ProfileImageStore {
                 profileImageUrls.removeAll()
             }
             for userData in response.data {
-                profileImageUrls[userData.id] = userData.profileImageUrl
+                // profileImageUrl が nil（空文字列・不正URL）のユーザーはキャッシュに追加しない
+                if let url = userData.profileImageUrl {
+                    profileImageUrls[userData.id] = url
+                }
             }
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はサイレントスキップ

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -33,6 +33,11 @@ final class ProfileImageStore {
     /// userId → profileImageUrl のキャッシュ
     private var profileImageUrls: [String: URL] = [:]
 
+    /// API レスポンスを受信済みの userId セット
+    ///
+    /// `profileImageUrl` が nil（空URL）のユーザーも含めて追跡し、繰り返しの API 呼び出しを防ぐ
+    private var fetchedUserIds: Set<String> = []
+
     /// 現在フェッチ中の userId セット
     ///
     /// `@MainActor` の await サスペンション中に別タスクが同じ userId を重複リクエストするのを防ぐ
@@ -68,8 +73,9 @@ final class ProfileImageStore {
     ///         認証エラーはサイレントスキップ（プロフィール画像は必須ではないため）。
     func fetchUsers(userIds: [String]) async {
         // 未取得かつフェッチ中でないユーザーのみ対象にする
-        // （@MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ）
-        let newUserIds = userIds.filter { profileImageUrls[$0] == nil && !inFlightUserIds.contains($0) }
+        // fetchedUserIds でフェッチ済み（URL が nil のユーザーを含む）を除外し、
+        // @MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ
+        let newUserIds = userIds.filter { !fetchedUserIds.contains($0) && !inFlightUserIds.contains($0) }
         guard !newUserIds.isEmpty else { return }
 
         // フェッチ中フラグを設定し、完了後に必ず解除する
@@ -88,6 +94,7 @@ final class ProfileImageStore {
     /// ログアウト時など、データを消去したい場合に使用する
     func clear() {
         profileImageUrls = [:]
+        fetchedUserIds = []
         inFlightUserIds = []
     }
 
@@ -107,7 +114,9 @@ final class ProfileImageStore {
                 profileImageUrls.removeAll()
             }
             for userData in response.data {
-                // profileImageUrl が nil（空文字列・不正URL）のユーザーはキャッシュに追加しない
+                // レスポンスを受信したユーザーはフェッチ済みとしてマーク（URL が nil でも再取得しない）
+                fetchedUserIds.insert(userData.id)
+                // profileImageUrl が nil（空文字列・不正URL）のユーザーはURLキャッシュに追加しない
                 if let url = userData.profileImageUrl {
                     profileImageUrls[userData.id] = url
                 }

--- a/Sources/TwitchChat/Views/ProfileImageView.swift
+++ b/Sources/TwitchChat/Views/ProfileImageView.swift
@@ -13,8 +13,8 @@ struct ProfileImageView: View {
 
     /// Twitch ユーザーID（キャッシュキーとして使用）
     let userId: String
-    /// プロフィール画像 URL 文字列
-    let imageUrl: String?
+    /// プロフィール画像 URL
+    let imageUrl: URL?
     /// 表示サイズ（ポイント）
     var size: CGFloat = ProfileImageCache.displaySize
 
@@ -42,7 +42,7 @@ struct ProfileImageView: View {
         .clipShape(Circle())
         // userId または imageUrl のどちらが変わっても再取得する
         // セパレータ（":"）を使用して userId + imageUrl の文字列衝突を防ぐ
-        .task(id: userId + ":" + (imageUrl ?? "")) {
+        .task(id: userId + ":" + (imageUrl?.absoluteString ?? "")) {
             await loadImage()
         }
     }

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -51,7 +51,7 @@ private func makeHelixUser(
     id: String = "111111",
     login: String = "テスト配信者",
     displayName: String = "テスト配信者の表示名",
-    profileImageUrl: String = "https://example.com/profile.png"
+    profileImageUrl: URL? = URL(string: "https://example.com/profile.png")
 ) -> HelixUserData {
     HelixUserData(
         id: id,
@@ -83,15 +83,15 @@ struct ProfileImageStoreTests {
     func testFetchProfileImageUrls() async {
         let mockClient = MockProfileImageAPIClient()
         await mockClient.setUsers([
-            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png"),
-            makeHelixUser(id: "222222", profileImageUrl: "https://example.com/user2.png")
+            makeHelixUser(id: "111111", profileImageUrl: URL(string: "https://example.com/user1.png")),
+            makeHelixUser(id: "222222", profileImageUrl: URL(string: "https://example.com/user2.png"))
         ])
         let store = ProfileImageStore(apiClient: mockClient)
 
         await store.fetchUsers(userIds: ["111111", "222222"])
 
-        #expect(store.profileImageUrl(for: "111111") == "https://example.com/user1.png")
-        #expect(store.profileImageUrl(for: "222222") == "https://example.com/user2.png")
+        #expect(store.profileImageUrl(for: "111111") == URL(string: "https://example.com/user1.png"))
+        #expect(store.profileImageUrl(for: "222222") == URL(string: "https://example.com/user2.png"))
     }
 
     @Test("ユーザーIDが空の場合は API を呼ばない")
@@ -121,7 +121,7 @@ struct ProfileImageStoreTests {
     func testDoesNotRefetchExistingUsers() async {
         let mockClient = MockProfileImageAPIClient()
         await mockClient.setUsers([
-            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png")
+            makeHelixUser(id: "111111", profileImageUrl: URL(string: "https://example.com/user1.png"))
         ])
         let store = ProfileImageStore(apiClient: mockClient)
 
@@ -139,8 +139,8 @@ struct ProfileImageStoreTests {
     func testFetchesOnlyNewUsers() async {
         let mockClient = MockProfileImageAPIClient()
         await mockClient.setUsers([
-            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png"),
-            makeHelixUser(id: "333333", profileImageUrl: "https://example.com/user3.png")
+            makeHelixUser(id: "111111", profileImageUrl: URL(string: "https://example.com/user1.png")),
+            makeHelixUser(id: "333333", profileImageUrl: URL(string: "https://example.com/user3.png"))
         ])
         let store = ProfileImageStore(apiClient: mockClient)
 
@@ -163,7 +163,7 @@ struct ProfileImageStoreTests {
     func testClearResetsUsers() async {
         let mockClient = MockProfileImageAPIClient()
         await mockClient.setUsers([
-            makeHelixUser(id: "111111", profileImageUrl: "https://example.com/user1.png")
+            makeHelixUser(id: "111111", profileImageUrl: URL(string: "https://example.com/user1.png"))
         ])
         let store = ProfileImageStore(apiClient: mockClient)
 

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -135,6 +135,27 @@ struct ProfileImageStoreTests {
         #expect(callCount == 1)
     }
 
+    @Test("プロフィール画像URLが nil のユーザーは再取得しない")
+    func testDoesNotRefetchUsersWithNilProfileImageUrl() async {
+        let mockClient = MockProfileImageAPIClient()
+        // profileImageUrl が nil（空URL）のユーザーを返す
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", profileImageUrl: nil)
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        // 1回目: APIレスポンスを受信（URL は nil）
+        await store.fetchUsers(userIds: ["111111"])
+        // 2回目: 同じユーザーID（フェッチ済みのため再取得しない）
+        await store.fetchUsers(userIds: ["111111"])
+
+        // API は1回しか呼ばれていないこと
+        let callCount = await mockClient.callCount
+        #expect(callCount == 1)
+        // profileImageUrl は nil のまま
+        #expect(store.profileImageUrl(for: "111111") == nil)
+    }
+
     @Test("未取得のユーザーのみ API を呼ぶ")
     func testFetchesOnlyNewUsers() async {
         let mockClient = MockProfileImageAPIClient()

--- a/Tests/TwitchChatTests/TwitchUserTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserTests.swift
@@ -41,7 +41,7 @@ struct TwitchUserTests {
         #expect(userData.id == "141981764")
         #expect(userData.login == "twitchdev")
         #expect(userData.displayName == "TwitchDev")
-        #expect(userData.profileImageUrl == "https://static-cdn.jtvnw.net/jtv_user_pictures/twitchdev-profile.png")
+        #expect(userData.profileImageUrl == URL(string: "https://static-cdn.jtvnw.net/jtv_user_pictures/twitchdev-profile.png"))
     }
 
     @Test("複数ユーザーの HelixUsersResponse が正しくデコードされる")
@@ -85,10 +85,10 @@ struct TwitchUserTests {
         #expect(response.data[0].id == "111111")
         #expect(response.data[0].login == "streamer_a")
         #expect(response.data[0].displayName == "配信者あ表示名")
-        #expect(response.data[0].profileImageUrl == "https://example.com/ah.png")
+        #expect(response.data[0].profileImageUrl == URL(string: "https://example.com/ah.png"))
         #expect(response.data[1].id == "222222")
         #expect(response.data[1].login == "streamer_b")
-        #expect(response.data[1].profileImageUrl == "https://example.com/i.png")
+        #expect(response.data[1].profileImageUrl == URL(string: "https://example.com/i.png"))
     }
 
     // MARK: - デコード失敗テスト
@@ -179,13 +179,39 @@ struct TwitchUserTests {
             id: "987654",
             login: "test_streamer",
             displayName: "テスト配信者の表示名",
-            profileImageUrl: "https://example.com/profile.png"
+            profileImageUrl: URL(string: "https://example.com/profile.png")
         )
 
         #expect(userData.id == "987654")
         #expect(userData.login == "test_streamer")
         #expect(userData.displayName == "テスト配信者の表示名")
-        #expect(userData.profileImageUrl == "https://example.com/profile.png")
+        #expect(userData.profileImageUrl == URL(string: "https://example.com/profile.png"))
+    }
+
+    @Test("profile_image_url が空文字列の場合は nil になる")
+    func testProfileImageUrlEmptyStringBecomesNil() throws {
+        // Twitch API が空文字列を返した場合、URL? は nil になることを検証する
+        let jsonData = """
+        {
+            "data": [
+                {
+                    "id": "111111",
+                    "login": "streamer_a",
+                    "display_name": "配信者あ表示名",
+                    "type": "",
+                    "broadcaster_type": "",
+                    "description": "",
+                    "profile_image_url": "",
+                    "offline_image_url": "",
+                    "view_count": 100,
+                    "created_at": "2020-01-01T00:00:00Z"
+                }
+            ]
+        }
+        """.data(using: .utf8)!
+
+        let response = try JSONDecoder().decode(HelixUsersResponse.self, from: jsonData)
+        #expect(response.data[0].profileImageUrl == nil)
     }
 
     @Test("空のデータ配列の HelixUsersResponse が正しくデコードされる")


### PR DESCRIPTION
## Summary

- `HelixUserData.profileImageUrl` を `String` から `URL?` に変更し、カスタム `init(from:)` で変換処理を実装
- `ProfileImageStore` の内部キャッシュ・戻り値型を `URL?` に変更し、`profileImageUrl` が nil のユーザーの繰り返し API 呼び出しを防止
- `ProfileImageCache.image(for:imageUrl:)` パラメータを `URL` 型に変更し、内部の `URL(string:)` 変換処理を削除
- `ProfileImageView.imageUrl` を `URL?` に変更
- テストを `URL?` 対応に更新し、空文字列 → nil・nil URL ユーザーの再取得防止を検証するテストを追加

## Test plan

- [x] `swift build` でビルドエラーなし
- [x] `swift test` で 139 テスト全て通過（新規テスト1件含む）
- [x] CodeRabbit の指摘（冗長変数削除・nil URL ユーザーの再取得防止）に対応済み

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)