### PR TITLE
fix: Keychain の open ACL 設定でビルドごとの許可ダイアログを解消する

### DIFF
--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -61,6 +61,8 @@ public final class AuthState {
 
     private let authClient: any TwitchAuthClientProtocol
     private let keychainStore: KeychainStore
+    /// ブラウザで URL を開く処理（テスト時は no-op を注入して実際のブラウザ起動を抑制する）
+    private let openURL: @Sendable (URL) -> Void
 
     /// 進行中のログインタスク（cancelDeviceFlow() でキャンセルするために保持）
     private var loginTask: Task<Void, Never>?
@@ -72,12 +74,15 @@ public final class AuthState {
     /// - Parameters:
     ///   - authClient: OAuth クライアント（テスト時はモックを注入）
     ///   - keychainStore: Keychain ストア（テスト時は別サービス名のものを注入）
+    ///   - openURL: ブラウザで URL を開く処理（テスト時は no-op を注入）
     init(
         authClient: any TwitchAuthClientProtocol = TwitchAuthClient(),
-        keychainStore: KeychainStore = KeychainStore()
+        keychainStore: KeychainStore = KeychainStore(),
+        openURL: @escaping @Sendable (URL) -> Void = { NSWorkspace.shared.open($0) }
     ) {
         self.authClient = authClient
         self.keychainStore = keychainStore
+        self.openURL = openURL
     }
 
     // MARK: - パブリックメソッド
@@ -156,7 +161,7 @@ public final class AuthState {
 
             // デフォルトブラウザで認証ページを開く
             if let url = URL(string: deviceResponse.verificationUri) {
-                NSWorkspace.shared.open(url)
+                openURL(url)
             }
 
             // ユーザーが認証するまでポーリング

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -88,13 +88,19 @@ public final class AuthState {
     /// - トークンが有効であれば `.loggedIn` に遷移
     /// - トークンが期限切れであればリフレッシュを試み、成功すれば `.loggedIn`、失敗すれば `.loggedOut`
     func restoreSession() async {
+        print("[AuthState] restoreSession: Keychain からトークンを読み込み中...")
         guard let savedToken = await keychainStore.load(key: "access_token") else {
+            print("[AuthState] restoreSession: access_token が見つからないため .loggedOut に遷移")
             status = .loggedOut
             return
         }
+        print("[AuthState] restoreSession: access_token を取得。validateToken を実行中...")
 
         do {
             let validateResponse = try await authClient.validateToken(accessToken: savedToken)
+            #if DEBUG
+            print("[AuthState] restoreSession: validateToken 成功 — login=\(validateResponse.login)")
+            #endif
             accessToken = savedToken
             // validateResponse.userId を優先して設定し、未保存なら Keychain にも保存する
             userId = validateResponse.userId
@@ -104,8 +110,10 @@ public final class AuthState {
             }
             status = .loggedIn(userLogin: validateResponse.login)
         } catch TwitchAuthError.tokenExpired {
+            print("[AuthState] restoreSession: トークン期限切れ。リフレッシュを試みる...")
             await tryRefreshToken()
         } catch {
+            print("[AuthState] restoreSession: validateToken 失敗 — errorType=\(type(of: error))")
             status = .loggedOut
         }
     }

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -88,13 +88,19 @@ public final class AuthState {
     /// - トークンが有効であれば `.loggedIn` に遷移
     /// - トークンが期限切れであればリフレッシュを試み、成功すれば `.loggedIn`、失敗すれば `.loggedOut`
     func restoreSession() async {
+        #if DEBUG
         print("[AuthState] restoreSession: Keychain からトークンを読み込み中...")
+        #endif
         guard let savedToken = await keychainStore.load(key: "access_token") else {
+            #if DEBUG
             print("[AuthState] restoreSession: access_token が見つからないため .loggedOut に遷移")
+            #endif
             status = .loggedOut
             return
         }
+        #if DEBUG
         print("[AuthState] restoreSession: access_token を取得。validateToken を実行中...")
+        #endif
 
         do {
             let validateResponse = try await authClient.validateToken(accessToken: savedToken)
@@ -110,10 +116,14 @@ public final class AuthState {
             }
             status = .loggedIn(userLogin: validateResponse.login)
         } catch TwitchAuthError.tokenExpired {
+            #if DEBUG
             print("[AuthState] restoreSession: トークン期限切れ。リフレッシュを試みる...")
+            #endif
             await tryRefreshToken()
         } catch {
+            #if DEBUG
             print("[AuthState] restoreSession: validateToken 失敗 — errorType=\(type(of: error))")
+            #endif
             status = .loggedOut
         }
     }

--- a/Sources/TwitchChat/Auth/KeychainStore.swift
+++ b/Sources/TwitchChat/Auth/KeychainStore.swift
@@ -29,12 +29,14 @@ actor KeychainStore {
 
     /// 指定キーに文字列値を保存する
     ///
-    /// 既存のアイテムが存在する場合は上書き（SecItemUpdate）する
+    /// 既存のアイテムがある場合は削除してから追加する（SecItemUpdate は ACL を引き継ぐため）。
+    /// open ACL の生成に失敗した場合は保存を中断し `accessCreationFailed` を throw する。
     ///
     /// - Parameters:
     ///   - key: 保存キー名
     ///   - value: 保存する文字列値
     /// - Throws: `KeychainError.saveFailed` Keychain 操作に失敗した場合
+    ///           `KeychainError.accessCreationFailed` open ACL 生成に失敗した場合
     func save(key: String, value: String) throws {
         guard let data = value.data(using: .utf8) else {
             throw KeychainError.saveFailed(status: errSecParam)
@@ -47,18 +49,23 @@ actor KeychainStore {
         ]
 
         // 既存アイテムがあれば削除してから追加する。
-        // SecItemUpdate は既存の ACL を引き継ぐため、open ACL に更新できない。
-        // 削除 + 追加することで常に open ACL が適用される。
-        SecItemDelete(query as CFDictionary)
+        // SecItemUpdate は既存の ACL を引き継ぐため open ACL に更新できない。
+        // errSecItemNotFound は「存在しない」を意味するため正常扱い。それ以外の失敗はエラーとする。
+        let deleteStatus = SecItemDelete(query as CFDictionary)
+        guard deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound else {
+            throw KeychainError.saveFailed(status: deleteStatus)
+        }
 
         // trustedList を nil にすることで任意のアプリからアクセス可能な open ACL を設定する。
         // SPM ビルドごとにバイナリのコード署名が変わっても Keychain 許可ダイアログが表示されなくなる。
-        let access = makeOpenAccess()
+        // ACL 生成に失敗した場合は保存を中断する（デフォルト ACL での暗黙保存を防ぐ）。
+        guard let access = makeOpenAccess() else {
+            throw KeychainError.accessCreationFailed
+        }
+
         var addQuery = query
         addQuery[kSecValueData as String] = data
-        if let access {
-            addQuery[kSecAttrAccess as String] = access
-        }
+        addQuery[kSecAttrAccess as String] = access
         let status = SecItemAdd(addQuery as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw KeychainError.saveFailed(status: status)
@@ -118,8 +125,6 @@ actor KeychainStore {
         while SecItemDelete(query as CFDictionary) == errSecSuccess {}
     }
 
-
-
     // MARK: - プライベートメソッド
 
     /// trustedList が nil の open ACL を持つ SecAccess を作成する
@@ -128,11 +133,14 @@ actor KeychainStore {
     /// これにより SPM ビルドごとにバイナリが変わっても Keychain 許可ダイアログが表示されない。
     /// - Note: SecAccessCreate は macOS 10.10 で deprecated だが、
     ///   App Store 外の SPM アプリで open ACL を設定する唯一の方法として使用する。
+    /// - Returns: 生成した `SecAccess`。失敗した場合は `nil`
     private func makeOpenAccess() -> SecAccess? {
         var access: SecAccess?
         let status = SecAccessCreate("TwitchChat Token" as CFString, nil, &access)
         guard status == errSecSuccess else {
+            #if DEBUG
             print("[KeychainStore] SecAccessCreate failed: OSStatus=\(status)")
+            #endif
             return nil
         }
         return access
@@ -145,4 +153,6 @@ actor KeychainStore {
 enum KeychainError: Error, Equatable {
     /// 保存に失敗した（OSStatus コード付き）
     case saveFailed(status: OSStatus)
+    /// open ACL（SecAccess）の生成に失敗した
+    case accessCreationFailed
 }

--- a/Sources/TwitchChat/Auth/KeychainStore.swift
+++ b/Sources/TwitchChat/Auth/KeychainStore.swift
@@ -46,21 +46,22 @@ actor KeychainStore {
             kSecAttrAccount as String: key
         ]
 
-        // 既存アイテムがあれば更新、なければ追加
-        let existingItem = SecItemCopyMatching(query as CFDictionary, nil)
-        if existingItem == errSecSuccess {
-            let attributes: [String: Any] = [kSecValueData as String: data]
-            let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
-            guard status == errSecSuccess else {
-                throw KeychainError.saveFailed(status: status)
-            }
-        } else {
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            let status = SecItemAdd(addQuery as CFDictionary, nil)
-            guard status == errSecSuccess else {
-                throw KeychainError.saveFailed(status: status)
-            }
+        // 既存アイテムがあれば削除してから追加する。
+        // SecItemUpdate は既存の ACL を引き継ぐため、open ACL に更新できない。
+        // 削除 + 追加することで常に open ACL が適用される。
+        SecItemDelete(query as CFDictionary)
+
+        // trustedList を nil にすることで任意のアプリからアクセス可能な open ACL を設定する。
+        // SPM ビルドごとにバイナリのコード署名が変わっても Keychain 許可ダイアログが表示されなくなる。
+        let access = makeOpenAccess()
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        if let access {
+            addQuery[kSecAttrAccess as String] = access
+        }
+        let status = SecItemAdd(addQuery as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw KeychainError.saveFailed(status: status)
         }
     }
 
@@ -79,6 +80,11 @@ actor KeychainStore {
 
         var item: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &item)
+        #if DEBUG
+        if status != errSecSuccess {
+            print("[KeychainStore] load(\(key)) failed: OSStatus=\(status)")
+        }
+        #endif
         guard status == errSecSuccess, let data = item as? Data else {
             return nil
         }
@@ -110,6 +116,26 @@ actor KeychainStore {
             kSecAttrService as String: service
         ]
         while SecItemDelete(query as CFDictionary) == errSecSuccess {}
+    }
+
+
+
+    // MARK: - プライベートメソッド
+
+    /// trustedList が nil の open ACL を持つ SecAccess を作成する
+    ///
+    /// nil の trustedList はすべてのアプリケーションからのアクセスを許可する。
+    /// これにより SPM ビルドごとにバイナリが変わっても Keychain 許可ダイアログが表示されない。
+    /// - Note: SecAccessCreate は macOS 10.10 で deprecated だが、
+    ///   App Store 外の SPM アプリで open ACL を設定する唯一の方法として使用する。
+    private func makeOpenAccess() -> SecAccess? {
+        var access: SecAccess?
+        let status = SecAccessCreate("TwitchChat Token" as CFString, nil, &access)
+        guard status == errSecSuccess else {
+            print("[KeychainStore] SecAccessCreate failed: OSStatus=\(status)")
+            return nil
+        }
+        return access
     }
 }
 

--- a/Tests/TwitchChatTests/AuthStateTests.swift
+++ b/Tests/TwitchChatTests/AuthStateTests.swift
@@ -232,9 +232,11 @@ struct AuthStateTests {
         authClient: (any TwitchAuthClientProtocol)? = nil,
         keychainStore: KeychainStore? = nil
     ) -> AuthState {
+        // openURL に no-op を渡し、テスト中に実際のブラウザが開かないようにする
         AuthState(
             authClient: authClient ?? MockTwitchAuthClient(),
-            keychainStore: keychainStore ?? makeTestKeychainStore()
+            keychainStore: keychainStore ?? makeTestKeychainStore(),
+            openURL: { _ in }
         )
     }
 


### PR DESCRIPTION
## Summary

- SPM ビルドごとにバイナリのコード署名が変わると Keychain アクセスが拒否され、毎回 `https://www.twitch.tv/activate` がブラウザで開かれる問題を修正
- `SecAccessCreate` に `nil` の `trustedList` を渡して open ACL を設定し、任意のアプリから許可ダイアログなしでアクセスできるようにした
- `SecItemUpdate`（既存 ACL を引き継ぐ）から「削除 + 追加」に変更し、常に open ACL が適用されるようにした
- `restoreSession()` にデバッグログを追加（ユーザー識別子は `#if DEBUG` でガード、エラーはエラー型のみ出力）
- `KeychainStore.load()` のエラーログを `#if DEBUG` でガード
- `makeOpenAccess()` で `SecAccessCreate` の戻り値を検証するように修正

## Test plan

- [ ] `swift build && swift run` でアプリを起動し、ログインする
- [ ] 再度 `swift build && swift run` で起動し、ブラウザが開かないことを確認
- [ ] `swift test` で全テスト（139件）がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 認証セッション復元処理の内部ロギングを強化しました。
  * 認証情報の保存・復元メカニズムを改善し、より堅牢な処理フローに変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->