### PR TITLE
feat: タブをドラッグで並び替えできるようにする

### DIFF
--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -134,6 +134,25 @@ final class ChannelManager {
         selectedChannel = normalized
     }
 
+    /// 指定チャンネルを目的のインデックス位置に移動する
+    ///
+    /// - 未知のチャンネル名は no-op（クラッシュしない）
+    /// - `destinationIndex` は `0...(channelOrder.count - 1)` の範囲に clamp する
+    /// - 元の位置と同じ index への移動は no-op（不要な再描画を防ぐ）
+    /// - `selectedChannel` は名前ベース管理のため並び替え後も変更不要
+    ///
+    /// - Parameters:
+    ///   - channelLogin: 移動するチャンネル名（大文字小文字は自動正規化）
+    ///   - destinationIndex: 移動先のインデックス
+    func moveChannel(_ channelLogin: String, toIndex destinationIndex: Int) {
+        let normalized = channelLogin.lowercased()
+        guard let currentIndex = channelOrder.firstIndex(of: normalized) else { return }
+        let clamped = min(max(destinationIndex, 0), channelOrder.count - 1)
+        guard currentIndex != clamped else { return }
+        let removed = channelOrder.remove(at: currentIndex)
+        channelOrder.insert(removed, at: clamped)
+    }
+
     /// 全チャンネルから切断して管理状態をリセットする
     func disconnectAll() async {
         let allChannels = channelOrder

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -1,6 +1,12 @@
 // ChannelTabBar.swift
 // 接続中チャンネルのタブバービュー
 // Chrome スタイル：左揃えの固定幅タブ、下のボーダーとアクティブタブが繋がって見える構造
+//
+// ドラッグ並び替えの設計：
+//   - ドラッグ中は channelOrder を変更しない（HStack のリレイアウト起因のちらつきを防ぐ）
+//   - ドラッグ中のタブ: dragOffset のみで常にカーソルに追従
+//   - 他のタブ: ドラッグ中タブが中心を通過した瞬間にアニメーションで退避
+//   - channelOrder の更新はドロップ時（onEnded）にのみ行う
 
 import SwiftUI
 
@@ -9,11 +15,19 @@ import SwiftUI
 /// - タブは左から並び、最大幅 `maxTabWidth` の固定幅で表示する
 /// - タブが多い場合は `ScrollView(.horizontal)` で横スクロール可能にする
 /// - アクティブタブは非アクティブタブより高く描画され、コンテンツエリアと視覚的に繋がって見える
+/// - タブをドラッグすると Chrome 同様にカーソルへ追従し、他タブがリアルタイムに退避する
 struct ChannelTabBar: View {
 
     let channelManager: ChannelManager
     let followedStreamStore: FollowedStreamStore
     let profileImageStore: ProfileImageStore
+
+    /// ドラッグ中のチャンネル名
+    @State private var draggingChannel: String?
+    /// ドラッグ開始からの累積水平移動量（カーソル追従に使用）
+    @State private var dragOffset: CGFloat = 0
+    /// ドラッグ開始時の channelOrder 上のインデックス（他タブの退避計算の基準）
+    @State private var draggingStartIndex: Int?
 
     /// 各タブの最大幅
     private static let maxTabWidth: CGFloat = 180
@@ -28,6 +42,9 @@ struct ChannelTabBar: View {
                         let stream = followedStreamStore.stream(forUserLogin: channel)
                         let userId = stream?.userId
                         let name = stream?.userName ?? channel
+                        let isDragging = draggingChannel == channel
+                        let visualOffset = tabVisualOffset(for: channel)
+
                         ChannelTabCell(
                             isSelected: channel == channelManager.selectedChannel,
                             displayName: name,
@@ -37,6 +54,40 @@ struct ChannelTabBar: View {
                             onClose: { Task { await channelManager.leaveChannel(channel) } }
                         )
                         .frame(width: Self.maxTabWidth)
+                        .offset(x: visualOffset)
+                        // ドラッグ中のタブを浮き上がらせる
+                        .scaleEffect(isDragging ? 1.03 : 1.0, anchor: .bottom)
+                        .shadow(radius: isDragging ? 6 : 0, y: isDragging ? -2 : 0)
+                        .zIndex(isDragging ? 1 : 0)
+                        // ドラッグ中タブは animation なし（カーソルへの即時追従）
+                        // 他のタブは visualOffset 変化時にアニメーションで退避
+                        .animation(isDragging ? nil : .easeInOut(duration: 0.2), value: visualOffset)
+                        // ChannelTabCell 内の onTapGesture / Button と同時に認識させる
+                        .simultaneousGesture(
+                            DragGesture(minimumDistance: 5)
+                                .onChanged { value in
+                                    if draggingChannel == nil {
+                                        draggingChannel = channel
+                                        draggingStartIndex = channelManager.channelOrder.firstIndex(of: channel)
+                                    }
+                                    guard draggingChannel == channel else { return }
+                                    // translation はドラッグ開始からの累積値なのでそのまま代入する
+                                    dragOffset = value.translation.width
+                                }
+                                .onEnded { _ in
+                                    guard let dragging = draggingChannel,
+                                          let startIdx = draggingStartIndex else {
+                                        resetDragState()
+                                        return
+                                    }
+                                    // ドロップ位置から最終インデックスを決定して channelOrder を更新する
+                                    let targetIdx = finalIndex(startIdx: startIdx)
+                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                        channelManager.moveChannel(dragging, toIndex: targetIdx)
+                                    }
+                                    resetDragState()
+                                }
+                        )
                     }
                 }
             }
