### PR TITLE
feat: コメント投稿機能（PRIVMSG 送信）を実装する

### DIFF
--- a/Sources/TwitchChat/Auth/AuthConfig.swift
+++ b/Sources/TwitchChat/Auth/AuthConfig.swift
@@ -31,8 +31,9 @@ enum AuthConfig {
     /// 必要な OAuth スコープ
     ///
     /// - `chat:read`: IRC チャット読み取り（認証接続に使用）
+    /// - `chat:edit`: IRC チャット書き込み（コメント投稿に使用）
     /// - `user:read:follows`: フォロー中の配信中ストリーム一覧取得に使用
-    static let scopes: [String] = ["chat:read", "user:read:follows"]
+    static let scopes: [String] = ["chat:read", "chat:edit", "user:read:follows"]
 
     // MARK: - Client ID
 

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -57,6 +57,17 @@ public final class AuthState {
     /// 直近のログインエラーメッセージ（UI 表示用、成功時は `nil` にリセット）
     private(set) var loginError: String?
 
+    /// 現在のアクセストークンに付与されているスコープ一覧
+    ///
+    /// `validateToken` レスポンスの `scopes` フィールドを保存する。
+    /// ログアウト時は空配列にリセットされる
+    private(set) var grantedScopes: [String] = []
+
+    /// コメント投稿（PRIVMSG 送信）に必要な `chat:edit` スコープを保有しているか
+    ///
+    /// `false` の場合、送信 UI は無効化され再ログインを促す
+    var canSendChat: Bool { grantedScopes.contains("chat:edit") }
+
     // MARK: - プライベートプロパティ
 
     private let authClient: any TwitchAuthClientProtocol
@@ -112,6 +123,19 @@ public final class AuthState {
             #if DEBUG
             print("[AuthState] restoreSession: validateToken 成功 — login=\(validateResponse.login)")
             #endif
+
+            // chat:edit スコープ不足の場合、既存セッションを自動ログアウトして再ログインを促す
+            // （コメント投稿機能追加に伴い、古いスコープのトークンを無効扱いにする）
+            let scopes = validateResponse.scopes
+            if !scopes.contains("chat:edit") {
+                #if DEBUG
+                print("[AuthState] restoreSession: chat:edit スコープなし — 自動ログアウトして再ログインを要求")
+                #endif
+                await logout()
+                return
+            }
+
+            grantedScopes = scopes
             accessToken = savedToken
             // validateResponse.userId を優先して設定し、未保存なら Keychain にも保存する
             userId = validateResponse.userId
@@ -179,6 +203,7 @@ public final class AuthState {
             try await keychainStore.save(key: "user_login", value: validateResponse.login)
 
             deviceFlowInfo = nil
+            grantedScopes = validateResponse.scopes
             accessToken = tokenResponse.accessToken
             userId = validateResponse.userId
             status = .loggedIn(userLogin: validateResponse.login)
@@ -220,6 +245,7 @@ public final class AuthState {
         await keychainStore.deleteAll()
         accessToken = nil
         userId = nil
+        grantedScopes = []
         status = .loggedOut
     }
 
@@ -262,6 +288,7 @@ public final class AuthState {
             try await keychainStore.save(key: "access_token", value: tokenResponse.accessToken)
             try await keychainStore.save(key: "refresh_token", value: tokenResponse.refreshToken)
 
+            grantedScopes = validateResponse.scopes
             accessToken = tokenResponse.accessToken
             userId = await keychainStore.load(key: "user_id")
             status = .loggedIn(userLogin: validateResponse.login)
@@ -269,6 +296,7 @@ public final class AuthState {
             await keychainStore.deleteAll()
             accessToken = nil
             userId = nil
+            grantedScopes = []
             status = .loggedOut
         }
     }

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -66,6 +66,35 @@ struct ChatMessage: Sendable, Identifiable {
     /// メッセージの受信時刻
     let receivedAt: Date
 
+    /// 楽観的 UI 表示のためのローカル ChatMessage を生成する
+    ///
+    /// Twitch IRC は自分が送信した PRIVMSG をエコーバックしないため、
+    /// 送信直後にローカルで ChatMessage を組み立てて表示リストに追加する際に使用する。
+    /// エモートは未解決のためセグメントはテキスト全体の1要素になる。
+    ///
+    /// - Parameters:
+    ///   - username: 送信者のログイン名（IRC の NICK に使用した小文字の識別子）
+    ///   - displayName: 表示名（省略時は username と同じ値を使用）
+    ///   - text: 送信したメッセージ本文
+    ///   - roomId: 接続中チャンネルの room-id（既知の場合は渡す、省略可）
+    init(
+        localUsername username: String,
+        displayName: String? = nil,
+        text: String,
+        roomId: String? = nil
+    ) {
+        self.id = UUID().uuidString
+        self.username = username
+        self.displayName = displayName ?? username
+        self.text = text
+        self.colorHex = nil
+        self.badges = []
+        self.emotes = []
+        self.segments = MessageSegment.segments(from: text, emotePositions: [])
+        self.roomId = roomId
+        self.receivedAt = Date()
+    }
+
     /// IRCMessage から ChatMessage を生成する
     ///
     /// PRIVMSG コマンド以外、または trailing がない場合は nil を返す

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -21,6 +21,12 @@ protocol TwitchIRCClientProtocol: Actor {
 
     /// IRC 接続を切断する
     func disconnect() async
+
+    /// 接続中チャンネルに PRIVMSG を送信する
+    ///
+    /// - Parameter text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    /// - Throws: `.notConnected`（未接続）、`.notAuthenticated`（匿名接続中）
+    func sendPrivmsg(_ text: String) async throws
 }
 
 /// Twitch IRC クライアント
@@ -53,6 +59,16 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// 受信ループのタスク（disconnect() でキャンセルするために保持）
     private var receiveLoopTask: Task<Void, Never>?
 
+    /// 現在 JOIN しているチャンネル名（小文字正規化済み）
+    ///
+    /// 未接続の場合は nil。PRIVMSG 送信のターゲットとして使用する
+    private var joinedChannel: String?
+
+    /// 認証接続（OAuth トークン）かどうか
+    ///
+    /// true のときのみ PRIVMSG 送信が許可される（匿名接続では false）
+    private var isAuthenticated: Bool = false
+
     /// 受信した ChatMessage を配信する AsyncStream
     let messageStream: AsyncStream<ChatMessage>
 
@@ -80,7 +96,10 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     func connect(to channel: String, accessToken: String? = nil, userLogin: String? = nil) async throws {
         let normalizedChannel = channel.lowercased()
         try await webSocketClient.connect(to: Self.websocketURL)
+        // 認証接続かどうかを記録してから認証シーケンスを送信
+        isAuthenticated = (accessToken != nil && userLogin != nil)
         try await sendAuthSequence(channel: normalizedChannel, accessToken: accessToken, userLogin: userLogin)
+        joinedChannel = normalizedChannel
         // receiveLoop を別タスクで起動し、connect() がブロックされないようにする
         receiveLoopTask = Task { await receiveLoop() }
     }
@@ -90,7 +109,23 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         receiveLoopTask?.cancel()
         receiveLoopTask = nil
         await webSocketClient.disconnect()
+        joinedChannel = nil
+        isAuthenticated = false
         // messageContinuation?.finish() を呼ばない → 再接続時に同じストリームを再利用できる
+    }
+
+    /// 接続中チャンネルに PRIVMSG を送信する
+    ///
+    /// - Parameter text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    /// - Throws: `.notConnected`（未接続）、`.notAuthenticated`（匿名接続中）
+    func sendPrivmsg(_ text: String) async throws {
+        guard let channel = joinedChannel else {
+            throw TwitchIRCClientError.notConnected
+        }
+        guard isAuthenticated else {
+            throw TwitchIRCClientError.notAuthenticated
+        }
+        try await webSocketClient.send("PRIVMSG #\(channel) :\(text)")
     }
 
     // MARK: - プライベートメソッド
@@ -170,10 +205,20 @@ enum TwitchIRCClientError: Error, LocalizedError {
     /// accessToken と userLogin の指定が不整合（片方のみ指定された場合）
     case invalidAuthParameters
 
+    /// 未接続状態で送信しようとした場合（connect() 前、または disconnect() 後）
+    case notConnected
+
+    /// 匿名接続中に PRIVMSG 送信しようとした場合（コメント投稿には認証接続が必要）
+    case notAuthenticated
+
     var errorDescription: String? {
         switch self {
         case .invalidAuthParameters:
             return "accessToken と userLogin はどちらも指定するか、どちらも省略してください"
+        case .notConnected:
+            return "チャンネルに接続していません"
+        case .notAuthenticated:
+            return "コメントの投稿にはログインが必要です"
         }
     }
 }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -112,6 +112,7 @@ final class ChatViewModel {
         connectionState = .connecting
         messages = []
         channelBadgesFetched = false
+        currentRoomId = nil
 
         // チャンネル切替時に前チャンネルのバッジが誤解決されないようクリア
         await badgeStore.resetChannelBadges()
@@ -156,6 +157,7 @@ final class ChatViewModel {
         await badgeStore.cancelGlobalFetch()
         await ircClient.disconnect()
         connectionState = .disconnected
+        currentRoomId = nil
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -52,6 +52,12 @@ final class ChatViewModel {
     /// 接続中のチャンネル名
     private(set) var channelName: String = ""
 
+    /// メッセージ送信中フラグ（UI のローディング表示用）
+    private(set) var isSending: Bool = false
+
+    /// 最後の送信エラーメッセージ（UI 表示用、成功時は nil にリセット）
+    private(set) var sendError: String?
+
     // MARK: - プライベートプロパティ
 
     private let ircClient: any TwitchIRCClientProtocol
@@ -71,6 +77,9 @@ final class ChatViewModel {
 
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false
+
+    /// 最初に受信したメッセージから抽出した room-id（楽観的 UI の ChatMessage 生成に使用）
+    private var currentRoomId: String?
 
     // MARK: - 初期化
 
@@ -158,9 +167,104 @@ final class ChatViewModel {
             channelBadgesFetched = true
             channelBadgeFetchTask = Task { await badgeStore.fetchChannelBadges(channelId: roomId) }
         }
+        // 楽観的 UI のために room-id を保持する（最初に取得できたものを使い続ける）
+        if currentRoomId == nil {
+            currentRoomId = message.roomId
+        }
         messages.append(message)
         if messages.count > Self.maxMessages {
             messages.removeFirst(messages.count - Self.maxMessages)
+        }
+    }
+
+    // MARK: - 送信
+
+    /// コメント投稿が可能かどうか
+    ///
+    /// 接続済み・ログイン済み・`chat:edit` スコープ保有の3条件をすべて満たす場合のみ `true`
+    var canSendMessage: Bool {
+        guard connectionState == .connected else { return false }
+        guard case .loggedIn = authState.status else { return false }
+        return authState.canSendChat
+    }
+
+    /// 入力テキストをサニタイズして PRIVMSG を送信し、楽観的 UI を更新する
+    ///
+    /// Twitch IRC は自分の PRIVMSG をエコーバックしないため、
+    /// 送信成功後にローカルで ChatMessage を生成して `messages` に追加する。
+    ///
+    /// - Parameter text: 生の入力テキスト（改行・空白を含む場合がある）
+    /// - Throws: `ChatSendError.empty`（空文字）、`.tooLong`（500 文字超）、
+    ///           `.notReady`（未接続・未ログイン・スコープ不足）、
+    ///           または IRC クライアントが throw するエラー
+    func sendMessage(_ text: String) async throws {
+        let sanitized = Self.sanitize(text)
+        guard !sanitized.isEmpty else { throw ChatSendError.empty }
+        guard sanitized.count <= 500 else { throw ChatSendError.tooLong }
+        guard canSendMessage else { throw ChatSendError.notReady }
+
+        isSending = true
+        sendError = nil
+        defer { isSending = false }
+
+        do {
+            try await ircClient.sendPrivmsg(sanitized)
+            // 楽観的 UI: 自分の PRIVMSG はサーバーからエコーバックされないのでローカルで追加する
+            if case .loggedIn(let login) = authState.status {
+                let localMessage = ChatMessage(
+                    localUsername: login,
+                    displayName: login,
+                    text: sanitized,
+                    roomId: currentRoomId
+                )
+                appendMessage(localMessage)
+            }
+        } catch {
+            sendError = error.localizedDescription
+            throw error
+        }
+    }
+
+    /// 送信エラーをリセットする（UI でエラー表示を消す際に呼ぶ）
+    func clearSendError() {
+        sendError = nil
+    }
+
+    /// IRC メッセージ送信用テキストのサニタイズ
+    ///
+    /// - `\r` を除去（CRLF の `\r` だけを除いて `\n` と `\r\n` を統一）
+    /// - `\n` をスペースに変換（IRC は行区切りプロトコルのため改行禁止）
+    /// - 前後の空白をトリム
+    ///
+    /// - Parameter text: 生の入力テキスト
+    /// - Returns: サニタイズ済みテキスト
+    static func sanitize(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "\r", with: "")
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+}
+
+// MARK: - 送信エラー定義
+
+/// チャットメッセージ送信時のエラー
+enum ChatSendError: Error, LocalizedError, Equatable {
+    /// 送信テキストが空（トリム後）
+    case empty
+    /// 送信テキストが 500 文字を超えている
+    case tooLong
+    /// 送信できる状態でない（未接続・未ログイン・スコープ不足）
+    case notReady
+
+    var errorDescription: String? {
+        switch self {
+        case .empty:
+            return "メッセージを入力してください"
+        case .tooLong:
+            return "メッセージは500文字以内にしてください"
+        case .notReady:
+            return "コメントの投稿にはログインが必要です"
         }
     }
 }

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -1,6 +1,6 @@
 // ChatDetailView.swift
 // チャット詳細ペイン
-// 選択中チャンネルのメッセージリストとエラー表示を担当する
+// 選択中チャンネルのメッセージリスト・エラー表示・コメント入力バーを担当する
 
 import SwiftUI
 
@@ -9,8 +9,10 @@ import SwiftUI
 /// - エラー時はエラーメッセージを表示
 /// - チャットメッセージを ScrollView + LazyVStack で表示
 /// - 新メッセージ到着時に自動スクロール
+/// - 下部にコメント投稿用入力バーを表示
 struct ChatDetailView: View {
     var viewModel: ChatViewModel
+    var authState: AuthState
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,6 +27,10 @@ struct ChatDetailView: View {
 
             // チャットメッセージリスト
             chatListView
+
+            // コメント投稿用入力バー
+            Divider()
+            ChatInputBar(viewModel: viewModel, authState: authState)
         }
         // タブバーのアクティブタブ色（controlBackgroundColor）と一致させる
         .background(Color(.controlBackgroundColor))

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -21,8 +21,8 @@ struct ChatInputBar: View {
             // 認証エラーバナー（chat:edit スコープ不足またはログアウト）
             authBanner
 
-            // 入力フォーム（有効な場合のみ表示）
-            if viewModel.canSendMessage || isConnected {
+            // 入力フォーム（接続中のみ表示、送信不可の場合は disabled）
+            if isConnected {
                 inputForm
             }
         }
@@ -155,7 +155,7 @@ struct ChatInputBar: View {
     private var canSubmit: Bool {
         viewModel.canSendMessage
             && !viewModel.isSending
-            && !draft.trimmingCharacters(in: .whitespaces).isEmpty
+            && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             && draft.count <= 500
     }
 
@@ -169,7 +169,7 @@ struct ChatInputBar: View {
     /// メッセージを送信する
     private func submit() {
         let text = draft
-        guard !text.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         draft = ""
         Task {
             try? await viewModel.sendMessage(text)

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -1,0 +1,178 @@
+// ChatInputBar.swift
+// コメント投稿用入力バー
+// テキスト入力・文字数カウント・送信ボタン・認証状態に応じた UI 切り替えを担当する
+
+import SwiftUI
+
+/// コメント投稿用入力バー
+///
+/// - ログイン済み + chat:edit スコープあり + 接続済みの場合のみ入力可能
+/// - Twitch IRC のメッセージ上限（500 文字）をカウントして超過時に警告表示
+/// - 送信エラーは 3 秒後に自動クリア
+struct ChatInputBar: View {
+    var viewModel: ChatViewModel
+    var authState: AuthState
+
+    /// 入力テキスト（下書き）
+    @State private var draft: String = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // 認証エラーバナー（chat:edit スコープ不足またはログアウト）
+            authBanner
+
+            // 入力フォーム（有効な場合のみ表示）
+            if viewModel.canSendMessage || isConnected {
+                inputForm
+            }
+        }
+        .background(Color(.controlBackgroundColor))
+    }
+
+    // MARK: - サブビュー
+
+    /// 認証状態に応じたバナー
+    @ViewBuilder
+    private var authBanner: some View {
+        switch authState.status {
+        case .loggedOut:
+            // ログアウト状態: ログインを促すバナー
+            HStack {
+                Text("コメントを投稿するにはログインしてください")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("ログイン") {
+                    authState.startLogin()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(.windowBackgroundColor))
+            Divider()
+
+        case .loggedIn where !authState.canSendChat:
+            // ログイン済みだが chat:edit スコープなし（旧スコープのトークン）
+            // 注意: このケースは restoreSession で自動ログアウトされるため通常は表示されない
+            HStack {
+                Text("コメント投稿には再ログインが必要です")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("再ログイン") {
+                    Task {
+                        await authState.logout()
+                        authState.startLogin()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(Color(.windowBackgroundColor))
+            Divider()
+
+        default:
+            EmptyView()
+        }
+    }
+
+    /// テキスト入力フォーム
+    private var inputForm: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            VStack(alignment: .trailing, spacing: 2) {
+                // テキストフィールド（複数行対応）
+                TextField("コメントを送信", text: $draft, axis: .vertical)
+                    .lineLimit(1...5)
+                    .textFieldStyle(.plain)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color(.textBackgroundColor))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(Color(.separatorColor), lineWidth: 0.5)
+                            )
+                    )
+                    .disabled(!viewModel.canSendMessage)
+                    .onSubmit(submit)
+
+                // 文字数カウンタ（450 文字超で警告）
+                if draft.count > 0 {
+                    Text("\(draft.count)/500")
+                        .font(.caption2)
+                        .foregroundStyle(counterColor)
+                        .monospacedDigit()
+                }
+            }
+
+            // 送信ボタン
+            Button(action: submit) {
+                if viewModel.isSending {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: 16, height: 16)
+                } else {
+                    Image(systemName: "paperplane.fill")
+                        .frame(width: 16, height: 16)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!canSubmit)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        // 送信エラー表示
+        .overlay(alignment: .topLeading) {
+            if let error = viewModel.sendError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 12)
+                    .offset(y: -20)
+                    .task(id: viewModel.sendError) {
+                        // 3 秒後にエラーを自動クリア
+                        try? await Task.sleep(nanoseconds: 3_000_000_000)
+                        viewModel.clearSendError()
+                    }
+                    .id(error)
+            }
+        }
+    }
+
+    // MARK: - ヘルパー
+
+    /// 接続中かどうか（入力フォームの表示判定用）
+    private var isConnected: Bool {
+        viewModel.connectionState == .connected
+    }
+
+    /// 送信可能かどうか（ボタン有効化条件）
+    private var canSubmit: Bool {
+        viewModel.canSendMessage
+            && !viewModel.isSending
+            && !draft.trimmingCharacters(in: .whitespaces).isEmpty
+            && draft.count <= 500
+    }
+
+    /// 文字数カウンタの色
+    private var counterColor: Color {
+        if draft.count > 500 { return .red }
+        if draft.count > 450 { return .yellow }
+        return .secondary
+    }
+
+    /// メッセージを送信する
+    private func submit() {
+        let text = draft
+        guard !text.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        draft = ""
+        Task {
+            try? await viewModel.sendMessage(text)
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -38,7 +38,7 @@ struct ContentView: View {
 
                 // チャット本体: 選択中チャンネルのチャット、未選択時はプレースホルダー
                 if let viewModel = channelManager.selectedViewModel {
-                    ChatDetailView(viewModel: viewModel)
+                    ChatDetailView(viewModel: viewModel, authState: authState)
                 } else {
                     Text("チャンネルを選択するか、ライブ中のストリーマーをクリックしてチャットを開始してください")
                         .multilineTextAlignment(.center)

--- a/Tests/TwitchChatTests/AuthStateTests.swift
+++ b/Tests/TwitchChatTests/AuthStateTests.swift
@@ -35,7 +35,7 @@ struct AuthStateTests {
                 clientId: "testclientid",
                 login: "テスト配信者",
                 userId: "12345678",
-                scopes: ["chat:read"],
+                scopes: ["chat:read", "chat:edit", "user:read:follows"],
                 expiresIn: 10000
             )
         )
@@ -222,6 +222,123 @@ struct AuthStateTests {
         #expect(authState.accessToken == nil)
         #expect(await store.load(key: "access_token") == nil)
         #expect(await store.load(key: "refresh_token") == nil)
+
+        await store.deleteAll()
+    }
+
+    // MARK: - スコープ管理・canSendChat
+
+    @Test("restoreSession 成功時に grantedScopes が保存される")
+    func restoreSession成功時にgrantedScopesが保存される() async throws {
+        let store = makeTestKeychainStore()
+        try await store.save(key: "access_token", value: "テスト用トークン")
+
+        // 前提: chat:read と chat:edit を含む validateResponse を返すモック
+        let mockClient = MockTwitchAuthClient(
+            validateResponse: TwitchValidateResponse(
+                clientId: "testclientid",
+                login: "配信者ユーザー",
+                userId: "99999",
+                scopes: ["chat:read", "chat:edit"],
+                expiresIn: 14400
+            )
+        )
+        let authState = makeAuthState(authClient: mockClient, keychainStore: store)
+        await authState.restoreSession()
+
+        // 検証: grantedScopes にスコープが保存される
+        #expect(authState.grantedScopes.contains("chat:read"))
+        #expect(authState.grantedScopes.contains("chat:edit"))
+        // 検証: canSendChat が true になる
+        #expect(authState.canSendChat == true)
+
+        await store.deleteAll()
+    }
+
+    @Test("login 成功時に grantedScopes が保存される")
+    func login成功時にgrantedScopesが保存される() async throws {
+        let store = makeTestKeychainStore()
+
+        let mockClient = MockTwitchAuthClient(
+            deviceCodeResponse: TwitchDeviceCodeResponse(
+                deviceCode: "テスト用デバイスコード",
+                userCode: "XYZ-67890",
+                verificationUri: "https://www.twitch.tv/activate",
+                expiresIn: 1800,
+                interval: 0
+            ),
+            tokenResponse: TwitchTokenResponse(
+                accessToken: "テスト用ログイントークン",
+                refreshToken: "テスト用リフレッシュトークン",
+                expiresIn: 14400,
+                tokenType: "bearer",
+                scope: ["chat:read", "chat:edit"]
+            ),
+            validateResponse: TwitchValidateResponse(
+                clientId: "testclientid",
+                login: "新規ログイン者",
+                userId: "11111",
+                scopes: ["chat:read", "chat:edit"],
+                expiresIn: 14400
+            )
+        )
+        let authState = makeAuthState(authClient: mockClient, keychainStore: store)
+        await authState.login()
+
+        // 検証: grantedScopes にスコープが保存される
+        #expect(authState.grantedScopes.contains("chat:edit"))
+        #expect(authState.canSendChat == true)
+
+        await store.deleteAll()
+    }
+
+    @Test("chat:edit を含まないスコープの場合 canSendChat は false になる")
+    func chatEditを含まないスコープの場合canSendChatはfalseになる() async throws {
+        let store = makeTestKeychainStore()
+        try await store.save(key: "access_token", value: "スコープ不足トークン")
+
+        // 前提: chat:edit を含まない validateResponse
+        let mockClient = MockTwitchAuthClient(
+            validateResponse: TwitchValidateResponse(
+                clientId: "testclientid",
+                login: "旧バージョンユーザー",
+                userId: "22222",
+                scopes: ["chat:read"],
+                expiresIn: 14400
+            )
+        )
+        let authState = makeAuthState(authClient: mockClient, keychainStore: store)
+        // restoreSession では chat:edit がない場合に自動ログアウト
+        await authState.restoreSession()
+
+        // 検証: 自動ログアウトされて canSendChat は false
+        #expect(authState.canSendChat == false)
+        #expect(authState.status == .loggedOut)
+
+        await store.deleteAll()
+    }
+
+    @Test("restoreSession で chat:edit がない場合は自動ログアウトされる")
+    func restoreSessionでchatEditがない場合は自動ログアウトされる() async throws {
+        let store = makeTestKeychainStore()
+        try await store.save(key: "access_token", value: "スコープ不足のトークン")
+
+        // 前提: chat:edit を含まない validateResponse（旧スコープのトークン）
+        let mockClient = MockTwitchAuthClient(
+            validateResponse: TwitchValidateResponse(
+                clientId: "testclientid",
+                login: "既存ユーザー",
+                userId: "33333",
+                scopes: ["chat:read", "user:read:follows"],
+                expiresIn: 14400
+            )
+        )
+        let authState = makeAuthState(authClient: mockClient, keychainStore: store)
+        await authState.restoreSession()
+
+        // 検証: chat:edit がないため自動ログアウト
+        #expect(authState.status == .loggedOut)
+        #expect(authState.accessToken == nil)
 
         await store.deleteAll()
     }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -186,4 +186,64 @@ struct ChatMessageTests {
         let chatMessage = ChatMessage(from: ircMessage)
         #expect(chatMessage?.roomId == nil)
     }
+
+    // MARK: - 楽観的 UI 用イニシャライザ
+
+    @Test("楽観的 UI 用イニシャライザで ChatMessage を生成できる")
+    func 楽観的UI用イニシャライザでChatMessageを生成できる() {
+        // 前提: ローカルユーザー名とテキストを指定
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            displayName: "山田太郎",
+            text: "こんにちは！",
+            roomId: "12345678"
+        )
+
+        // 検証: 各フィールドが期待通りに設定される
+        #expect(chatMessage.username == "yamadataro")
+        #expect(chatMessage.displayName == "山田太郎")
+        #expect(chatMessage.text == "こんにちは！")
+        #expect(chatMessage.roomId == "12345678")
+        #expect(chatMessage.colorHex == nil)
+        #expect(chatMessage.badges.isEmpty)
+        #expect(chatMessage.emotes.isEmpty)
+        #expect(!chatMessage.id.isEmpty)
+    }
+
+    @Test("楽観的 UI 用イニシャライザで displayName を省略すると username にフォールバックされる")
+    func 楽観的UI用イニシャライザでdisplayNameを省略するとusernameにフォールバックされる() {
+        // 前提: displayName を省略して生成
+        let chatMessage = ChatMessage(
+            localUsername: "testviewer",
+            text: "テストメッセージ"
+        )
+
+        // 検証: displayName が username と同じになる
+        #expect(chatMessage.username == "testviewer")
+        #expect(chatMessage.displayName == "testviewer")
+    }
+
+    @Test("楽観的 UI 用イニシャライザで segments はテキスト全体の1セグメントになる")
+    func 楽観的UI用イニシャライザでsegmentsはテキスト全体の1セグメントになる() {
+        // 前提: テキストを指定して生成（エモートなし）
+        let chatMessage = ChatMessage(
+            localUsername: "haishinshaA",
+            text: "配信開始！"
+        )
+
+        // 検証: segments がテキスト全体の1セグメントになる
+        #expect(chatMessage.segments == [.text("配信開始！")])
+        #expect(chatMessage.emotes.isEmpty)
+    }
+
+    @Test("楽観的 UI 用イニシャライザで生成した id は一意な UUID 形式になる")
+    func 楽観的UI用イニシャライザで生成したidは一意なUUID形式になる() {
+        // 前提: 同じパラメータで2つのメッセージを生成
+        let message1 = ChatMessage(localUsername: "視聴者001", text: "同じメッセージ")
+        let message2 = ChatMessage(localUsername: "視聴者001", text: "同じメッセージ")
+
+        // 検証: id が異なる（UUID によるユニーク保証）
+        #expect(message1.id != message2.id)
+        #expect(!message1.id.isEmpty)
+    }
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -17,6 +17,12 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
     let messageStream: AsyncStream<ChatMessage>
 
+    /// sendPrivmsg() で送信されたメッセージのログ（テスト検証用）
+    private(set) var sentPrivmsgs: [String] = []
+
+    /// sendPrivmsg() が throw するエラー（nil の場合は成功）
+    var sendPrivmsgError: (any Error)?
+
     init() {
         var continuation: AsyncStream<ChatMessage>.Continuation?
         self.messageStream = AsyncStream { continuation = $0 }
@@ -30,7 +36,18 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
 
     func disconnect() async {
         disconnectCalled = true
+        connectedChannel = nil
         messageContinuation?.finish()
+    }
+
+    func sendPrivmsg(_ text: String) async throws {
+        if let error = sendPrivmsgError {
+            throw error
+        }
+        guard connectedChannel != nil else {
+            throw TwitchIRCClientError.notConnected
+        }
+        sentPrivmsgs.append(text)
     }
 
     /// テスト用にメッセージを流し込む
@@ -125,6 +142,120 @@ struct ChatViewModelTests {
         #expect(viewModel.messages.last?.text == "メッセージ 500")
     }
 
+    // MARK: - sendMessage 送信機能
+
+    @Test("sendMessage で IRC クライアントへサニタイズ済み文字列が渡る")
+    func sendMessageでIRCクライアントへサニタイズ済み文字列が渡る() async throws {
+        // 前提: 認証接続済みの状態を作る
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "送信者001")
+
+        try await viewModel.sendMessage("こんにちは！")
+
+        let sent = await mockClient.sentPrivmsgs
+        #expect(sent == ["こんにちは！"])
+    }
+
+    @Test("sendMessage 成功時に messages に楽観的メッセージが追加される")
+    func sendMessage成功時にmessagesに楽観的メッセージが追加される() async throws {
+        // 前提: 認証接続済みの状態
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "送信者002")
+
+        try await viewModel.sendMessage("配信見てます！")
+
+        // 検証: messages に自分のメッセージが追加される
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages[0].username == "送信者002")
+        #expect(viewModel.messages[0].text == "配信見てます！")
+    }
+
+    @Test("空文字列の sendMessage は empty エラーを throw し messages は変化しない")
+    func 空文字列のsendMessageはemptyエラーをthrowしmessagesは変化しない() async throws {
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "送信者003")
+
+        await #expect(throws: ChatSendError.empty) {
+            try await viewModel.sendMessage("")
+        }
+        #expect(viewModel.messages.isEmpty)
+    }
+
+    @Test("空白のみの sendMessage は empty エラーを throw する")
+    func 空白のみのsendMessageはemptyエラーをthrowする() async throws {
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "送信者004")
+
+        await #expect(throws: ChatSendError.empty) {
+            try await viewModel.sendMessage("   　\t")
+        }
+        #expect(viewModel.messages.isEmpty)
+    }
+
+    @Test("501 文字の sendMessage は tooLong エラーを throw し IRC 送信は呼ばれない")
+    func 文字数制限超えのsendMessageはtooLongエラーをthrowしIRC送信は呼ばれない() async throws {
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "送信者005")
+
+        // 501 文字のテキスト
+        let longText = String(repeating: "あ", count: 501)
+        await #expect(throws: ChatSendError.tooLong) {
+            try await viewModel.sendMessage(longText)
+        }
+        // 検証: IRC には何も送信されていない
+        let sent = await mockClient.sentPrivmsgs
+        #expect(sent.isEmpty)
+    }
+
+    @Test("改行文字を含むテキストはサニタイズされてスペースに変換される")
+    func 改行文字を含むテキストはサニタイズされてスペースに変換される() async throws {
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "送信者006")
+
+        try await viewModel.sendMessage("前半\r\n後半")
+
+        let sent = await mockClient.sentPrivmsgs
+        // \r\n は \r 除去 → \n をスペースに変換 の順で処理される
+        #expect(sent == ["前半 後半"])
+    }
+
+    @Test("未接続状態での sendMessage は notReady エラーを throw する")
+    func 未接続状態でのsendMessageはnotReadyエラーをthrowする() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let authState = try await makeLoggedInAuthState(userLogin: "送信者007")
+        let viewModel = ChatViewModel(ircClient: mockClient, authState: authState)
+        // 接続しない（disconnected 状態）
+
+        await #expect(throws: ChatSendError.notReady) {
+            try await viewModel.sendMessage("テストメッセージ")
+        }
+    }
+
+    @Test("ログアウト状態では canSendMessage が false になる")
+    func ログアウト状態ではcanSendMessageがfalseになる() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let authState = AuthState(
+            authClient: MockTwitchAuthClient(),
+            keychainStore: KeychainStore(service: "test.\(UUID().uuidString)"),
+            openURL: { _ in }
+        )
+        // 前提: ログアウト状態（Keychain にトークンなし）
+        await authState.restoreSession()
+        let viewModel = ChatViewModel(ircClient: mockClient, authState: authState)
+
+        // 接続（匿名接続になる）
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: ログアウト中は canSendMessage = false
+        #expect(viewModel.canSendMessage == false)
+    }
+
+    @Test("isSending は sendMessage の実行中だけ true になる")
+    func isSendingはsendMessageの実行中だけtrueになる() async throws {
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "送信者008")
+
+        // 送信前は false
+        #expect(viewModel.isSending == false)
+        try await viewModel.sendMessage("送信テスト")
+        // 送信完了後は false に戻る
+        #expect(viewModel.isSending == false)
+    }
+
     // MARK: - ヘルパー
 
     /// テスト用の ChatMessage を生成する
