### PR TITLE
feat: Chrome スタイルのタブ UI でチャット表示を改善する

### DIFF
--- a/Sources/TwitchChat/ViewModels/ChannelDisplayNameResolver.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelDisplayNameResolver.swift
@@ -23,7 +23,8 @@ struct ChannelDisplayNameResolver {
 
     /// チャンネルログイン名に対応する表示名を返す
     ///
-    /// - Parameter channelLogin: チャンネルのログイン名（大文字小文字は自動正規化）
+    /// 大文字小文字の正規化は `FollowedStreamStore.stream(forUserLogin:)` が担う。
+    /// - Parameter channelLogin: チャンネルのログイン名
     /// - Returns: フォロー中かつライブ中なら `FollowedStream.userName`、それ以外は `channelLogin` をそのまま返す
     func displayName(for channelLogin: String) -> String {
         store.stream(forUserLogin: channelLogin)?.userName ?? channelLogin

--- a/Sources/TwitchChat/ViewModels/ChannelDisplayNameResolver.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelDisplayNameResolver.swift
@@ -1,0 +1,31 @@
+// ChannelDisplayNameResolver.swift
+// チャンネルログイン名から表示名を解決するロジック
+// FollowedStreamStore の userName を優先し、取得できない場合は channelLogin をそのまま返す
+
+import Foundation
+
+/// チャンネルの表示名を解決するリゾルバ
+///
+/// フォロー中の配信者には `FollowedStream.userName`（例: "山田太郎"）を返し、
+/// フォロー外または未ライブのチャンネルには `channelLogin` をそのまま返す。
+/// SwiftUI 非依存の純粋なロジック層として実装する。
+@MainActor
+struct ChannelDisplayNameResolver {
+
+    private let store: FollowedStreamStore
+
+    /// `ChannelDisplayNameResolver` を初期化する
+    ///
+    /// - Parameter store: フォロー中ストリーム情報のストア
+    init(store: FollowedStreamStore) {
+        self.store = store
+    }
+
+    /// チャンネルログイン名に対応する表示名を返す
+    ///
+    /// - Parameter channelLogin: チャンネルのログイン名（大文字小文字は自動正規化）
+    /// - Returns: フォロー中かつライブ中なら `FollowedStream.userName`、それ以外は `channelLogin` をそのまま返す
+    func displayName(for channelLogin: String) -> String {
+        store.stream(forUserLogin: channelLogin)?.userName ?? channelLogin
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -113,6 +113,27 @@ final class ChannelManager {
         }
     }
 
+    /// 指定チャンネルが既に接続中かどうかを返す
+    ///
+    /// - Parameter channelLogin: チャンネルのログイン名（大文字小文字は自動正規化）
+    /// - Returns: 接続中なら `true`、未接続なら `false`
+    func isJoined(_ channelLogin: String) -> Bool {
+        channels[channelLogin.lowercased()] != nil
+    }
+
+    /// 既接続チャンネルを選択状態にする（同期）
+    ///
+    /// 未接続チャンネルを指定した場合は何もしない。
+    /// `joinChannel(_:)` は未接続時に新規接続を開始するが、このメソッドは選択切替のみ行う。
+    /// サイドバーのアイコンクリックやタブバーのタブクリックから呼ぶことを想定している。
+    ///
+    /// - Parameter channelLogin: チャンネルのログイン名（大文字小文字は自動正規化）
+    func selectChannel(_ channelLogin: String) {
+        let normalized = channelLogin.lowercased()
+        guard channels[normalized] != nil else { return }
+        selectedChannel = normalized
+    }
+
     /// 全チャンネルから切断して管理状態をリセットする
     func disconnectAll() async {
         let allChannels = channelOrder

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -1,0 +1,42 @@
+// ChannelTabBar.swift
+// 接続中チャンネルのタブバービュー
+// detail 領域の上端に表示し、HStack で等幅タブを並べてタブ切り替えを提供する
+
+import SwiftUI
+
+/// 接続中チャンネルを横並びタブで表示するタブバー
+///
+/// - `channelManager.channelOrder` の順にタブを並べる
+/// - 各タブは `ChannelTabCell` で描画し、選択・クローズ操作を処理する
+/// - タブ数が増えると各タブ幅が縮小し、`ChannelTabCell` が自動的にアイコンのみに縮退する
+struct ChannelTabBar: View {
+
+    let channelManager: ChannelManager
+    let followedStreamStore: FollowedStreamStore
+    let profileImageStore: ProfileImageStore
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(channelManager.channelOrder, id: \.self) { channel in
+                if let vm = channelManager.channels[channel] {
+                    let stream = followedStreamStore.stream(forUserLogin: channel)
+                    let uid = stream?.userId ?? channel
+                    let name = stream?.userName ?? channel
+                    ChannelTabCell(
+                        viewModel: vm,
+                        isSelected: channel == channelManager.selectedChannel,
+                        displayName: name,
+                        profileImageUrl: profileImageStore.profileImageUrl(for: uid),
+                        userId: uid,
+                        onSelect: { channelManager.selectChannel(channel) },
+                        onClose: { Task { await channelManager.leaveChannel(channel) } }
+                    )
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .frame(height: 36)
+        .background(.bar)
+    }
+}

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -46,6 +46,8 @@ struct ChannelTabBar: View {
             .frame(height: Self.height, alignment: .bottom)
         }
         .frame(height: Self.height)
-        .background(Color(.windowBackgroundColor))
+        // タブバー背景: チャット欄（controlBackgroundColor）より明示的に少し暗くする
+        // brightness(-0.05) は絶対値ではなく相対的な暗さのため、ライト/ダーク両対応
+        .background(Color(.controlBackgroundColor).brightness(-0.05))
     }
 }

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -8,8 +8,7 @@ import SwiftUI
 ///
 /// - タブは左から並び、最大幅 `maxTabWidth` の固定幅で表示する
 /// - タブが多い場合は `ScrollView(.horizontal)` で横スクロール可能にする
-/// - アクティブタブは `ChannelTabCell.activeHeight` の分だけ下の Divider を隠し、
-///   コンテンツエリアと繋がっているように見える
+/// - アクティブタブは非アクティブタブより高く描画され、コンテンツエリアと視覚的に繋がって見える
 struct ChannelTabBar: View {
 
     let channelManager: ChannelManager
@@ -27,13 +26,13 @@ struct ChannelTabBar: View {
                 ForEach(channelManager.channelOrder, id: \.self) { channel in
                     if channelManager.channels[channel] != nil {
                         let stream = followedStreamStore.stream(forUserLogin: channel)
-                        let uid = stream?.userId ?? channel
+                        let userId = stream?.userId
                         let name = stream?.userName ?? channel
                         ChannelTabCell(
                             isSelected: channel == channelManager.selectedChannel,
                             displayName: name,
-                            profileImageUrl: profileImageStore.profileImageUrl(for: uid),
-                            userId: uid,
+                            profileImageUrl: userId.flatMap { profileImageStore.profileImageUrl(for: $0) },
+                            userId: userId,
                             onSelect: { channelManager.selectChannel(channel) },
                             onClose: { Task { await channelManager.leaveChannel(channel) } }
                         )

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -1,42 +1,51 @@
 // ChannelTabBar.swift
 // 接続中チャンネルのタブバービュー
-// detail 領域の上端に表示し、HStack で等幅タブを並べてタブ切り替えを提供する
+// Chrome スタイル：左揃えの固定幅タブ、下のボーダーとアクティブタブが繋がって見える構造
 
 import SwiftUI
 
-/// 接続中チャンネルを横並びタブで表示するタブバー
+/// 接続中チャンネルを Chrome スタイルのタブで表示するタブバー
 ///
-/// - `channelManager.channelOrder` の順にタブを並べる
-/// - 各タブは `ChannelTabCell` で描画し、選択・クローズ操作を処理する
-/// - タブ数が増えると各タブ幅が縮小し、`ChannelTabCell` が自動的にアイコンのみに縮退する
+/// - タブは左から並び、最大幅 `maxTabWidth` の固定幅で表示する
+/// - タブが多い場合は `ScrollView(.horizontal)` で横スクロール可能にする
+/// - アクティブタブは `ChannelTabCell.activeHeight` の分だけ下の Divider を隠し、
+///   コンテンツエリアと繋がっているように見える
 struct ChannelTabBar: View {
 
     let channelManager: ChannelManager
     let followedStreamStore: FollowedStreamStore
     let profileImageStore: ProfileImageStore
 
+    /// 各タブの最大幅
+    private static let maxTabWidth: CGFloat = 180
+    /// タブバー全体の高さ（アクティブタブは +1pt で Divider を隠す）
+    static let height: CGFloat = ChannelTabCell.inactiveHeight + 2
+
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(channelManager.channelOrder, id: \.self) { channel in
-                if let vm = channelManager.channels[channel] {
-                    let stream = followedStreamStore.stream(forUserLogin: channel)
-                    let uid = stream?.userId ?? channel
-                    let name = stream?.userName ?? channel
-                    ChannelTabCell(
-                        viewModel: vm,
-                        isSelected: channel == channelManager.selectedChannel,
-                        displayName: name,
-                        profileImageUrl: profileImageStore.profileImageUrl(for: uid),
-                        userId: uid,
-                        onSelect: { channelManager.selectChannel(channel) },
-                        onClose: { Task { await channelManager.leaveChannel(channel) } }
-                    )
-                    .frame(maxWidth: .infinity)
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 0) {
+                ForEach(channelManager.channelOrder, id: \.self) { channel in
+                    if let vm = channelManager.channels[channel] {
+                        let stream = followedStreamStore.stream(forUserLogin: channel)
+                        let uid = stream?.userId ?? channel
+                        let name = stream?.userName ?? channel
+                        ChannelTabCell(
+                            viewModel: vm,
+                            isSelected: channel == channelManager.selectedChannel,
+                            displayName: name,
+                            profileImageUrl: profileImageStore.profileImageUrl(for: uid),
+                            userId: uid,
+                            onSelect: { channelManager.selectChannel(channel) },
+                            onClose: { Task { await channelManager.leaveChannel(channel) } }
+                        )
+                        .frame(width: Self.maxTabWidth)
+                    }
                 }
             }
+            // ScrollView 内でタブを底揃えにする
+            .frame(height: Self.height, alignment: .bottom)
         }
-        .padding(.horizontal, 4)
-        .frame(height: 36)
-        .background(.bar)
+        .frame(height: Self.height)
+        .background(Color(.windowBackgroundColor))
     }
 }

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -18,19 +18,18 @@ struct ChannelTabBar: View {
 
     /// 各タブの最大幅
     private static let maxTabWidth: CGFloat = 180
-    /// タブバー全体の高さ（アクティブタブは +1pt で Divider を隠す）
+    /// タブバー全体の高さ（アクティブタブは +2pt 分の余白を含む）
     static let height: CGFloat = ChannelTabCell.inactiveHeight + 2
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
                 ForEach(channelManager.channelOrder, id: \.self) { channel in
-                    if let vm = channelManager.channels[channel] {
+                    if channelManager.channels[channel] != nil {
                         let stream = followedStreamStore.stream(forUserLogin: channel)
                         let uid = stream?.userId ?? channel
                         let name = stream?.userName ?? channel
                         ChannelTabCell(
-                            viewModel: vm,
                             isSelected: channel == channelManager.selectedChannel,
                             displayName: name,
                             profileImageUrl: profileImageStore.profileImageUrl(for: uid),

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -1,0 +1,108 @@
+// ChannelTabCell.swift
+// チャンネルタブバーの個別タブセルビュー
+// ViewThatFits で「アイコン+名前+×」→「アイコン+×」→「アイコンのみ」の 3 段階で幅に応じて縮退する
+
+import SwiftUI
+
+/// チャンネルタブバーの 1 タブを表すセルビュー
+///
+/// - `ViewThatFits` により、利用可能な幅が狭い場合は自動的にコンパクト表示へ縮退する
+/// - アイコンには接続状態（緑/黄/赤/灰）の色付きボーダーを表示する
+/// - 選択中タブはアクセントカラーの薄い背景で強調する
+/// - × ボタンは選択中またはホバー時に表示し、押下で `onClose` を呼ぶ
+struct ChannelTabCell: View {
+
+    /// このタブに対応する ChatViewModel
+    let viewModel: ChatViewModel
+    /// このタブが選択中かどうか
+    let isSelected: Bool
+    /// タブに表示する名前（フォロー中は表示名、フォロー外は channelLogin）
+    let displayName: String
+    /// プロフィール画像 URL（nil の場合はプレースホルダーを表示）
+    let profileImageUrl: URL?
+    /// Twitch ユーザーID（プロフィール画像キャッシュのキー）
+    let userId: String
+    /// タブ選択時のコールバック
+    let onSelect: () -> Void
+    /// タブを閉じる（チャンネルから退出する）コールバック
+    let onClose: () -> Void
+
+    @State private var isHovered = false
+
+    // MARK: - 定数
+
+    private static let iconSize: CGFloat = 20
+    private static let closeIconSize: CGFloat = 7
+
+    var body: some View {
+        Button(action: onSelect) {
+            ViewThatFits(in: .horizontal) {
+                // フル表示: アイコン + 名前 + × ボタン
+                fullLabel
+                // 中間表示: アイコン + × ボタン
+                compactLabel
+                // 最小表示: アイコンのみ（ホバー/選択中に × オーバーレイ）
+                iconOnly
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+        .background(
+            isSelected ? Color.accentColor.opacity(0.15) : Color.clear,
+            in: RoundedRectangle(cornerRadius: 6)
+        )
+        .onHover { isHovered = $0 }
+    }
+
+    // MARK: - サブビュー
+
+    private var icon: some View {
+        ProfileImageView(userId: userId, imageUrl: profileImageUrl, size: Self.iconSize)
+            .overlay {
+                Circle()
+                    .strokeBorder(viewModel.connectionState.connectionColor, lineWidth: 2)
+            }
+    }
+
+    private var closeButton: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark")
+                .font(.system(size: Self.closeIconSize, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var fullLabel: some View {
+        HStack(spacing: 4) {
+            icon
+            Text(displayName)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(minWidth: 40)
+            closeButton
+        }
+    }
+
+    private var compactLabel: some View {
+        HStack(spacing: 4) {
+            icon
+            closeButton
+        }
+    }
+
+    private var iconOnly: some View {
+        icon
+            .overlay(alignment: .topTrailing) {
+                if isHovered || isSelected {
+                    closeButton
+                        .font(.system(size: Self.closeIconSize - 1))
+                        .padding(2)
+                        .background(Circle().fill(.bar))
+                        .offset(x: 4, y: -4)
+                }
+            }
+    }
+}

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -18,8 +18,8 @@ struct ChannelTabCell: View {
     let displayName: String
     /// プロフィール画像 URL（nil の場合はプレースホルダーを表示）
     let profileImageUrl: URL?
-    /// Twitch ユーザーID（プロフィール画像キャッシュのキー）
-    let userId: String
+    /// Twitch ユーザーID（プロフィール画像キャッシュのキー、nil の場合はプレースホルダーアイコンを表示）
+    let userId: String?
     /// タブ選択時のコールバック
     let onSelect: () -> Void
     /// タブを閉じる（チャンネルから退出する）コールバック
@@ -37,46 +37,58 @@ struct ChannelTabCell: View {
     private static let cornerRadius: CGFloat = 8
     /// タブの通常高さ（非アクティブ）
     static let inactiveHeight: CGFloat = 30
-    /// タブのアクティブ高さ（Divider を 1pt 隠すため +1）
+    /// タブのアクティブ高さ（非アクティブより +2pt 高く、タブバー下端まで広がる）
     static let activeHeight: CGFloat = 32
 
     var body: some View {
-        Button(action: onSelect) {
-            HStack(spacing: 5) {
-                // プロフィールアイコン
+        HStack(spacing: 5) {
+            // プロフィールアイコン（userId が nil の場合はプレースホルダーを表示）
+            if let userId {
                 ProfileImageView(userId: userId, imageUrl: profileImageUrl, size: Self.iconSize)
-
-                // チャンネル名（truncation あり）
-                Text(displayName)
-                    .font(.system(size: 12))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                Spacer(minLength: 0)
-
-                // × ボタン（選択中またはホバー時のみ表示）
-                if isSelected || isHovered {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: Self.closeIconSize, weight: .medium))
+            } else {
+                Circle()
+                    .fill(Color.secondary.opacity(0.3))
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: Self.iconSize * 0.5))
                             .foregroundStyle(.secondary)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("タブを閉じる")
-                    // × ボタンの幅を確保して他のタブの幅計算が安定するよう hidden で埋め
-                } else {
+                    .frame(width: Self.iconSize, height: Self.iconSize)
+            }
+
+            // チャンネル名（truncation あり）
+            Text(displayName)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 0)
+
+            // × ボタン（選択中またはホバー時のみ表示）
+            if isSelected || isHovered {
+                Button(action: onClose) {
                     Image(systemName: "xmark")
                         .font(.system(size: Self.closeIconSize, weight: .medium))
-                        .hidden()
+                        .foregroundStyle(.secondary)
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("タブを閉じる")
+                // × ボタンの幅を確保して他のタブの幅計算が安定するよう hidden で埋め
+            } else {
+                Image(systemName: "xmark")
+                    .font(.system(size: Self.closeIconSize, weight: .medium))
+                    .hidden()
             }
-            .padding(.horizontal, 8)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            // ラベル内に contentShape を置くことで空白部分も含めてクリック領域にする
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
-        // アクティブタブはコンテンツ領域と繋げるため 1pt 高くする
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // 空白部分も含めてクリック領域にする
+        .contentShape(Rectangle())
+        // タブ全体のタップでチャンネル選択（× ボタンとイベントが競合しない構造）
+        .onTapGesture(perform: onSelect)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction { onSelect() }
+        // アクティブタブはタブバー下端まで広がる
         .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)
         .frame(maxHeight: .infinity, alignment: .bottom)
         .background(alignment: .top) {

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -91,6 +91,10 @@ struct ChannelTabCell: View {
     // MARK: - タブ背景
 
     /// Chrome 風の上部角丸タブ形状の背景
+    ///
+    /// - アクティブタブ: `controlBackgroundColor`（チャット欄の背景色と一致）
+    /// - 非アクティブタブ: `windowBackgroundColor`（タブバー背景色と同じ＝目立たない）
+    ///   ホバー時は `controlBackgroundColor` に近づける
     private var tabBackground: some View {
         let shape = UnevenRoundedRectangle(
             topLeadingRadius: Self.cornerRadius,
@@ -100,16 +104,19 @@ struct ChannelTabCell: View {
         )
         return ZStack {
             if isSelected {
-                // アクティブタブ: コンテンツエリアと同じ背景色
+                // アクティブタブ: チャット欄（controlBackgroundColor）と同色
                 shape
-                    .fill(Color(.windowBackgroundColor))
+                    .fill(Color(.controlBackgroundColor))
                 // 上部・左右の細いボーダー
                 shape
                     .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
             } else {
-                // 非アクティブタブ: ホバー時に少し明るくする
+                // 非アクティブタブ: タブバー背景と同系色（windowBackgroundColor）
+                // ホバー時のみ少し明るくして存在を示す
                 shape
-                    .fill(Color(.windowBackgroundColor).opacity(isHovered ? 0.6 : 0.3))
+                    .fill(isHovered
+                          ? Color(.controlBackgroundColor).opacity(0.5)
+                          : Color(.windowBackgroundColor))
             }
         }
         .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -6,14 +6,12 @@ import SwiftUI
 
 /// チャンネルタブバーの 1 タブを表すセルビュー
 ///
-/// - アクティブタブは `windowBackgroundColor` でコンテンツエリアと同色になり「繋がって見える」
+/// - アクティブタブは `controlBackgroundColor` でコンテンツエリアと同色になり「繋がって見える」
 /// - 非アクティブタブは少し暗い背景色で区別する
 /// - `UnevenRoundedRectangle` で上部のみ角丸のタブ形状を実現する
 /// - × ボタンはホバー中または選択中のタブにのみ表示する
 struct ChannelTabCell: View {
 
-    /// このタブに対応する ChatViewModel
-    let viewModel: ChatViewModel
     /// このタブが選択中かどうか
     let isSelected: Bool
     /// タブに表示する名前（フォロー中は表示名、フォロー外は channelLogin）
@@ -64,6 +62,7 @@ struct ChannelTabCell: View {
                             .foregroundStyle(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("タブを閉じる")
                     // × ボタンの幅を確保して他のタブの幅計算が安定するよう hidden で埋め
                 } else {
                     Image(systemName: "xmark")

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -106,11 +106,9 @@ struct ChannelTabCell: View {
         return ZStack {
             if isSelected {
                 // アクティブタブ: チャット欄（controlBackgroundColor）と同色
+                // ボーダーなし（下端の線をなくしてコンテンツと繋げる）
                 shape
                     .fill(Color(.controlBackgroundColor))
-                // 上部・左右の細いボーダー
-                shape
-                    .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
             } else {
                 // 非アクティブタブ: 透明（タブバー背景に同化）
                 // ホバー時のみ薄い塗りで存在をほのめかす

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -92,9 +92,10 @@ struct ChannelTabCell: View {
 
     /// Chrome 風の上部角丸タブ形状の背景
     ///
-    /// - アクティブタブ: `controlBackgroundColor`（チャット欄の背景色と一致）
-    /// - 非アクティブタブ: `windowBackgroundColor`（タブバー背景色と同じ＝目立たない）
-    ///   ホバー時は `controlBackgroundColor` に近づける
+    /// - アクティブタブ: `controlBackgroundColor`（チャット欄の背景色と一致）で塗り、
+    ///   左右・上部に細いボーダーを付ける
+    /// - 非アクティブタブ: 塗りは透明（タブバー背景と完全に同化）にして目立たせない
+    ///   ホバー時のみ薄い塗りで存在を示す
     private var tabBackground: some View {
         let shape = UnevenRoundedRectangle(
             topLeadingRadius: Self.cornerRadius,
@@ -111,12 +112,10 @@ struct ChannelTabCell: View {
                 shape
                     .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
             } else {
-                // 非アクティブタブ: タブバー背景と同系色（windowBackgroundColor）
-                // ホバー時のみ少し明るくして存在を示す
+                // 非アクティブタブ: 透明（タブバー背景に同化）
+                // ホバー時のみ薄い塗りで存在をほのめかす
                 shape
-                    .fill(isHovered
-                          ? Color(.controlBackgroundColor).opacity(0.5)
-                          : Color(.windowBackgroundColor))
+                    .fill(Color.primary.opacity(isHovered ? 0.06 : 0))
             }
         }
         .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -73,9 +73,10 @@ struct ChannelTabCell: View {
             }
             .padding(.horizontal, 8)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // ラベル内に contentShape を置くことで空白部分も含めてクリック領域にする
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .contentShape(Rectangle())
         // アクティブタブはコンテンツ領域と繋げるため 1pt 高くする
         .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)
         .frame(maxHeight: .infinity, alignment: .bottom)

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -45,12 +45,8 @@ struct ChannelTabCell: View {
     var body: some View {
         Button(action: onSelect) {
             HStack(spacing: 5) {
-                // プロフィールアイコン + 接続状態ボーダー
+                // プロフィールアイコン
                 ProfileImageView(userId: userId, imageUrl: profileImageUrl, size: Self.iconSize)
-                    .overlay {
-                        Circle()
-                            .strokeBorder(viewModel.connectionState.connectionColor, lineWidth: 1.5)
-                    }
 
                 // チャンネル名（truncation あり）
                 Text(displayName)

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -1,15 +1,15 @@
 // ChannelTabCell.swift
 // チャンネルタブバーの個別タブセルビュー
-// ViewThatFits で「アイコン+名前+×」→「アイコン+×」→「アイコンのみ」の 3 段階で幅に応じて縮退する
+// Chrome スタイルのタブデザイン：上部角丸の形状、アクティブタブはコンテンツエリアと繋がる
 
 import SwiftUI
 
 /// チャンネルタブバーの 1 タブを表すセルビュー
 ///
-/// - `ViewThatFits` により、利用可能な幅が狭い場合は自動的にコンパクト表示へ縮退する
-/// - アイコンには接続状態（緑/黄/赤/灰）の色付きボーダーを表示する
-/// - 選択中タブはアクセントカラーの薄い背景で強調する
-/// - × ボタンは選択中またはホバー時に表示し、押下で `onClose` を呼ぶ
+/// - アクティブタブは `windowBackgroundColor` でコンテンツエリアと同色になり「繋がって見える」
+/// - 非アクティブタブは少し暗い背景色で区別する
+/// - `UnevenRoundedRectangle` で上部のみ角丸のタブ形状を実現する
+/// - × ボタンはホバー中または選択中のタブにのみ表示する
 struct ChannelTabCell: View {
 
     /// このタブに対応する ChatViewModel
@@ -31,78 +31,87 @@ struct ChannelTabCell: View {
 
     // MARK: - 定数
 
-    private static let iconSize: CGFloat = 20
+    /// アイコンサイズ（ポイント）
+    private static let iconSize: CGFloat = 16
+    /// × ボタンのアイコンサイズ（ポイント）
     private static let closeIconSize: CGFloat = 7
+    /// タブの上部角丸半径
+    private static let cornerRadius: CGFloat = 8
+    /// タブの通常高さ（非アクティブ）
+    static let inactiveHeight: CGFloat = 30
+    /// タブのアクティブ高さ（Divider を 1pt 隠すため +1）
+    static let activeHeight: CGFloat = 32
 
     var body: some View {
         Button(action: onSelect) {
-            ViewThatFits(in: .horizontal) {
-                // フル表示: アイコン + 名前 + × ボタン
-                fullLabel
-                // 中間表示: アイコン + × ボタン
-                compactLabel
-                // 最小表示: アイコンのみ（ホバー/選択中に × オーバーレイ）
-                iconOnly
+            HStack(spacing: 5) {
+                // プロフィールアイコン + 接続状態ボーダー
+                ProfileImageView(userId: userId, imageUrl: profileImageUrl, size: Self.iconSize)
+                    .overlay {
+                        Circle()
+                            .strokeBorder(viewModel.connectionState.connectionColor, lineWidth: 1.5)
+                    }
+
+                // チャンネル名（truncation あり）
+                Text(displayName)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 0)
+
+                // × ボタン（選択中またはホバー時のみ表示）
+                if isSelected || isHovered {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: Self.closeIconSize, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    // × ボタンの幅を確保して他のタブの幅計算が安定するよう hidden で埋め
+                } else {
+                    Image(systemName: "xmark")
+                        .font(.system(size: Self.closeIconSize, weight: .medium))
+                        .hidden()
+                }
             }
-            .padding(.horizontal, 6)
-            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .buttonStyle(.plain)
-        .background(
-            isSelected ? Color.accentColor.opacity(0.15) : Color.clear,
-            in: RoundedRectangle(cornerRadius: 6)
-        )
+        // アクティブタブはコンテンツ領域と繋げるため 1pt 高くする
+        .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)
+        .frame(maxHeight: .infinity, alignment: .bottom)
+        .background(alignment: .top) {
+            tabBackground
+        }
         .onHover { isHovered = $0 }
     }
 
-    // MARK: - サブビュー
+    // MARK: - タブ背景
 
-    private var icon: some View {
-        ProfileImageView(userId: userId, imageUrl: profileImageUrl, size: Self.iconSize)
-            .overlay {
-                Circle()
-                    .strokeBorder(viewModel.connectionState.connectionColor, lineWidth: 2)
+    /// Chrome 風の上部角丸タブ形状の背景
+    private var tabBackground: some View {
+        let shape = UnevenRoundedRectangle(
+            topLeadingRadius: Self.cornerRadius,
+            bottomLeadingRadius: 0,
+            bottomTrailingRadius: 0,
+            topTrailingRadius: Self.cornerRadius
+        )
+        return ZStack {
+            if isSelected {
+                // アクティブタブ: コンテンツエリアと同じ背景色
+                shape
+                    .fill(Color(.windowBackgroundColor))
+                // 上部・左右の細いボーダー
+                shape
+                    .strokeBorder(Color(.separatorColor), lineWidth: 0.5)
+            } else {
+                // 非アクティブタブ: ホバー時に少し明るくする
+                shape
+                    .fill(Color(.windowBackgroundColor).opacity(isHovered ? 0.6 : 0.3))
             }
-    }
-
-    private var closeButton: some View {
-        Button(action: onClose) {
-            Image(systemName: "xmark")
-                .font(.system(size: Self.closeIconSize, weight: .medium))
-                .foregroundStyle(.secondary)
         }
-        .buttonStyle(.plain)
-    }
-
-    private var fullLabel: some View {
-        HStack(spacing: 4) {
-            icon
-            Text(displayName)
-                .font(.system(size: 12))
-                .lineLimit(1)
-                .truncationMode(.tail)
-                .frame(minWidth: 40)
-            closeButton
-        }
-    }
-
-    private var compactLabel: some View {
-        HStack(spacing: 4) {
-            icon
-            closeButton
-        }
-    }
-
-    private var iconOnly: some View {
-        icon
-            .overlay(alignment: .topTrailing) {
-                if isHovered || isSelected {
-                    closeButton
-                        .font(.system(size: Self.closeIconSize - 1))
-                        .padding(2)
-                        .background(Circle().fill(.bar))
-                        .offset(x: 4, y: -4)
-                }
-            }
+        .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)
     }
 }

--- a/Sources/TwitchChat/Views/ChannelTabCell.swift
+++ b/Sources/TwitchChat/Views/ChannelTabCell.swift
@@ -75,6 +75,7 @@ struct ChannelTabCell: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .buttonStyle(.plain)
+        .contentShape(Rectangle())
         // アクティブタブはコンテンツ領域と繋げるため 1pt 高くする
         .frame(height: isSelected ? Self.activeHeight : Self.inactiveHeight)
         .frame(maxHeight: .infinity, alignment: .bottom)

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -26,6 +26,8 @@ struct ChatDetailView: View {
             // チャットメッセージリスト
             chatListView
         }
+        // タブバーのアクティブタブ色（controlBackgroundColor）と一致させる
+        .background(Color(.controlBackgroundColor))
     }
 
     /// チャットメッセージのスクロールビュー

--- a/Sources/TwitchChat/Views/ConnectedChannelIconStrip.swift
+++ b/Sources/TwitchChat/Views/ConnectedChannelIconStrip.swift
@@ -1,0 +1,106 @@
+// ConnectedChannelIconStrip.swift
+// 接続中チャンネルのプロフィールアイコンを横並び表示するビュー
+// サイドバーの「ライブ」セクション先頭に配置し、アイコンクリックで対応タブへフォーカスする
+
+import SwiftUI
+
+/// 接続中チャンネルのプロフィールアイコンを横並びで表示するストリップビュー
+///
+/// - 接続状態（connected/connecting/error/disconnected）に応じた色のボーダーをアイコンに表示する
+/// - 現在選択中のタブに対応するアイコンは、アクセントカラーの外側リングを重ねて強調する
+/// - フォロー外チャンネルの場合は `person.fill` プレースホルダーを表示する
+/// - アイコンをクリックすると `selectChannel` を呼び、対応するタブへフォーカスする
+struct ConnectedChannelIconStrip: View {
+
+    let channelManager: ChannelManager
+    let followedStreamStore: FollowedStreamStore
+    let profileImageStore: ProfileImageStore
+
+    /// アイコンサイズ（ポイント）
+    private static let iconSize: CGFloat = ProfileImageCache.displaySize
+    /// 接続状態ボーダーの幅（ポイント）
+    private static let borderWidth: CGFloat = 2
+    /// 選択中アイコンの外側リング幅（ポイント）
+    private static let selectedRingWidth: CGFloat = 2
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(channelManager.channelOrder, id: \.self) { channel in
+                    iconButton(for: channel)
+                }
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+
+    // MARK: - サブビュー
+
+    /// チャンネル 1 件分のアイコンボタン
+    @ViewBuilder
+    private func iconButton(for channel: String) -> some View {
+        let vm = channelManager.channels[channel]
+        let stream = followedStreamStore.stream(forUserLogin: channel)
+        let connectionColor = (vm?.connectionState ?? .disconnected).connectionColor
+        let isSelected = channelManager.selectedChannel == channel
+
+        Button {
+            channelManager.selectChannel(channel)
+        } label: {
+            channelIcon(
+                userId: stream?.userId,
+                imageUrl: stream.flatMap { profileImageStore.profileImageUrl(for: $0.userId) },
+                connectionColor: connectionColor,
+                isSelected: isSelected
+            )
+        }
+        .buttonStyle(.plain)
+        // フォロー外チャンネルの場合はチャンネル名をツールチップで表示
+        .help(stream?.userName ?? channel)
+    }
+
+    /// プロフィールアイコン（接続状態ボーダー + 選択中の外側リング）
+    ///
+    /// - Note: userId が nil の場合（フォロー外チャンネル）は ProfileImageCache を汚染しないよう、
+    ///   `ProfileImageView` を使わず `person.fill` プレースホルダーを直接描画する
+    @ViewBuilder
+    private func channelIcon(
+        userId: String?,
+        imageUrl: URL?,
+        connectionColor: Color,
+        isSelected: Bool
+    ) -> some View {
+        let size = Self.iconSize
+
+        Group {
+            if let userId {
+                ProfileImageView(userId: userId, imageUrl: imageUrl, size: size)
+            } else {
+                // フォロー外チャンネル: プレースホルダー
+                Circle()
+                    .fill(Color.secondary.opacity(0.3))
+                    .overlay {
+                        Image(systemName: "person.fill")
+                            .font(.system(size: size * 0.5))
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: size, height: size)
+            }
+        }
+        // 接続状態ボーダー（内側）
+        .overlay {
+            Circle()
+                .strokeBorder(connectionColor, lineWidth: Self.borderWidth)
+        }
+        // 選択中の場合、アクセントカラーの外側リングを追加
+        .overlay {
+            if isSelected {
+                Circle()
+                    .strokeBorder(Color.accentColor, lineWidth: Self.selectedRingWidth)
+                    .padding(-Self.borderWidth - Self.selectedRingWidth)
+            }
+        }
+        // 選択中の外側リング分のパディングを確保
+        .padding(isSelected ? Self.borderWidth + Self.selectedRingWidth : 0)
+    }
+}

--- a/Sources/TwitchChat/Views/ConnectionState+Color.swift
+++ b/Sources/TwitchChat/Views/ConnectionState+Color.swift
@@ -1,0 +1,22 @@
+// ConnectionState+Color.swift
+// ConnectionState に対応する表示色を提供する SwiftUI 拡張
+// タブバーやサイドバーアイコンの接続状態ボーダー色の一元管理
+
+import SwiftUI
+
+extension ConnectionState {
+    /// 接続状態を表す色
+    ///
+    /// - connected: 緑（接続済み）
+    /// - connecting: 黄（接続中）
+    /// - error: 赤（エラー）
+    /// - disconnected: グレー（未接続）
+    var connectionColor: Color {
+        switch self {
+        case .connected: .green
+        case .connecting: .yellow
+        case .error: .red
+        case .disconnected: .gray
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -10,8 +10,7 @@ import SwiftUI
 /// - サイドバー: フォロー中ライブ一覧（接続中は先頭）（SidebarView）
 /// - 詳細ペイン:
 ///   - タブバー（接続中チャンネルをタブで切り替え、Chrome スタイル）
-///   - 下部の Divider（アクティブタブが 1pt 覆うことでコンテンツと繋がって見える）
-///   - 選択チャンネルのチャット本体
+///   - 選択チャンネルのチャット本体（未選択時はプレースホルダーを表示）
 struct ContentView: View {
     var authState: AuthState
     var channelManager: ChannelManager

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -7,9 +7,9 @@ import SwiftUI
 /// アプリのメインコンテンツビュー
 ///
 /// レイアウト:
-/// - サイドバー: フォロー中ライブ一覧 + 接続中チャンネル一覧（SidebarView）
-/// - 詳細ペイン: 選択中チャンネルのチャットメッセージ（ChatDetailView）
-/// - 未選択時: プレースホルダーを表示
+/// - サイドバー: フォロー中ライブ一覧 + 接続中アイコン横並び（SidebarView）
+/// - 詳細ペイン: タブバー（接続中チャンネルをタブで切り替え）+ 選択チャンネルのチャット
+/// - 未接続時: プレースホルダーを表示
 struct ContentView: View {
     var authState: AuthState
     var channelManager: ChannelManager
@@ -26,13 +26,27 @@ struct ContentView: View {
             )
             .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
         } detail: {
-            if let viewModel = channelManager.selectedViewModel {
-                ChatDetailView(viewModel: viewModel)
-            } else {
-                Text("チャンネルを選択するか、ライブ中のストリーマーをクリックしてチャットを開始してください")
-                    .multilineTextAlignment(.center)
-                    .foregroundStyle(.secondary)
-                    .padding()
+            VStack(spacing: 0) {
+                // タブバー: 接続中チャンネルがある場合のみ表示
+                if !channelManager.channelOrder.isEmpty {
+                    ChannelTabBar(
+                        channelManager: channelManager,
+                        followedStreamStore: followedStreamStore,
+                        profileImageStore: profileImageStore
+                    )
+                    Divider()
+                }
+                // チャット本体: 選択中チャンネルのチャット、未選択時はプレースホルダー
+                if let viewModel = channelManager.selectedViewModel {
+                    ChatDetailView(viewModel: viewModel)
+                } else {
+                    Spacer()
+                    Text("チャンネルを選択するか、ライブ中のストリーマーをクリックしてチャットを開始してください")
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.secondary)
+                        .padding()
+                    Spacer()
+                }
             }
         }
         .frame(minWidth: 600, minHeight: 400)

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -7,9 +7,11 @@ import SwiftUI
 /// アプリのメインコンテンツビュー
 ///
 /// レイアウト:
-/// - サイドバー: フォロー中ライブ一覧 + 接続中アイコン横並び（SidebarView）
-/// - 詳細ペイン: タブバー（接続中チャンネルをタブで切り替え）+ 選択チャンネルのチャット
-/// - 未接続時: プレースホルダーを表示
+/// - サイドバー: フォロー中ライブ一覧（接続中は先頭）（SidebarView）
+/// - 詳細ペイン:
+///   - タブバー（接続中チャンネルをタブで切り替え、Chrome スタイル）
+///   - 下部の Divider（アクティブタブが 1pt 覆うことでコンテンツと繋がって見える）
+///   - 選択チャンネルのチャット本体
 struct ContentView: View {
     var authState: AuthState
     var channelManager: ChannelManager
@@ -27,15 +29,23 @@ struct ContentView: View {
             .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 320)
         } detail: {
             VStack(spacing: 0) {
-                // タブバー: 接続中チャンネルがある場合のみ表示
                 if !channelManager.channelOrder.isEmpty {
-                    ChannelTabBar(
-                        channelManager: channelManager,
-                        followedStreamStore: followedStreamStore,
-                        profileImageStore: profileImageStore
-                    )
-                    Divider()
+                    // ZStack でタブバーと Divider を重ねる
+                    // アクティブタブが activeHeight (inactiveHeight + 2) になるため
+                    // Divider の 1pt を覆い、コンテンツエリアと繋がって見える
+                    ZStack(alignment: .bottom) {
+                        ChannelTabBar(
+                            channelManager: channelManager,
+                            followedStreamStore: followedStreamStore,
+                            profileImageStore: profileImageStore
+                        )
+                        Rectangle()
+                            .fill(Color(.separatorColor))
+                            .frame(height: 1)
+                    }
+                    .frame(height: ChannelTabBar.height)
                 }
+
                 // チャット本体: 選択中チャンネルのチャット、未選択時はプレースホルダー
                 if let viewModel = channelManager.selectedViewModel {
                     ChatDetailView(viewModel: viewModel)

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -41,12 +41,11 @@ struct ContentView: View {
                 if let viewModel = channelManager.selectedViewModel {
                     ChatDetailView(viewModel: viewModel)
                 } else {
-                    Spacer()
                     Text("チャンネルを選択するか、ライブ中のストリーマーをクリックしてチャットを開始してください")
                         .multilineTextAlignment(.center)
                         .foregroundStyle(.secondary)
                         .padding()
-                    Spacer()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
         }

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -30,20 +30,11 @@ struct ContentView: View {
         } detail: {
             VStack(spacing: 0) {
                 if !channelManager.channelOrder.isEmpty {
-                    // ZStack でタブバーと Divider を重ねる
-                    // アクティブタブが activeHeight (inactiveHeight + 2) になるため
-                    // Divider の 1pt を覆い、コンテンツエリアと繋がって見える
-                    ZStack(alignment: .bottom) {
-                        ChannelTabBar(
-                            channelManager: channelManager,
-                            followedStreamStore: followedStreamStore,
-                            profileImageStore: profileImageStore
-                        )
-                        Rectangle()
-                            .fill(Color(.separatorColor))
-                            .frame(height: 1)
-                    }
-                    .frame(height: ChannelTabBar.height)
+                    ChannelTabBar(
+                        channelManager: channelManager,
+                        followedStreamStore: followedStreamStore,
+                        profileImageStore: profileImageStore
+                    )
                 }
 
                 // チャット本体: 選択中チャンネルのチャット、未選択時はプレースホルダー

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -1,6 +1,6 @@
 // SidebarView.swift
 // サイドバービュー
-// フォロー中の配信中ストリーマー一覧と、接続中チャンネルのアイコン横並びを表示する
+// フォロー中の配信中ストリーマー一覧を表示する（接続中チャンネルは先頭に並ぶ）
 
 import SwiftUI
 
@@ -8,8 +8,8 @@ import SwiftUI
 ///
 /// セクション構成:
 /// - ヘッダー: ログイン状態表示（LoginView）
-/// - 「ライブ」: 接続中チャンネルのアイコン横並び + フォロー中の配信中ストリーマー一覧
-///   - 接続中チャンネルはリストから除外し、アイコンストリップのみで表示する
+/// - 「ライブ」: フォロー中の配信中ストリーマー一覧
+///   - 接続中チャンネルはリスト先頭に表示し、選択中タブと選択状態が連動する
 struct SidebarView: View {
     var authState: AuthState
     var channelManager: ChannelManager
@@ -37,18 +37,6 @@ struct SidebarView: View {
 
             // フォロー中ライブセクション
             Section {
-                // 接続中チャンネルのアイコン横並び（セクション先頭に表示）
-                if !channelManager.channelOrder.isEmpty {
-                    ConnectedChannelIconStrip(
-                        channelManager: channelManager,
-                        followedStreamStore: followedStreamStore,
-                        profileImageStore: profileImageStore
-                    )
-                    .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
-                    .listRowBackground(Color.clear)
-                    .selectionDisabled(true)
-                }
-
                 if authState.status == .unknown {
                     ProgressView()
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -70,9 +58,16 @@ struct SidebarView: View {
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
                 } else {
-                    // 接続中チャンネルはアイコンストリップで表示済みのため、ライブリストから除外する
-                    let connectedChannels = Set(channelManager.channelOrder)
-                    ForEach(followedStreamStore.streams.filter { !connectedChannels.contains($0.userLogin.lowercased()) }) { stream in
+                    // 接続中チャンネルを先頭に並べる（安定ソートで元の順序を維持）
+                    let connectedSet = Set(channelManager.channelOrder)
+                    let sortedStreams = followedStreamStore.streams.sorted { a, b in
+                        let aConnected = connectedSet.contains(a.userLogin.lowercased())
+                        let bConnected = connectedSet.contains(b.userLogin.lowercased())
+                        if aConnected && !bConnected { return true }
+                        if !aConnected && bConnected { return false }
+                        return false  // 同じグループ内は元の順序を維持（Swift の sort は安定）
+                    }
+                    ForEach(sortedStreams) { stream in
                         StreamRow(stream: stream, profileImageStore: profileImageStore)
                             .tag(stream.userLogin)
                     }
@@ -93,7 +88,6 @@ struct SidebarView: View {
         }
         .listStyle(.sidebar)
         // ストリーム一覧が更新されたら新しい配信者のプロフィール画像を取得する
-        // （fetchUsers は取得済みユーザーを内部でフィルタリングするため重複APIコールは発生しない）
         .onChange(of: followedStreamStore.streams) { _, streams in
             let userIds = streams.map(\.userId)
             Task { await profileImageStore.fetchUsers(userIds: userIds) }

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -58,15 +58,15 @@ struct SidebarView: View {
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
                 } else {
-                    // 接続中チャンネルを先頭に並べる（安定ソートで元の順序を維持）
+                    // 接続中チャンネルを先頭に並べる（各グループ内は元の順序を維持）
                     let connectedSet = Set(channelManager.channelOrder)
-                    let sortedStreams = followedStreamStore.streams.sorted { a, b in
-                        let aConnected = connectedSet.contains(a.userLogin.lowercased())
-                        let bConnected = connectedSet.contains(b.userLogin.lowercased())
-                        if aConnected && !bConnected { return true }
-                        if !aConnected && bConnected { return false }
-                        return false  // 同じグループ内は元の順序を維持（Swift の sort は安定）
+                    let connectedStreams = followedStreamStore.streams.filter {
+                        connectedSet.contains($0.userLogin.lowercased())
                     }
+                    let otherStreams = followedStreamStore.streams.filter {
+                        !connectedSet.contains($0.userLogin.lowercased())
+                    }
+                    let sortedStreams = connectedStreams + otherStreams
                     ForEach(sortedStreams) { stream in
                         StreamRow(stream: stream, profileImageStore: profileImageStore)
                             .tag(stream.userLogin)

--- a/Sources/TwitchChat/Views/SidebarView.swift
+++ b/Sources/TwitchChat/Views/SidebarView.swift
@@ -1,6 +1,6 @@
 // SidebarView.swift
 // サイドバービュー
-// フォロー中の配信中ストリーマー一覧と接続中チャンネル一覧を表示する
+// フォロー中の配信中ストリーマー一覧と、接続中チャンネルのアイコン横並びを表示する
 
 import SwiftUI
 
@@ -8,8 +8,8 @@ import SwiftUI
 ///
 /// セクション構成:
 /// - ヘッダー: ログイン状態表示（LoginView）
-/// - 「接続中」: 現在接続しているチャンネルの一覧（コンテキストメニューで切断可能）
-/// - 「ライブ」: フォロー中の配信中ストリーマー一覧（選択でチャット接続）
+/// - 「ライブ」: 接続中チャンネルのアイコン横並び + フォロー中の配信中ストリーマー一覧
+///   - 接続中チャンネルはリストから除外し、アイコンストリップのみで表示する
 struct SidebarView: View {
     var authState: AuthState
     var channelManager: ChannelManager
@@ -20,7 +20,12 @@ struct SidebarView: View {
         List(selection: Binding(
             get: { channelManager.selectedChannel },
             set: { newValue in
-                if let channel = newValue {
+                guard let channel = newValue else { return }
+                if channelManager.isJoined(channel) {
+                    // 既接続: 選択のみ切り替え（再接続させない）
+                    channelManager.selectChannel(channel)
+                } else {
+                    // 未接続: 新規接続
                     Task { await channelManager.joinChannel(channel) }
                 }
             }
@@ -30,18 +35,20 @@ struct SidebarView: View {
                 .listRowInsets(EdgeInsets())
                 .listRowBackground(Color.clear)
 
-            // 接続中チャンネルセクション
-            if !channelManager.channelOrder.isEmpty {
-                Section("接続中") {
-                    ForEach(channelManager.channelOrder, id: \.self) { channel in
-                        connectedChannelRow(channel: channel)
-                            .tag(channel)
-                    }
-                }
-            }
-
             // フォロー中ライブセクション
             Section {
+                // 接続中チャンネルのアイコン横並び（セクション先頭に表示）
+                if !channelManager.channelOrder.isEmpty {
+                    ConnectedChannelIconStrip(
+                        channelManager: channelManager,
+                        followedStreamStore: followedStreamStore,
+                        profileImageStore: profileImageStore
+                    )
+                    .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+                    .listRowBackground(Color.clear)
+                    .selectionDisabled(true)
+                }
+
                 if authState.status == .unknown {
                     ProgressView()
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -63,8 +70,7 @@ struct SidebarView: View {
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
                 } else {
-                    // 接続中チャンネルはライブリストから除外（接続中セクションに移動済みのため）
-                    // Set を事前構築して O(n*m) → O(n) に最適化
+                    // 接続中チャンネルはアイコンストリップで表示済みのため、ライブリストから除外する
                     let connectedChannels = Set(channelManager.channelOrder)
                     ForEach(followedStreamStore.streams.filter { !connectedChannels.contains($0.userLogin.lowercased()) }) { stream in
                         StreamRow(stream: stream, profileImageStore: profileImageStore)
@@ -102,64 +108,6 @@ struct SidebarView: View {
             if let userId = authState.userId {
                 await profileImageStore.fetchUsers(userIds: [userId])
             }
-        }
-    }
-
-    /// 接続中チャンネルの行（コンテキストメニューで切断可能）
-    ///
-    /// FollowedStreamStore からプロフィール情報を引き、プロフィールアイコン＋接続状態ボーダーで表示する。
-    /// フォロー外のチャンネルの場合はプレースホルダーアイコンを表示する。
-    @ViewBuilder
-    private func connectedChannelRow(channel: String) -> some View {
-        let vm = channelManager.channels[channel]
-        let stream = followedStreamStore.stream(forUserLogin: channel)
-        let connectionColor = connectionColor(for: vm?.connectionState ?? .disconnected)
-        HStack(spacing: 8) {
-            // プロフィールアイコン + 接続状態ボーダー
-            // userId が nil（フォロー外チャンネル）の場合は ProfileImageCache を汚染しないようプレースホルダーを直接描画する
-            if let userId = stream?.userId {
-                ProfileImageView(
-                    userId: userId,
-                    imageUrl: profileImageStore.profileImageUrl(for: userId)
-                )
-                .overlay(
-                    Circle()
-                        .strokeBorder(connectionColor, lineWidth: 2)
-                )
-            } else {
-                Circle()
-                    .fill(Color.secondary.opacity(0.3))
-                    .overlay {
-                        Image(systemName: "person.fill")
-                            .font(.system(size: ProfileImageCache.displaySize * 0.5))
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(width: ProfileImageCache.displaySize, height: ProfileImageCache.displaySize)
-                    .overlay(
-                        Circle()
-                            .strokeBorder(connectionColor, lineWidth: 2)
-                    )
-            }
-            Text(stream?.userName ?? channel)
-                .font(.body)
-                .lineLimit(1)
-            Spacer()
-        }
-        .padding(.vertical, 2)
-        .contextMenu {
-            Button("切断", role: .destructive) {
-                Task { await channelManager.leaveChannel(channel) }
-            }
-        }
-    }
-
-    /// 接続状態に対応する色を返す
-    private func connectionColor(for state: ConnectionState) -> Color {
-        switch state {
-        case .connected: return .green
-        case .connecting: return .yellow
-        case .error: return .red
-        case .disconnected: return .gray
         }
     }
 }

--- a/Tests/TwitchChatTests/ChannelDisplayNameResolverTests.swift
+++ b/Tests/TwitchChatTests/ChannelDisplayNameResolverTests.swift
@@ -22,7 +22,7 @@ struct ChannelDisplayNameResolverTests {
         viewerCount: Int = 500
     ) -> HelixFollowedStreamData {
         HelixFollowedStreamData(
-            id: UUID().uuidString,
+            id: "test-stream-id-1",
             userId: userId,
             userLogin: userLogin,
             userName: userName,
@@ -50,7 +50,7 @@ struct ChannelDisplayNameResolverTests {
     // MARK: - テスト
 
     @Test("フォロー中ストリームがある場合、userName を返す")
-    func testDisplayNameReturnsUserNameForFollowedStream() async throws {
+    func testDisplayNameReturnsUserNameForFollowedStream() async {
         // 前提: "yamada_game" チャンネルがフォロー中でライブ中
         let store = await makeStore(streams: [
             makeHelixStream(userLogin: "yamada_game", userName: "山田太郎")
@@ -62,7 +62,7 @@ struct ChannelDisplayNameResolverTests {
     }
 
     @Test("フォロー外チャンネルの場合、channelLogin をそのまま返す")
-    func testDisplayNameReturnsChannelLoginForUnfollowedChannel() async throws {
+    func testDisplayNameReturnsChannelLoginForUnfollowedChannel() async {
         // 前提: ストリームなし（フォロー外または未ライブ）
         let store = await makeStore(streams: [])
         let resolver = ChannelDisplayNameResolver(store: store)
@@ -72,7 +72,7 @@ struct ChannelDisplayNameResolverTests {
     }
 
     @Test("大文字混在の channelLogin も正規化して解決される")
-    func testDisplayNameNormalizesChannelLogin() async throws {
+    func testDisplayNameNormalizesChannelLogin() async {
         // 前提: "suzuki_live" チャンネルがフォロー中でライブ中（小文字で登録）
         let store = await makeStore(streams: [
             makeHelixStream(userLogin: "suzuki_live", userName: "鈴木次郎")

--- a/Tests/TwitchChatTests/ChannelDisplayNameResolverTests.swift
+++ b/Tests/TwitchChatTests/ChannelDisplayNameResolverTests.swift
@@ -1,0 +1,85 @@
+// ChannelDisplayNameResolverTests.swift
+// ChannelDisplayNameResolver の単体テスト
+// FollowedStreamStore のデータを使ったチャンネル表示名解決ロジックを検証する
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("ChannelDisplayNameResolver テスト")
+@MainActor
+struct ChannelDisplayNameResolverTests {
+
+    // MARK: - テストヘルパー
+
+    /// テスト用の HelixFollowedStreamData を生成する
+    private func makeHelixStream(
+        userId: String = "111111",
+        userLogin: String = "yamada_game",
+        userName: String = "山田太郎",
+        gameName: String = "マインクラフト",
+        title: String = "毎日配信中！",
+        viewerCount: Int = 500
+    ) -> HelixFollowedStreamData {
+        HelixFollowedStreamData(
+            id: UUID().uuidString,
+            userId: userId,
+            userLogin: userLogin,
+            userName: userName,
+            gameId: "9999",
+            gameName: gameName,
+            type: "live",
+            title: title,
+            viewerCount: viewerCount,
+            startedAt: "2024-01-01T00:00:00Z",
+            language: "ja",
+            thumbnailUrl: "https://example.com/thumb.jpg",
+            isMature: false
+        )
+    }
+
+    /// テスト用の FollowedStreamStore を作成してデータをセットアップする
+    private func makeStore(streams: [HelixFollowedStreamData]) async -> FollowedStreamStore {
+        let mockClient = MockFollowedStreamAPIClient()
+        await mockClient.updateStreams(streams)
+        let store = FollowedStreamStore(apiClient: mockClient, userId: "テスト用ユーザーID")
+        await store.refresh()
+        return store
+    }
+
+    // MARK: - テスト
+
+    @Test("フォロー中ストリームがある場合、userName を返す")
+    func testDisplayNameReturnsUserNameForFollowedStream() async throws {
+        // 前提: "yamada_game" チャンネルがフォロー中でライブ中
+        let store = await makeStore(streams: [
+            makeHelixStream(userLogin: "yamada_game", userName: "山田太郎")
+        ])
+        let resolver = ChannelDisplayNameResolver(store: store)
+
+        // フォロー中の配信者は表示名（userName）が返ること
+        #expect(resolver.displayName(for: "yamada_game") == "山田太郎")
+    }
+
+    @Test("フォロー外チャンネルの場合、channelLogin をそのまま返す")
+    func testDisplayNameReturnsChannelLoginForUnfollowedChannel() async throws {
+        // 前提: ストリームなし（フォロー外または未ライブ）
+        let store = await makeStore(streams: [])
+        let resolver = ChannelDisplayNameResolver(store: store)
+
+        // フォロー外チャンネルは channelLogin がそのまま返ること
+        #expect(resolver.displayName(for: "unknown_channel") == "unknown_channel")
+    }
+
+    @Test("大文字混在の channelLogin も正規化して解決される")
+    func testDisplayNameNormalizesChannelLogin() async throws {
+        // 前提: "suzuki_live" チャンネルがフォロー中でライブ中（小文字で登録）
+        let store = await makeStore(streams: [
+            makeHelixStream(userLogin: "suzuki_live", userName: "鈴木次郎")
+        ])
+        let resolver = ChannelDisplayNameResolver(store: store)
+
+        // 大文字混在で渡しても userName が返ること（FollowedStreamStore が小文字正規化済み）
+        #expect(resolver.displayName(for: "Suzuki_Live") == "鈴木次郎")
+    }
+}

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -125,4 +125,125 @@ struct ChannelManagerTests {
         #expect(manager.channelOrder.isEmpty)
         #expect(manager.selectedChannel == nil)
     }
+
+    @Test("選択中チャンネルを退出すると直前のチャンネルが選択される")
+    func testLeaveSelectedChannelFallsBackToPreviousChannel() async throws {
+        // 2チャンネル接続中にhaishinsha2（選択中）を退出すると、haishinsha1が選択される
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(manager.selectedChannel == "haishinsha2")
+
+        await manager.leaveChannel("haishinsha2")
+
+        #expect(manager.selectedChannel == "haishinsha1")
+        #expect(manager.channels.count == 1)
+    }
+
+    // MARK: - selectChannel / isJoined
+
+    @Test("selectChannel で未接続チャンネルを指定しても selectedChannel は変化しない")
+    func testSelectChannelIgnoresNonJoined() {
+        // 前提: どのチャンネルにも接続していない
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+
+        // 未接続チャンネルを selectChannel しても selectedChannel は nil のまま
+        manager.selectChannel("みんなの配信者")
+        #expect(manager.selectedChannel == nil)
+    }
+
+    @Test("selectChannel で既接続チャンネルに切り替えられる")
+    func testSelectChannelSwitchesSelection() async throws {
+        // 前提: haishinsha1 と haishinsha2 の 2 チャンネルに接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // haishinsha2 が選択中のときに haishinsha1 を selectChannel する
+        #expect(manager.selectedChannel == "haishinsha2")
+        manager.selectChannel("haishinsha1")
+
+        // channels の数は変化せず、selectedChannel だけ切り替わること
+        #expect(manager.selectedChannel == "haishinsha1")
+        #expect(manager.channels.count == 2)
+    }
+
+    @Test("selectChannel を呼んでも IRC クライアントの connect は再発火しない")
+    func testSelectChannelDoesNotReconnect() async throws {
+        // 前提: haishinsha1 と haishinsha2 に接続済み
+        var mockClients: [MockTwitchIRCClient] = []
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: {
+            let client = MockTwitchIRCClient()
+            mockClients.append(client)
+            return client
+        })
+
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // この時点での各クライアントの接続呼び出し回数を取得
+        let countsBefore = await withTaskGroup(of: Int.self) { group in
+            for client in mockClients {
+                group.addTask { await client.connectCallCount }
+            }
+            var results: [Int] = []
+            for await count in group { results.append(count) }
+            return results
+        }
+
+        // selectChannel を呼ぶ（再接続が走らないことを検証）
+        manager.selectChannel("haishinsha1")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // connect の呼び出し回数が増えていないこと
+        let countsAfter = await withTaskGroup(of: Int.self) { group in
+            for client in mockClients {
+                group.addTask { await client.connectCallCount }
+            }
+            var results: [Int] = []
+            for await count in group { results.append(count) }
+            return results
+        }
+
+        #expect(countsBefore.reduce(0, +) == countsAfter.reduce(0, +))
+    }
+
+    @Test("isJoined は接続中のチャンネルに true を返す")
+    func testIsJoinedReturnsTrueForJoinedChannel() async throws {
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+
+        await manager.joinChannel("haishinsha_yamada")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(manager.isJoined("haishinsha_yamada") == true)
+    }
+
+    @Test("isJoined は未接続のチャンネルに false を返す")
+    func testIsJoinedReturnsFalseForNonJoinedChannel() {
+        let manager = ChannelManager(authState: AuthState())
+
+        #expect(manager.isJoined("未接続チャンネル") == false)
+    }
+
+    @Test("selectChannel と isJoined は大文字混在のチャンネル名を正規化して扱う")
+    func testSelectChannelAndIsJoinedNormalizesChannelName() async throws {
+        // 前提: 小文字 "nintendojp" で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+
+        await manager.joinChannel("nintendojp")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 大文字混在で isJoined を呼んでも true が返ること
+        #expect(manager.isJoined("NintendoJP") == true)
+
+        // 大文字混在で selectChannel を呼んでも selectedChannel が正規化された名前に切り替わること
+        manager.selectChannel("NintendoJP")
+        #expect(manager.selectedChannel == "nintendojp")
+    }
 }

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -25,12 +25,11 @@ struct ChannelManagerTests {
     // MARK: - チャンネル参加
 
     @Test("joinChannel で新しいチャンネルに接続できる")
-    func testJoinNewChannel() async throws {
+    func testJoinNewChannel() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         // チャンネル名は小文字なので正規化しても変わらない
         await manager.joinChannel("haishinsha1")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(manager.channels.count == 1)
         #expect(manager.channelOrder == ["haishinsha1"])
@@ -39,12 +38,11 @@ struct ChannelManagerTests {
     }
 
     @Test("複数チャンネルに同時接続できる")
-    func testJoinMultipleChannels() async throws {
+    func testJoinMultipleChannels() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         // 両チャンネルが接続中であること
         #expect(manager.channels.count == 2)
@@ -55,12 +53,11 @@ struct ChannelManagerTests {
     }
 
     @Test("joinChannel は既存チャンネルへの再参加時に選択のみ切り替える")
-    func testJoinExistingChannelSwitchesSelection() async throws {
+    func testJoinExistingChannelSwitchesSelection() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         // haishinsha1 を再度 join → 接続数は増えず選択が切り替わること
         await manager.joinChannel("haishinsha1")
@@ -69,12 +66,11 @@ struct ChannelManagerTests {
     }
 
     @Test("チャンネル名は小文字に正規化される")
-    func testChannelNameNormalized() async throws {
+    func testChannelNameNormalized() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         // 大文字混じりの名前を渡しても小文字で管理される
         await manager.joinChannel("NintendoJP")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(manager.channels["nintendojp"] != nil)
         #expect(manager.selectedChannel == "nintendojp")
@@ -83,12 +79,11 @@ struct ChannelManagerTests {
     // MARK: - チャンネル退出
 
     @Test("leaveChannel で接続を切断してリストから削除される")
-    func testLeaveChannel() async throws {
+    func testLeaveChannel() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         await manager.leaveChannel("haishinsha1")
 
@@ -98,11 +93,10 @@ struct ChannelManagerTests {
     }
 
     @Test("選択中のチャンネルを退出すると選択が解除される")
-    func testLeaveSelectedChannelClearsSelection() async throws {
+    func testLeaveSelectedChannelClearsSelection() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         await manager.leaveChannel("haishinsha1")
 
@@ -111,13 +105,12 @@ struct ChannelManagerTests {
     }
 
     @Test("disconnectAll で全チャンネルが切断される")
-    func testDisconnectAll() async throws {
+    func testDisconnectAll() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
         await manager.joinChannel("haishinsha3")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         await manager.disconnectAll()
 
@@ -127,13 +120,12 @@ struct ChannelManagerTests {
     }
 
     @Test("選択中チャンネルを退出すると直前のチャンネルが選択される")
-    func testLeaveSelectedChannelFallsBackToPreviousChannel() async throws {
+    func testLeaveSelectedChannelFallsBackToPreviousChannel() async {
         // 2チャンネル接続中にhaishinsha2（選択中）を退出すると、haishinsha1が選択される
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(manager.selectedChannel == "haishinsha2")
 
@@ -156,13 +148,12 @@ struct ChannelManagerTests {
     }
 
     @Test("selectChannel で既接続チャンネルに切り替えられる")
-    func testSelectChannelSwitchesSelection() async throws {
+    func testSelectChannelSwitchesSelection() async {
         // 前提: haishinsha1 と haishinsha2 の 2 チャンネルに接続済み
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         // haishinsha2 が選択中のときに haishinsha1 を selectChannel する
         #expect(manager.selectedChannel == "haishinsha2")
@@ -185,6 +176,7 @@ struct ChannelManagerTests {
 
         await manager.joinChannel("haishinsha1")
         await manager.joinChannel("haishinsha2")
+        // バックグラウンド Task（connect）の完了を待つ
         try await Task.sleep(nanoseconds: 50_000_000)
 
         // この時点での各クライアントの接続呼び出し回数を取得
@@ -198,8 +190,8 @@ struct ChannelManagerTests {
         }
 
         // selectChannel を呼ぶ（再接続が走らないことを検証）
+        // selectChannel は同期的で新しい Task を生成しないため、追加の sleep は不要
         manager.selectChannel("haishinsha1")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         // connect の呼び出し回数が増えていないこと
         let countsAfter = await withTaskGroup(of: Int.self) { group in
@@ -215,11 +207,10 @@ struct ChannelManagerTests {
     }
 
     @Test("isJoined は接続中のチャンネルに true を返す")
-    func testIsJoinedReturnsTrueForJoinedChannel() async throws {
+    func testIsJoinedReturnsTrueForJoinedChannel() async {
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("haishinsha_yamada")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         #expect(manager.isJoined("haishinsha_yamada") == true)
     }
@@ -232,12 +223,11 @@ struct ChannelManagerTests {
     }
 
     @Test("selectChannel と isJoined は大文字混在のチャンネル名を正規化して扱う")
-    func testSelectChannelAndIsJoinedNormalizesChannelName() async throws {
+    func testSelectChannelAndIsJoinedNormalizesChannelName() async {
         // 前提: 小文字 "nintendojp" で接続済み
         let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
 
         await manager.joinChannel("nintendojp")
-        try await Task.sleep(nanoseconds: 50_000_000)
 
         // 大文字混在で isJoined を呼んでも true が返ること
         #expect(manager.isJoined("NintendoJP") == true)

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -12,6 +12,8 @@ import Testing
 actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     private(set) var connectedChannel: String?
     private(set) var disconnectCalled = false
+    /// connect() が呼ばれた回数（selectChannel での再接続がないことを検証するために使用）
+    private(set) var connectCallCount = 0
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
     let messageStream: AsyncStream<ChatMessage>
 
@@ -22,6 +24,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     }
 
     func connect(to channel: String, accessToken: String?, userLogin: String?) async throws {
+        connectCallCount += 1
         connectedChannel = channel
     }
 


### PR DESCRIPTION
## Summary

- サイドバーから配信者を選択するとタブでチャットが開くように変更（複数チャンネル同時表示対応）
- Chrome スタイルのタブデザインを実装（アクティブタブとコンテンツエリアが視覚的に繋がる）
- サイドバーの「接続中」セクションを廃止し、ライブリスト先頭に接続中チャンネルを表示
- タブ全体がクリック領域（`contentShape(Rectangle())`）
- `ChannelManager` に `selectChannel(_:)` / `isJoined(_:)` API を追加（TDD）
- `ChannelDisplayNameResolver` を新規追加してフォロー中チャンネルの表示名解決を分離

## Changes

- `Sources/TwitchChat/ViewModels/ChannelManager.swift` — `selectChannel`/`isJoined` 追加
- `Sources/TwitchChat/ViewModels/ChannelDisplayNameResolver.swift` — 新規
- `Sources/TwitchChat/Views/ChannelTabBar.swift` — 新規
- `Sources/TwitchChat/Views/ChannelTabCell.swift` — 新規
- `Sources/TwitchChat/Views/ContentView.swift` — タブバー統合
- `Sources/TwitchChat/Views/SidebarView.swift` — 接続中セクション廃止・リストソート
- `Sources/TwitchChat/Views/ChatDetailView.swift` — 背景色修正
- `Tests/TwitchChatTests/ChannelManagerTests.swift` — 新規テスト追加
- `Tests/TwitchChatTests/ChannelDisplayNameResolverTests.swift` — 新規

## Test plan

- [x] `swift build` — Build complete（警告ゼロ）
- [x] `swift test` — 149 tests passed
- [x] CodeRabbit レビュー実施・指摘事項対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャンネルタブバーを追加し、接続中のチャンネルを視覚的に表示・管理できるようになりました。
  * アイコンストリップで接続中のチャンネルを一覧表示し、素早く切り替え可能に。
  * 接続状態を色で表示（接続中＝緑、接続中＝黄色、エラー＝赤、切断＝灰色）。
  * チャンネル名解決機能を実装し、ユーザー情報の取得を改善。

* **改善**
  * サイドバーで接続中のチャンネルが「ライブ」セクションの上部に表示されるよう最適化。

* **テスト**
  * チャンネル選択機能とマルチチャンネル動作のテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->