@@ -45,7 +96,54 @@ struct ChannelTabBar: View {
         }
         .frame(height: Self.height)
         // タブバー背景: チャット欄（controlBackgroundColor）より明示的に少し暗くする
-        // brightness(-0.05) は絶対値ではなく相対的な暗さのため、ライト/ダーク両対応
         .background(Color(.controlBackgroundColor).brightness(-0.05))
+    }
+
+    // MARK: - ドラッグ計算
+
+    /// 各タブの視覚的オフセットを返す
+    ///
+    /// - ドラッグ中のタブ: `dragOffset` でカーソルに完全追従
+    /// - 他のタブ: ドラッグ中タブがそのタブの中心を通過した場合にタブ幅分退避する
+    private func tabVisualOffset(for channel: String) -> CGFloat {
+        guard let draggingCh = draggingChannel,
+              let startIdx = draggingStartIndex,
+              let thisIdx = channelManager.channelOrder.firstIndex(of: channel) else { return 0 }
+
+        if channel == draggingCh {
+            return dragOffset
+        }
+
+        // ドラッグ中タブの現在の視覚的中心 X（タブバー内絶対位置）
+        let draggingCenterX = CGFloat(startIdx) * Self.maxTabWidth + Self.maxTabWidth / 2 + dragOffset
+        // このタブの元の中心 X
+        let thisCenterX = CGFloat(thisIdx) * Self.maxTabWidth + Self.maxTabWidth / 2
+
+        if startIdx < thisIdx && draggingCenterX > thisCenterX {
+            // ドラッグ中タブが右方向に通過 → 左にタブ幅分退避
+            return -Self.maxTabWidth
+        }
+        if startIdx > thisIdx && draggingCenterX < thisCenterX {
+            // ドラッグ中タブが左方向に通過 → 右にタブ幅分退避
+            return Self.maxTabWidth
+        }
+        return 0
+    }
+
+    /// ドロップ時の最終インデックスを計算する
+    ///
+    /// ドラッグ中タブの最終中心位置をタブ幅で割ってインデックスを決定する
+    private func finalIndex(startIdx: Int) -> Int {
+        let finalCenterX = CGFloat(startIdx) * Self.maxTabWidth + Self.maxTabWidth / 2 + dragOffset
+        // floor を使って負の値でも正しく切り捨てる（Int 変換は 0 方向への truncation のため）
+        let raw = Int(floor(finalCenterX / Self.maxTabWidth))
+        return min(max(raw, 0), channelManager.channelOrder.count - 1)
+    }
+
+    /// ドラッグ状態をリセットする
+    private func resetDragState() {
+        draggingChannel = nil
+        dragOffset = 0
+        draggingStartIndex = nil
     }
 }

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -81,11 +81,12 @@ struct ChannelTabBar: View {
                                         return
                                     }
                                     // ドロップ位置から最終インデックスを決定して channelOrder を更新する
+                                    // withAnimation(nil) で全変化を即座に適用し、ドロップ時のアニメーションを防ぐ
                                     let targetIdx = finalIndex(startIdx: startIdx)
-                                    withAnimation(.easeInOut(duration: 0.15)) {
+                                    withAnimation(nil) {
                                         channelManager.moveChannel(dragging, toIndex: targetIdx)
+                                        resetDragState()
                                     }
-                                    resetDragState()
                                 }
                         )
                     }