@@ -132,5 +263,58 @@ struct ChatViewModelTests {
         let rawMessage = "@badges=;color=#FF0000;display-name=\(displayName);emotes=;id=\(UUID().uuidString);user-id=12345 :testuser!testuser@testuser.tmi.twitch.tv PRIVMSG #testchannel :\(text)"
         let ircMessage = IRCMessageParser.parse(rawMessage)!
         return ChatMessage(from: ircMessage)!
+    }
+
+    /// chat:edit スコープ付きでログイン済みの AuthState を生成するヘルパー
+    ///
+    /// MockTwitchAuthClient を使って Device Code Flow をシミュレートし、
+    /// authState.login() でログイン済み状態（grantedScopes に chat:edit あり）にする
+    private func makeLoggedInAuthState(userLogin: String) async throws -> AuthState {
+        let store = KeychainStore(service: "test.\(UUID().uuidString)")
+        let mockAuthClient = MockTwitchAuthClient(
+            deviceCodeResponse: TwitchDeviceCodeResponse(
+                deviceCode: "テスト用デバイスコード",
+                userCode: "TEST-1234",
+                verificationUri: "https://www.twitch.tv/activate",
+                expiresIn: 1800,
+                interval: 0
+            ),
+            tokenResponse: TwitchTokenResponse(
+                accessToken: "テスト用アクセストークン",
+                refreshToken: "テスト用リフレッシュトークン",
+                expiresIn: 14400,
+                tokenType: "bearer",
+                scope: ["chat:read", "chat:edit"]
+            ),
+            validateResponse: TwitchValidateResponse(
+                clientId: "testclientid",
+                login: userLogin,
+                userId: "12345",
+                scopes: ["chat:read", "chat:edit"],
+                expiresIn: 14400
+            )
+        )
+        let authState = AuthState(
+            authClient: mockAuthClient,
+            keychainStore: store,
+            openURL: { _ in }
+        )
+        await authState.login()
+        return authState
+    }
+
+    /// 認証接続済み（connected）の ChatViewModel と MockTwitchIRCClient のペアを返す
+    ///
+    /// - Parameter userLogin: ログインユーザー名（楽観的 UI の username に使用）
+    private func makeConnectedViewModel(userLogin: String) async throws -> (ChatViewModel, MockTwitchIRCClient) {
+        let mockClient = MockTwitchIRCClient()
+        let authState = try await makeLoggedInAuthState(userLogin: userLogin)
+        let viewModel = ChatViewModel(ircClient: mockClient, authState: authState)
+
+        // チャンネルに接続して connected 状態にする
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        return (viewModel, mockClient)
     }
 }

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -184,4 +184,97 @@ struct TwitchIRCClientTests {
         #expect(receivedMessages[0].text == "こんにちはテストです")
         #expect(receivedMessages[0].colorHex == "#FF0000")
     }
+
+    // MARK: - PRIVMSG 送信
+
+    @Test("認証接続後に sendPrivmsg を呼ぶと正しいフォーマットで送信される")
+    func 認証接続後にsendPrivmsgを呼ぶと正しいフォーマットで送信される() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 認証接続でチャンネルに参加
+        let connectTask = Task {
+            try await client.connect(to: "haishinshaA", accessToken: "テスト用トークン", userLogin: "視聴者001")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: sendPrivmsg を呼ぶと PRIVMSG コマンドが送信される（チャンネル名は小文字正規化済み）
+        try await client.sendPrivmsg("こんにちは！")
+
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("PRIVMSG #haishinshaa :こんにちは！"))
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("未接続状態での sendPrivmsg は notConnected を throw する")
+    func 未接続状態でのsendPrivmsgはnotConnectedをthrowする() async {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 接続していない状態
+        await #expect(throws: TwitchIRCClientError.notConnected) {
+            try await client.sendPrivmsg("メッセージ送信テスト")
+        }
+    }
+
+    @Test("匿名接続状態での sendPrivmsg は notAuthenticated を throw する")
+    func 匿名接続状態でのsendPrivmsgはnotAuthenticatedをthrowする() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 匿名接続（accessToken/userLogin なし）
+        let connectTask = Task {
+            try await client.connect(to: "testchannel", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: 匿名接続では notAuthenticated を throw する
+        await #expect(throws: TwitchIRCClientError.notAuthenticated) {
+            try await client.sendPrivmsg("匿名送信テスト")
+        }
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("disconnect 後の sendPrivmsg は notConnected を throw する")
+    func disconnect後のsendPrivmsgはnotConnectedをthrowする() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 認証接続後に切断
+        let connectTask = Task {
+            try await client.connect(to: "testchannel", accessToken: "テスト用トークン", userLogin: "視聴者002")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        await client.disconnect()
+        connectTask.cancel()
+
+        // 検証: 切断後は notConnected を throw する
+        await #expect(throws: TwitchIRCClientError.notConnected) {
+            try await client.sendPrivmsg("切断後送信テスト")
+        }
+    }
+
+    @Test("チャンネル名は接続時に正規化された小文字が PRIVMSG ターゲットに使われる")
+    func チャンネル名は正規化された小文字がPRIVMSGターゲットに使われる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 大文字を含むチャンネル名で認証接続
+        let connectTask = Task {
+            try await client.connect(to: "TestChannel", accessToken: "テスト用トークン", userLogin: "視聴者003")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: PRIVMSG は小文字チャンネル名を使う
+        try await client.sendPrivmsg("大文字チャンネルテスト")
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("PRIVMSG #testchannel :大文字チャンネルテスト"))
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
 }