--- a/Sources/TwitchChat/Views/ChannelTabBar.swift
+++ b/Sources/TwitchChat/Views/ChannelTabBar.swift
@@ -37,13 +37,18 @@ struct ChannelTabBar: View {
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
+                // インデックス辞書を ForEach の外で一度だけ構築し tabVisualOffset の O(n^2) を防ぐ
+                let indexMap = Dictionary(
+                    uniqueKeysWithValues: channelManager.channelOrder.enumerated().map { ($1, $0) }
+                )
                 ForEach(channelManager.channelOrder, id: \.self) { channel in
                     if channelManager.channels[channel] != nil {
                         let stream = followedStreamStore.stream(forUserLogin: channel)
                         let userId = stream?.userId
                         let name = stream?.userName ?? channel
                         let isDragging = draggingChannel == channel
-                        let visualOffset = tabVisualOffset(for: channel)
+                        let thisIdx = indexMap[channel] ?? 0
+                        let visualOffset = tabVisualOffset(for: channel, at: thisIdx)
 
                         ChannelTabCell(
                             isSelected: channel == channelManager.selectedChannel,
@@ -59,9 +64,12 @@ struct ChannelTabBar: View {
                         .scaleEffect(isDragging ? 1.03 : 1.0, anchor: .bottom)
                         .shadow(radius: isDragging ? 6 : 0, y: isDragging ? -2 : 0)
                         .zIndex(isDragging ? 1 : 0)
-                        // ドラッグ中タブは animation なし（カーソルへの即時追従）
-                        // 他のタブは visualOffset 変化時にアニメーションで退避
-                        .animation(isDragging ? nil : .easeInOut(duration: 0.2), value: visualOffset)
+                        // ドラッグ中のみ他タブのアニメーションを有効にする
+                        // draggingChannel == nil（ドロップ後）は nil を返してドロップ時の余分なアニメーションを防ぐ
+                        .animation(
+                            (draggingChannel != nil && !isDragging) ? .easeInOut(duration: 0.2) : nil,
+                            value: visualOffset
+                        )
                         // ChannelTabCell 内の onTapGesture / Button と同時に認識させる
                         .simultaneousGesture(
                             DragGesture(minimumDistance: 5)
@@ -106,10 +114,10 @@ struct ChannelTabBar: View {
     ///
     /// - ドラッグ中のタブ: `dragOffset` でカーソルに完全追従
     /// - 他のタブ: ドラッグ中タブがそのタブの中心を通過した場合にタブ幅分退避する
-    private func tabVisualOffset(for channel: String) -> CGFloat {
+    /// - `thisIdx` を呼び元で渡すことで、メソッド内での O(n) 探索を排除する
+    private func tabVisualOffset(for channel: String, at thisIdx: Int) -> CGFloat {
         guard let draggingCh = draggingChannel,
-              let startIdx = draggingStartIndex,
-              let thisIdx = channelManager.channelOrder.firstIndex(of: channel) else { return 0 }
+              let startIdx = draggingStartIndex else { return 0 }
 
         if channel == draggingCh {
             return dragOffset
@@ -138,7 +146,8 @@ struct ChannelTabBar: View {
         let finalCenterX = CGFloat(startIdx) * Self.maxTabWidth + Self.maxTabWidth / 2 + dragOffset
         // floor を使って負の値でも正しく切り捨てる（Int 変換は 0 方向への truncation のため）
         let raw = Int(floor(finalCenterX / Self.maxTabWidth))
-        return min(max(raw, 0), channelManager.channelOrder.count - 1)
+        // channelOrder が空のとき count - 1 が -1 になるため max(..., 0) でガードする
+        return min(max(raw, 0), max(channelManager.channelOrder.count - 1, 0))
     }
 
     /// ドラッグ状態をリセットする

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -236,4 +236,116 @@ struct ChannelManagerTests {
         manager.selectChannel("NintendoJP")
         #expect(manager.selectedChannel == "nintendojp")
     }
+
+    // MARK: - チャンネル並び替え
+
+    @Test("moveChannel で末尾のチャンネルを先頭に移動できる")
+    func testMoveChannelToFront() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+
+        // 末尾の haishinsha3 を先頭（index 0）に移動する
+        manager.moveChannel("haishinsha3", toIndex: 0)
+
+        #expect(manager.channelOrder == ["haishinsha3", "haishinsha1", "haishinsha2"])
+    }
+
+    @Test("moveChannel で先頭のチャンネルを末尾に移動できる")
+    func testMoveChannelToEnd() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+
+        // 先頭の haishinsha1 を末尾（index 2）に移動する
+        manager.moveChannel("haishinsha1", toIndex: 2)
+
+        #expect(manager.channelOrder == ["haishinsha2", "haishinsha3", "haishinsha1"])
+    }
+
+    @Test("moveChannel は同じ位置への移動で no-op になる")
+    func testMoveChannelSamePositionIsNoop() async {
+        // 前提: haishinsha1, haishinsha2 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+
+        // haishinsha1（index 0）を index 0 に移動しても順序が変わらない
+        manager.moveChannel("haishinsha1", toIndex: 0)
+
+        #expect(manager.channelOrder == ["haishinsha1", "haishinsha2"])
+    }
+
+    @Test("moveChannel は未知のチャンネル名では何もしない")
+    func testMoveChannelUnknownChannelIsNoop() async {
+        // 前提: haishinsha1 のみ接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+
+        // 接続していない "みんなの配信者" を移動しようとしてもクラッシュしない
+        manager.moveChannel("みんなの配信者", toIndex: 0)
+
+        #expect(manager.channelOrder == ["haishinsha1"])
+    }
+
+    @Test("moveChannel は上限を超える index を末尾にクランプする")
+    func testMoveChannelClampsLargeIndex() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+
+        // toIndex: 999 は末尾（index 2）にクランプされること
+        manager.moveChannel("haishinsha1", toIndex: 999)
+        #expect(manager.channelOrder == ["haishinsha2", "haishinsha3", "haishinsha1"])
+    }
+
+    @Test("moveChannel は負の index を先頭にクランプする")
+    func testMoveChannelClampsNegativeIndex() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+
+        // toIndex: -1 は先頭（index 0）にクランプされること
+        manager.moveChannel("haishinsha3", toIndex: -1)
+        #expect(manager.channelOrder == ["haishinsha3", "haishinsha1", "haishinsha2"])
+    }
+
+    @Test("moveChannel しても selectedChannel は変化しない")
+    func testMoveChannelPreservesSelection() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 に接続し haishinsha2 を選択中
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+        manager.selectChannel("haishinsha2")
+
+        // haishinsha2 が選択中のまま haishinsha3 を先頭に移動する
+        manager.moveChannel("haishinsha3", toIndex: 0)
+
+        // 並び替えても選択中チャンネルが変わらないこと
+        #expect(manager.selectedChannel == "haishinsha2")
+        #expect(manager.channelOrder == ["haishinsha3", "haishinsha1", "haishinsha2"])
+    }
+
+    @Test("moveChannel は大文字混在のチャンネル名を正規化して扱う")
+    func testMoveChannelNormalizesChannelName() async {
+        // 前提: haishinsha1, haishinsha2, haishinsha3 の順で接続済み
+        let manager = ChannelManager(authState: AuthState(), makeIRCClient: { MockTwitchIRCClient() })
+        await manager.joinChannel("haishinsha1")
+        await manager.joinChannel("haishinsha2")
+        await manager.joinChannel("haishinsha3")
+
+        // 大文字混在の "Haishinsha3" を渡しても正規化して正しく動作する
+        manager.moveChannel("Haishinsha3", toIndex: 0)
+
+        #expect(manager.channelOrder == ["haishinsha3", "haishinsha1", "haishinsha2"])
+    }
 }


### PR DESCRIPTION
## Summary

- `ChannelManager` に `moveChannel(_:toIndex:)` を追加し、並び替えロジックを実装
- `ChannelTabBar` に Chrome 風ドラッグ並び替えを実装
  - ドラッグ中のタブは常にカーソルにピッタリ追従
  - 閾値（タブ幅の半分）を超えると他のタブがアニメーションで退避
  - `channelOrder` の更新はドロップ時のみ（ちらつき防止）
  - ドロップ時は `withAnimation(nil)` で即座にスナップ
- `moveChannel` の Swift Testing テストを 8 本追加

## Test plan

- [ ] タブをドラッグして左右に並び替えできることを確認
- [ ] ドラッグ中のタブが常にカーソルに追従することを確認
- [ ] 他のタブが閾値を超えた瞬間にアニメーションで退避することを確認
- [ ] ドロップ後にタブがスムーズにスナップして確定することを確認
- [ ] タブのクリック選択・× ボタンが従来通り動作することを確認
- [ ] `swift test` で 157 テスト全パスを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャンネルタブをドラッグアンドドロップで並び替えできるようになりました。

* **テスト**
  * 並び替え機能の動作を検証する包括的なテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->