### PR DESCRIPTION
## Summary

- **IRC 送信レイヤー**: `TwitchIRCClient` に `sendPrivmsg` を追加。`joinedChannel` / `isAuthenticated` を actor 内部で保持し、未接続・匿名接続時は早期失敗
- **スコープ管理**: `AuthConfig` に `chat:edit` を追加。`AuthState` に `grantedScopes` / `canSendChat` を実装。起動時に `chat:edit` 未付与の既存セッションは自動ログアウトして再ログインを促す
- **楽観的 UI**: Twitch IRC は自分の PRIVMSG をエコーバックしないため、送信直後にローカルで `ChatMessage` を生成して表示リストに追加
- **入力バー**: `ChatInputBar`（新規）をメッセージリスト下部に配置。CRLF サニタイズ・500 文字制限・文字数カウンタ・認証バナー・送信ボタンを実装

## Test plan

- [ ] `swift build` でビルド成功・警告ゼロを確認
- [ ] `swift test` で全テスト通過を確認（新規テスト 22 本追加）
- [ ] Twitch でログイン（`chat:edit` スコープを認可）
- [ ] チャンネルに JOIN してコメントを入力・送信し、自分のメッセージが即座に表示されることを確認
- [ ] 別タブ/ブラウザで同チャンネルを開き、送信したメッセージが他者にも見えることを確認
- [ ] ログアウト状態でバナー「ログインしてコメント投稿」が表示されることを確認
- [ ] 500 文字超で赤色カウンタ、送信ボタン disabled を確認
- [ ] Enter で送信、Shift+Enter で改行、空白のみ送信は無視されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)