### PR TITLE
feat: Twitch NOTICE ハンドリングと楽観 UI rollback を実装する

### DIFF
--- a/Sources/TwitchChat/Models/TwitchNotice.swift
+++ b/Sources/TwitchChat/Models/TwitchNotice.swift
@@ -2,8 +2,6 @@
 // Twitch IRC NOTICE コマンドを表すモデル
 // サーバーからの通知（レートリミット超過・BAN・スローモードなど）を保持する
 
-import Foundation
-
 /// Twitch IRC の NOTICE コマンド（サーバーからの通知）
 ///
 /// 認証接続後に `CAP REQ :twitch.tv/commands` を要求している場合、

--- a/Sources/TwitchChat/Models/TwitchNotice.swift
+++ b/Sources/TwitchChat/Models/TwitchNotice.swift
@@ -1,0 +1,30 @@
+// TwitchNotice.swift
+// Twitch IRC NOTICE コマンドを表すモデル
+// サーバーからの通知（レートリミット超過・BAN・スローモードなど）を保持する
+
+import Foundation
+
+/// Twitch IRC の NOTICE コマンド（サーバーからの通知）
+///
+/// 認証接続後に `CAP REQ :twitch.tv/commands` を要求している場合、
+/// NOTICE には `@msg-id=...` タグが付与され、通知の種類を識別できる。
+///
+/// 実際の IRC 形式:
+/// `@msg-id=msg_ratelimit :tmi.twitch.tv NOTICE #channel :You are sending messages too quickly.`
+struct TwitchNotice: Sendable, Equatable {
+    /// 通知の種類を識別するタグ（例: "msg_ratelimit", "msg_duplicate"）
+    ///
+    /// `CAP REQ :twitch.tv/commands` が有効な場合のみ付与される。
+    /// 匿名接続時や古い接続では nil になる。
+    let msgId: String?
+
+    /// 通知の対象チャンネル名（`#` なし）
+    ///
+    /// 特定チャンネル向けでない NOTICE（例: ログイン失敗通知）では nil になる。
+    let channel: String?
+
+    /// ユーザー向け通知文言（IRC メッセージの trailing 部分）
+    ///
+    /// 例: "You are sending messages too quickly."
+    let message: String
+}

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -209,9 +209,11 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
         case "NOTICE":
             // サーバーからの通知（レートリミット・BAN・スローモードなど）を配信
-            // params[0] は "#channel" 形式。"#" を除いてチャンネル名として保持する
-            let rawChannel = ircMessage.params.first
-            let channel = rawChannel.map { String($0.dropFirst()) }
+            // params[0] は "#channel" 形式または "*"（サーバー全体通知）。
+            // "#" プレフィックスを持つ場合のみ除去する。"*" などは nil にする。
+            let channel = ircMessage.params.first.flatMap { raw in
+                raw.hasPrefix("#") ? String(raw.dropFirst()) : nil
+            }
             let notice = TwitchNotice(
                 msgId: ircMessage.tags["msg-id"],
                 channel: channel,

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -11,6 +11,12 @@ protocol TwitchIRCClientProtocol: Actor {
     /// 受信した ChatMessage を配信する AsyncStream
     var messageStream: AsyncStream<ChatMessage> { get }
 
+    /// サーバーから受信した NOTICE を配信する AsyncStream
+    ///
+    /// レートリミット超過・BAN・スローモードなどのエラー通知が流れる。
+    /// `CAP REQ :twitch.tv/commands` が有効な場合のみ `msg-id` タグ付きで届く。
+    var noticeStream: AsyncStream<TwitchNotice> { get }
+
     /// 指定チャンネルに接続する
     ///
     /// - Parameters:
@@ -56,6 +62,7 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
     private let webSocketClient: any WebSocketClientProtocol
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
+    private var noticeContinuation: AsyncStream<TwitchNotice>.Continuation?
     /// 受信ループのタスク（disconnect() でキャンセルするために保持）
     private var receiveLoopTask: Task<Void, Never>?
 
@@ -72,15 +79,23 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// 受信した ChatMessage を配信する AsyncStream
     let messageStream: AsyncStream<ChatMessage>
 
+    /// サーバーから受信した NOTICE を配信する AsyncStream
+    let noticeStream: AsyncStream<TwitchNotice>
+
     // MARK: - 初期化
 
     /// TwitchIRCClient を初期化する
     ///
     /// - Parameter webSocketClient: WebSocket クライアント実装（テスト時はモックを注入）
     init(webSocketClient: any WebSocketClientProtocol = URLSessionWebSocketClient()) {
-        var continuation: AsyncStream<ChatMessage>.Continuation?
-        self.messageStream = AsyncStream { continuation = $0 }
-        self.messageContinuation = continuation
+        var msgContinuation: AsyncStream<ChatMessage>.Continuation?
+        self.messageStream = AsyncStream { msgContinuation = $0 }
+        self.messageContinuation = msgContinuation
+
+        var ntcContinuation: AsyncStream<TwitchNotice>.Continuation?
+        self.noticeStream = AsyncStream { ntcContinuation = $0 }
+        self.noticeContinuation = ntcContinuation
+
         self.webSocketClient = webSocketClient
     }
 
@@ -191,6 +206,18 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
             if let chatMessage = ChatMessage(from: ircMessage) {
                 messageContinuation?.yield(chatMessage)
             }
+
+        case "NOTICE":
+            // サーバーからの通知（レートリミット・BAN・スローモードなど）を配信
+            // params[0] は "#channel" 形式。"#" を除いてチャンネル名として保持する
+            let rawChannel = ircMessage.params.first
+            let channel = rawChannel.map { String($0.dropFirst()) }
+            let notice = TwitchNotice(
+                msgId: ircMessage.tags["msg-id"],
+                channel: channel,
+                message: ircMessage.trailing ?? ""
+            )
+            noticeContinuation?.yield(notice)
 
         default:
             break

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -168,6 +168,8 @@ final class ChatViewModel {
         } catch {
             connectionState = .error(error.localizedDescription)
             receiveTask?.cancel()
+            noticeReceiveTask?.cancel()
+            globalBadgeFetchTask?.cancel()
         }
     }
 
@@ -271,15 +273,19 @@ final class ChatViewModel {
         }
         sendError = error.errorDescription
 
-        // rollback: ウィンドウ内の pending メッセージのうち最も古いものを除去する
-        // Twitch はメッセージを受け付けた順に NOTICE を返すため、最も古い pending を除去する
         let now = Date()
         let windowStart = now.addingTimeInterval(-Self.optimisticRollbackWindow)
-        if let (oldestId, _) = optimisticPendingMessages
-            .filter({ $0.value >= windowStart })
-            .min(by: { $0.value < $1.value }) {
-            messages.removeAll { $0.id == oldestId }
-            optimisticPendingMessages.removeValue(forKey: oldestId)
+
+        // 期限切れエントリを先に除去して辞書が無限に膨らむのを防ぐ
+        optimisticPendingMessages = optimisticPendingMessages.filter { $0.value >= windowStart }
+
+        // rollback: ウィンドウ内で最も新しい pending を除去する
+        // NOTICE はユーザーが直前に送ったメッセージへの拒否通知であるため、
+        // 最後に追加されたものが拒否された可能性が最も高い
+        if let (newestId, _) = optimisticPendingMessages
+            .max(by: { $0.value < $1.value }) {
+            messages.removeAll { $0.id == newestId }
+            optimisticPendingMessages.removeValue(forKey: newestId)
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -264,8 +264,9 @@ final class ChatViewModel {
     /// サーバーから受信した NOTICE を処理する
     ///
     /// エラー系 msg-id に対応する ChatSendError を `sendError` に反映し、
-    /// rollback ウィンドウ内で最も古い楽観的 UI メッセージを `messages` から除去する。
-    /// 複数メッセージを連続送信した場合は各メッセージを個別に rollback する。
+    /// `optimisticPendingMessages` の rollback ウィンドウ内で最も新しい楽観的 UI メッセージを
+    /// `messages` から除去する。直前に送ったメッセージが拒否された可能性が最も高いため、
+    /// 送信時刻が最新のエントリを rollback 対象とする。
     private func handleIncomingNotice(_ notice: TwitchNotice) {
         guard let error = ChatSendError.from(notice: notice) else {
             // 情報系通知（host_on, host_off 等）は何もしない

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -84,11 +84,11 @@ final class ChatViewModel {
     /// 最初に受信したメッセージから抽出した room-id（楽観的 UI の ChatMessage 生成に使用）
     private var currentRoomId: String?
 
-    /// 直近の楽観的 UI メッセージの ID（サーバー拒否時に rollback するために保持）
-    private var lastOptimisticMessageId: String?
-
-    /// 楽観的 UI メッセージの送信時刻（rollback 有効期間の判定に使用）
-    private var lastOptimisticSentAt: Date?
+    /// 楽観的 UI メッセージの送信時刻マップ（messageId → 送信時刻）
+    ///
+    /// 複数のメッセージを連続送信した場合でも各メッセージを個別に rollback できるよう
+    /// 辞書で管理する。NOTICE 受信時は rollback ウィンドウ内で最も古いものを除去する。
+    private var optimisticPendingMessages: [String: Date] = [:]
 
     /// 楽観的 UI メッセージを rollback する有効期間（秒）
     ///
@@ -182,8 +182,7 @@ final class ChatViewModel {
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil
-        lastOptimisticMessageId = nil
-        lastOptimisticSentAt = nil
+        optimisticPendingMessages.removeAll()
     }
 
     // MARK: - プライベートメソッド
@@ -247,8 +246,7 @@ final class ChatViewModel {
                 )
                 appendMessage(localMessage)
                 // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する
-                lastOptimisticMessageId = localMessage.id
-                lastOptimisticSentAt = Date()
+                optimisticPendingMessages[localMessage.id] = Date()
             }
         } catch {
             sendError = error.localizedDescription
@@ -264,7 +262,8 @@ final class ChatViewModel {
     /// サーバーから受信した NOTICE を処理する
     ///
     /// エラー系 msg-id に対応する ChatSendError を `sendError` に反映し、
-    /// rollback ウィンドウ内であれば楽観的 UI メッセージを `messages` から除去する。
+    /// rollback ウィンドウ内で最も古い楽観的 UI メッセージを `messages` から除去する。
+    /// 複数メッセージを連続送信した場合は各メッセージを個別に rollback する。
     private func handleIncomingNotice(_ notice: TwitchNotice) {
         guard let error = ChatSendError.from(notice: notice) else {
             // 情報系通知（host_on, host_off 等）は何もしない
@@ -272,13 +271,15 @@ final class ChatViewModel {
         }
         sendError = error.errorDescription
 
-        // rollback: 直近の楽観的 UI メッセージが rollback ウィンドウ内なら除去する
-        if let messageId = lastOptimisticMessageId,
-           let sentAt = lastOptimisticSentAt,
-           Date().timeIntervalSince(sentAt) <= Self.optimisticRollbackWindow {
-            messages.removeAll { $0.id == messageId }
-            lastOptimisticMessageId = nil
-            lastOptimisticSentAt = nil
+        // rollback: ウィンドウ内の pending メッセージのうち最も古いものを除去する
+        // Twitch はメッセージを受け付けた順に NOTICE を返すため、最も古い pending を除去する
+        let now = Date()
+        let windowStart = now.addingTimeInterval(-Self.optimisticRollbackWindow)
+        if let (oldestId, _) = optimisticPendingMessages
+            .filter({ $0.value >= windowStart })
+            .min(by: { $0.value < $1.value }) {
+            messages.removeAll { $0.id == oldestId }
+            optimisticPendingMessages.removeValue(forKey: oldestId)
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -75,11 +75,25 @@ final class ChatViewModel {
     /// チャンネルバッジフェッチタスク（切断時にキャンセル）
     private var channelBadgeFetchTask: Task<Void, Never>?
 
+    /// NOTICE 受信ループタスク（切断時にキャンセル）
+    private var noticeReceiveTask: Task<Void, Never>?
+
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false
 
     /// 最初に受信したメッセージから抽出した room-id（楽観的 UI の ChatMessage 生成に使用）
     private var currentRoomId: String?
+
+    /// 直近の楽観的 UI メッセージの ID（サーバー拒否時に rollback するために保持）
+    private var lastOptimisticMessageId: String?
+
+    /// 楽観的 UI メッセージの送信時刻（rollback 有効期間の判定に使用）
+    private var lastOptimisticSentAt: Date?
+
+    /// 楽観的 UI メッセージを rollback する有効期間（秒）
+    ///
+    /// この期間内に受信した NOTICE のみを直近の送信に対するサーバー拒否とみなす。
+    private static let optimisticRollbackWindow: TimeInterval = 5
 
     // MARK: - 初期化
 
@@ -131,6 +145,15 @@ final class ChatViewModel {
             }
         }
 
+        noticeReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.noticeStream
+            for await notice in stream {
+                guard !Task.isCancelled else { break }
+                self.handleIncomingNotice(notice)
+            }
+        }
+
         do {
             // ログイン済みなら認証接続、ログアウト中なら匿名接続にフォールバック
             let token = await authState.validAccessToken()
@@ -151,6 +174,7 @@ final class ChatViewModel {
     /// チャンネルから切断する
     func disconnect() async {
         receiveTask?.cancel()
+        noticeReceiveTask?.cancel()
         globalBadgeFetchTask?.cancel()
         channelBadgeFetchTask?.cancel()
         // BadgeStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
@@ -158,6 +182,8 @@ final class ChatViewModel {
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil
+        lastOptimisticMessageId = nil
+        lastOptimisticSentAt = nil
     }
 
     // MARK: - プライベートメソッド
@@ -220,6 +246,9 @@ final class ChatViewModel {
                     roomId: currentRoomId
                 )
                 appendMessage(localMessage)
+                // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する
+                lastOptimisticMessageId = localMessage.id
+                lastOptimisticSentAt = Date()
             }
         } catch {
             sendError = error.localizedDescription
@@ -230,6 +259,27 @@ final class ChatViewModel {
     /// 送信エラーをリセットする（UI でエラー表示を消す際に呼ぶ）
     func clearSendError() {
         sendError = nil
+    }
+
+    /// サーバーから受信した NOTICE を処理する
+    ///
+    /// エラー系 msg-id に対応する ChatSendError を `sendError` に反映し、
+    /// rollback ウィンドウ内であれば楽観的 UI メッセージを `messages` から除去する。
+    private func handleIncomingNotice(_ notice: TwitchNotice) {
+        guard let error = ChatSendError.from(notice: notice) else {
+            // 情報系通知（host_on, host_off 等）は何もしない
+            return
+        }
+        sendError = error.errorDescription
+
+        // rollback: 直近の楽観的 UI メッセージが rollback ウィンドウ内なら除去する
+        if let messageId = lastOptimisticMessageId,
+           let sentAt = lastOptimisticSentAt,
+           Date().timeIntervalSince(sentAt) <= Self.optimisticRollbackWindow {
+            messages.removeAll { $0.id == messageId }
+            lastOptimisticMessageId = nil
+            lastOptimisticSentAt = nil
+        }
     }
 
     /// IRC メッセージ送信用テキストのサニタイズ
@@ -258,6 +308,26 @@ enum ChatSendError: Error, LocalizedError, Equatable {
     case tooLong
     /// 送信できる状態でない（未接続・未ログイン・スコープ不足）
     case notReady
+    /// レートリミット超過（msg_ratelimit）
+    case rateLimited
+    /// 重複メッセージの連投（msg_duplicate）
+    case duplicate
+    /// エモートオンリーモード（msg_emoteonly）
+    case emoteOnly
+    /// フォロワー限定モード（msg_followersonly / msg_followersonly_followed / msg_followersonly_zero）
+    case followersOnly
+    /// サブスクライバー限定モード（msg_subsonly）
+    case subscribersOnly
+    /// スローモード中（msg_slowmode）
+    case slowMode
+    /// BAN またはチャンネル停止（msg_banned / msg_channel_suspended / tos_ban）
+    case banned
+    /// タイムアウト中（msg_timedout）
+    case timedOut
+    /// メール/電話番号認証が必要（msg_verified_email / msg_requires_verified_phone_number）
+    case verificationRequired
+    /// 上記以外のサーバー起因エラー（エラー文言をそのまま保持）
+    case serverRejected(String)
 
     var errorDescription: String? {
         switch self {
@@ -267,6 +337,70 @@ enum ChatSendError: Error, LocalizedError, Equatable {
             return "メッセージは500文字以内にしてください"
         case .notReady:
             return "コメントの投稿にはログインが必要です"
+        case .rateLimited:
+            return "メッセージの送信頻度が速すぎます。少し待ってから送信してください"
+        case .duplicate:
+            return "直前と同じメッセージは連投できません"
+        case .emoteOnly:
+            return "このチャンネルはエモートのみ送信できます"
+        case .followersOnly:
+            return "このチャンネルはフォロワー限定モードです"
+        case .subscribersOnly:
+            return "このチャンネルはサブスクライバー限定モードです"
+        case .slowMode:
+            return "スローモード中です。時間を空けて送信してください"
+        case .banned:
+            return "このチャンネルで投稿が制限されています"
+        case .timedOut:
+            return "タイムアウト中は投稿できません"
+        case .verificationRequired:
+            return "投稿にはメール/電話番号の認証が必要です"
+        case .serverRejected(let message):
+            return "送信できませんでした: \(message)"
         }
     }
+
+    /// TwitchNotice を ChatSendError に変換する
+    ///
+    /// 送信エラーに相当しない NOTICE（情報系通知など）は nil を返す。
+    ///
+    /// - Parameter notice: サーバーから受信した TwitchNotice
+    /// - Returns: 対応する ChatSendError、または変換対象外の場合は nil
+    static func from(notice: TwitchNotice) -> ChatSendError? {
+        guard let msgId = notice.msgId else { return nil }
+        if let mapped = msgIdToError[msgId] {
+            return mapped
+        }
+        // "msg_" プレフィックスを持つ未知の msg-id はサーバー起因エラーとして扱う
+        if msgId.hasPrefix("msg_") {
+            return .serverRejected(notice.message)
+        }
+        // 情報系通知（host_on, host_off, raid 等）は nil を返してスキップする
+        return nil
+    }
+
+    /// msg-id → ChatSendError のマッピングテーブル
+    ///
+    /// 複数の msg-id が同じエラーに対応する場合は同じ case を指定する。
+    private static let msgIdToError: [String: ChatSendError] = {
+        let entries: [(String, ChatSendError)] = [
+            ("msg_ratelimit",                          .rateLimited),
+            ("msg_duplicate",                          .duplicate),
+            ("msg_emoteonly",                          .emoteOnly),
+            ("msg_followersonly",                      .followersOnly),
+            ("msg_followersonly_followed",             .followersOnly),
+            ("msg_followersonly_zero",                 .followersOnly),
+            ("msg_subsonly",                           .subscribersOnly),
+            ("msg_slowmode",                           .slowMode),
+            ("msg_banned",                             .banned),
+            ("msg_channel_suspended",                  .banned),
+            ("tos_ban",                                .banned),
+            ("no_permission",                          .banned),
+            ("msg_suspended",                          .banned),
+            ("msg_timedout",                           .timedOut),
+            ("msg_verified_email",                     .verificationRequired),
+            ("msg_requires_verified_phone_number",     .verificationRequired),
+        ]
+        return Dictionary(uniqueKeysWithValues: entries)
+    }()
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -16,6 +16,8 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     private(set) var connectCallCount = 0
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
     let messageStream: AsyncStream<ChatMessage>
+    private var noticeContinuation: AsyncStream<TwitchNotice>.Continuation?
+    let noticeStream: AsyncStream<TwitchNotice>
 
     /// sendPrivmsg() で送信されたメッセージのログ（テスト検証用）
     private(set) var sentPrivmsgs: [String] = []
@@ -24,9 +26,13 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     var sendPrivmsgError: (any Error)?
 
     init() {
-        var continuation: AsyncStream<ChatMessage>.Continuation?
-        self.messageStream = AsyncStream { continuation = $0 }
-        self.messageContinuation = continuation
+        var msgContinuation: AsyncStream<ChatMessage>.Continuation?
+        self.messageStream = AsyncStream { msgContinuation = $0 }
+        self.messageContinuation = msgContinuation
+
+        var ntcContinuation: AsyncStream<TwitchNotice>.Continuation?
+        self.noticeStream = AsyncStream { ntcContinuation = $0 }
+        self.noticeContinuation = ntcContinuation
     }
 
     func connect(to channel: String, accessToken: String?, userLogin: String?) async throws {
@@ -38,6 +44,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         disconnectCalled = true
         connectedChannel = nil
         messageContinuation?.finish()
+        noticeContinuation?.finish()
     }
 
     func sendPrivmsg(_ text: String) async throws {
@@ -53,6 +60,11 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     /// テスト用にメッセージを流し込む
     func sendMessage(_ message: ChatMessage) {
         messageContinuation?.yield(message)
+    }
+
+    /// テスト用に NOTICE を流し込む
+    func sendNotice(_ notice: TwitchNotice) {
+        noticeContinuation?.yield(notice)
     }
 }
 
@@ -243,6 +255,99 @@ struct ChatViewModelTests {
 
         // 検証: ログアウト中は canSendMessage = false
         #expect(viewModel.canSendMessage == false)
+    }
+
+    // MARK: - NOTICE によるエラー反映
+
+    @Test("msg_ratelimit NOTICE を受信すると sendError にレートリミット文言が設定される")
+    func msgRatelimitNOTICEを受信するとsendErrorにレートリミット文言が設定される() async throws {
+        // 前提: 認証接続済みの状態
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者001")
+
+        // sendMessage で楽観 UI を追加してから NOTICE を流し込む
+        try await viewModel.sendMessage("速攻コメント")
+        await mockClient.sendNotice(TwitchNotice(
+            msgId: "msg_ratelimit",
+            channel: "テストチャンネル",
+            message: "You are sending messages too quickly."
+        ))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // 検証: sendError が日本語のレートリミット文言になっている
+        #expect(viewModel.sendError != nil)
+        #expect(viewModel.sendError == ChatSendError.rateLimited.errorDescription)
+    }
+
+    @Test("msg_duplicate NOTICE を受信すると楽観 UI メッセージが messages から取り消される")
+    func msgDuplicateNOTICEを受信すると楽観UIメッセージがmessagesから取り消される() async throws {
+        // 前提: 認証接続済みの状態
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者002")
+
+        // sendMessage で楽観 UI を追加してから NOTICE を流し込む
+        try await viewModel.sendMessage("同じ文言")
+        #expect(viewModel.messages.count == 1)
+
+        await mockClient.sendNotice(TwitchNotice(
+            msgId: "msg_duplicate",
+            channel: "テストチャンネル",
+            message: "Your message was not sent because it is identical to the previous one."
+        ))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // 検証: 楽観 UI メッセージが取り消されて messages が空になる
+        #expect(viewModel.messages.isEmpty)
+        #expect(viewModel.sendError == ChatSendError.duplicate.errorDescription)
+    }
+
+    @Test("msg_banned NOTICE を受信すると sendError に BAN 文言が設定される")
+    func msgBannedNOTICEを受信するとsendErrorにBAN文言が設定される() async throws {
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者003")
+
+        try await viewModel.sendMessage("書き込みテスト")
+        await mockClient.sendNotice(TwitchNotice(
+            msgId: "msg_banned",
+            channel: "テストチャンネル",
+            message: "You are permanently banned from talking in this channel."
+        ))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(viewModel.sendError == ChatSendError.banned.errorDescription)
+        // 楽観 UI メッセージも取り消される
+        #expect(viewModel.messages.isEmpty)
+    }
+
+    @Test("未対応の msg-id の NOTICE は sendError を変化させない")
+    func 未対応のmsgidのNOTICEはsendErrorを変化させない() async throws {
+        // 前提: 認証接続済みの状態
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者004")
+
+        // sendError が nil の状態から
+        #expect(viewModel.sendError == nil)
+
+        // 情報系 NOTICE（host_on など）を流し込む
+        await mockClient.sendNotice(TwitchNotice(
+            msgId: "host_on",
+            channel: "テストチャンネル",
+            message: "Now hosting another channel."
+        ))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        // 検証: sendError は変化しない
+        #expect(viewModel.sendError == nil)
+    }
+
+    @Test("msg-id なしの NOTICE は sendError を変化させない")
+    func msgidなしのNOTICEはsendErrorを変化させない() async throws {
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者005")
+
+        await mockClient.sendNotice(TwitchNotice(
+            msgId: nil,
+            channel: nil,
+            message: "Login unsuccessful"
+        ))
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(viewModel.sendError == nil)
     }
 
     @Test("isSending は sendMessage の実行中だけ true になる")

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -271,10 +271,9 @@ struct ChatViewModelTests {
             channel: "テストチャンネル",
             message: "You are sending messages too quickly."
         ))
-        try await Task.sleep(nanoseconds: 100_000_000)
 
         // 検証: sendError が日本語のレートリミット文言になっている
-        #expect(viewModel.sendError != nil)
+        await waitFor { viewModel.sendError != nil }
         #expect(viewModel.sendError == ChatSendError.rateLimited.errorDescription)
     }
 
@@ -292,9 +291,9 @@ struct ChatViewModelTests {
             channel: "テストチャンネル",
             message: "Your message was not sent because it is identical to the previous one."
         ))
-        try await Task.sleep(nanoseconds: 100_000_000)
 
         // 検証: 楽観 UI メッセージが取り消されて messages が空になる
+        await waitFor { viewModel.messages.isEmpty }
         #expect(viewModel.messages.isEmpty)
         #expect(viewModel.sendError == ChatSendError.duplicate.errorDescription)
     }
@@ -309,8 +308,8 @@ struct ChatViewModelTests {
             channel: "テストチャンネル",
             message: "You are permanently banned from talking in this channel."
         ))
-        try await Task.sleep(nanoseconds: 100_000_000)
 
+        await waitFor { viewModel.sendError != nil }
         #expect(viewModel.sendError == ChatSendError.banned.errorDescription)
         // 楽観 UI メッセージも取り消される
         #expect(viewModel.messages.isEmpty)
@@ -330,6 +329,7 @@ struct ChatViewModelTests {
             channel: "テストチャンネル",
             message: "Now hosting another channel."
         ))
+        // 十分に待ってから確認（状態変化がないことを確認するため最低限の待機）
         try await Task.sleep(nanoseconds: 100_000_000)
 
         // 検証: sendError は変化しない
@@ -345,6 +345,7 @@ struct ChatViewModelTests {
             channel: nil,
             message: "Login unsuccessful"
         ))
+        // 状態変化がないことを確認するため最低限の待機
         try await Task.sleep(nanoseconds: 100_000_000)
 
         #expect(viewModel.sendError == nil)
@@ -362,6 +363,22 @@ struct ChatViewModelTests {
     }
 
     // MARK: - ヘルパー
+
+    /// ViewModel の状態変化を条件が満たされるまで待機する
+    ///
+    /// `Task.sleep` による固定待機より確実に状態更新を待てる。
+    /// `timeout` 秒以内に条件が満たされなければタイムアウトとして抜ける。
+    ///
+    /// - Parameters:
+    ///   - timeout: 最大待機秒数（デフォルト 1.0 秒）
+    ///   - condition: 満たされるべき条件
+    private func waitFor(timeout: TimeInterval = 1.0, condition: () -> Bool) async {
+        let start = Date()
+        while !condition() {
+            if Date().timeIntervalSince(start) >= timeout { break }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms ポーリング
+        }
+    }
 
     /// テスト用の ChatMessage を生成する
     private func makeTestChatMessage(displayName: String, text: String) -> ChatMessage {

--- a/Tests/TwitchChatTests/IRCMessageParserTests.swift
+++ b/Tests/TwitchChatTests/IRCMessageParserTests.swift
@@ -148,6 +148,7 @@ struct IRCMessageParserTests {
         #expect(result?.command == "NOTICE")
         #expect(result?.tags["msg-id"] == "msg_duplicate")
         #expect(result?.params == ["#haishinsha"])
+        #expect(result?.trailing == "Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago.")
     }
 
     @Test("msg-id タグなしの NOTICE もパースできる")
@@ -159,6 +160,7 @@ struct IRCMessageParserTests {
         #expect(result != nil)
         #expect(result?.command == "NOTICE")
         #expect(result?.tags["msg-id"] == nil)
+        #expect(result?.params == ["*"])
         #expect(result?.trailing == "Login unsuccessful")
     }
 
@@ -171,6 +173,7 @@ struct IRCMessageParserTests {
         #expect(result?.command == "NOTICE")
         #expect(result?.tags["msg-id"] == "msg_banned")
         #expect(result?.params == ["#haishinsha"])
+        #expect(result?.trailing == "You are permanently banned from talking in haishinsha.")
     }
 
     // MARK: - 数値コマンド（RPL）

--- a/Tests/TwitchChatTests/IRCMessageParserTests.swift
+++ b/Tests/TwitchChatTests/IRCMessageParserTests.swift
@@ -123,6 +123,56 @@ struct IRCMessageParserTests {
         #expect(result?.tags["display-name"] == "テスト ユーザー")
     }
 
+    // MARK: - NOTICE メッセージ
+
+    @Test("msg-id タグ付き NOTICE をパースできる")
+    func msgidタグ付きNOTICEをパースできる() {
+        // Twitch がレートリミット超過時に返す NOTICE の実際の形式
+        let rawMessage = "@msg-id=msg_ratelimit :tmi.twitch.tv NOTICE #haishinsha :You are sending messages too quickly."
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "NOTICE")
+        #expect(result?.tags["msg-id"] == "msg_ratelimit")
+        #expect(result?.params == ["#haishinsha"])
+        #expect(result?.trailing == "You are sending messages too quickly.")
+        #expect(result?.prefix == "tmi.twitch.tv")
+    }
+
+    @Test("重複メッセージの NOTICE をパースできる")
+    func 重複メッセージのNOTICEをパースできる() {
+        let rawMessage = "@msg-id=msg_duplicate :tmi.twitch.tv NOTICE #haishinsha :Your message was not sent because it is identical to the previous one you sent, less than 30 seconds ago."
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "NOTICE")
+        #expect(result?.tags["msg-id"] == "msg_duplicate")
+        #expect(result?.params == ["#haishinsha"])
+    }
+
+    @Test("msg-id タグなしの NOTICE もパースできる")
+    func msgidタグなしのNOTICEもパースできる() {
+        // 匿名接続時など、msg-id が付かない NOTICE も IRC メッセージとして解析できる
+        let rawMessage = ":tmi.twitch.tv NOTICE * :Login unsuccessful"
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "NOTICE")
+        #expect(result?.tags["msg-id"] == nil)
+        #expect(result?.trailing == "Login unsuccessful")
+    }
+
+    @Test("msg-id=msg_banned の NOTICE をパースできる")
+    func msgidmsgbannedのNOTICEをパースできる() {
+        let rawMessage = "@msg-id=msg_banned :tmi.twitch.tv NOTICE #haishinsha :You are permanently banned from talking in haishinsha."
+        let result = IRCMessageParser.parse(rawMessage)
+
+        #expect(result != nil)
+        #expect(result?.command == "NOTICE")
+        #expect(result?.tags["msg-id"] == "msg_banned")
+        #expect(result?.params == ["#haishinsha"])
+    }
+
     // MARK: - 数値コマンド（RPL）
 
     @Test("数値コマンド 001 をパースできる")

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -305,7 +305,7 @@ struct TwitchIRCClientTests {
         await client.disconnect()
         connectTask.cancel()
 
-        // 検証: TwitchNotice が正しいプロパティで届く
+        // 検証: TwitchNotice が正しいプロパティで届く（"#haishinsha" → "haishinsha" に正規化）
         #expect(receivedNotices.count == 1)
         #expect(receivedNotices[0].msgId == "msg_ratelimit")
         #expect(receivedNotices[0].channel == "haishinsha")
@@ -336,9 +336,10 @@ struct TwitchIRCClientTests {
         await client.disconnect()
         connectTask.cancel()
 
-        // 検証: msgId が nil で message は trailing の通り
+        // 検証: msgId が nil、channel も nil（"*" はチャンネルではないため）、message は trailing の通り
         #expect(receivedNotices.count == 1)
         #expect(receivedNotices[0].msgId == nil)
+        #expect(receivedNotices[0].channel == nil)
         #expect(receivedNotices[0].message == "Login unsuccessful")
     }
 }

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -277,4 +277,68 @@ struct TwitchIRCClientTests {
         await client.disconnect()
         connectTask.cancel()
     }
+
+    // MARK: - NOTICE 受信
+
+    @Test("msg-id タグ付き NOTICE を受信すると noticeStream に TwitchNotice が流れる")
+    func msgidタグ付きNOTICEを受信するとnoticeStreamにTwitchNoticeが流れる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: NOTICE を事前にキュー
+        let rawNotice = "@msg-id=msg_ratelimit :tmi.twitch.tv NOTICE #haishinsha :You are sending messages too quickly."
+        await mockWS.enqueueMessage(rawNotice)
+
+        var receivedNotices: [TwitchNotice] = []
+        let noticeStream = await client.noticeStream
+
+        let connectTask = Task {
+            try await client.connect(to: "haishinsha", accessToken: "テスト用トークン", userLogin: "視聴者001")
+        }
+
+        // 最初の NOTICE を受信する
+        for await notice in noticeStream {
+            receivedNotices.append(notice)
+            break
+        }
+
+        await client.disconnect()
+        connectTask.cancel()
+
+        // 検証: TwitchNotice が正しいプロパティで届く
+        #expect(receivedNotices.count == 1)
+        #expect(receivedNotices[0].msgId == "msg_ratelimit")
+        #expect(receivedNotices[0].channel == "haishinsha")
+        #expect(receivedNotices[0].message == "You are sending messages too quickly.")
+    }
+
+    @Test("msg-id タグなしの NOTICE も noticeStream に流れ msgId が nil になる")
+    func msgidタグなしのNOTICEもnoticeStreamに流れmsgIdがnilになる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: msg-id タグがない NOTICE（匿名接続時など）
+        let rawNotice = ":tmi.twitch.tv NOTICE * :Login unsuccessful"
+        await mockWS.enqueueMessage(rawNotice)
+
+        var receivedNotices: [TwitchNotice] = []
+        let noticeStream = await client.noticeStream
+
+        let connectTask = Task {
+            try await client.connect(to: "testchannel")
+        }
+
+        for await notice in noticeStream {
+            receivedNotices.append(notice)
+            break
+        }
+
+        await client.disconnect()
+        connectTask.cancel()
+
+        // 検証: msgId が nil で message は trailing の通り
+        #expect(receivedNotices.count == 1)
+        #expect(receivedNotices[0].msgId == nil)
+        #expect(receivedNotices[0].message == "Login unsuccessful")
+    }
 }


### PR DESCRIPTION
## Summary

- Twitch IRC の `NOTICE` コマンドを受信して `msg-id` に応じた日本語エラーを UI に表示する（送信失敗が無音で起きる問題を解消）
- 拒否された楽観 UI メッセージを `messages` から取り消す rollback 機能を追加
- 対応する msg-id: `msg_ratelimit`, `msg_duplicate`, `msg_emoteonly`, `msg_followersonly`, `msg_subsonly`, `msg_slowmode`, `msg_banned`, `msg_timedout`, `msg_verified_email` など 10 種
- 情報系 NOTICE（`host_on`, `host_off` 等）は `sendError` に影響しない

## Changes

| ファイル | 変更内容 |
|---------|------|
| `Sources/TwitchChat/Models/TwitchNotice.swift`（新規） | `TwitchNotice` 構造体（msgId / channel / message） |
| `Sources/TwitchChat/Services/TwitchIRCClient.swift` | `noticeStream` 追加、`case "NOTICE"` ハンドラ、`#` プレフィックス判定 |
| `Sources/TwitchChat/ViewModels/ChatViewModel.swift` | `ChatSendError` 10 case + Dictionary マッピング、`noticeReceiveTask`、`handleIncomingNotice`、辞書ベースの rollback |

## Test plan

- [ ] `swift build` — 警告ゼロ
- [ ] `swift test --filter IRCMessageParserTests` — NOTICE パース 4 件通過
- [ ] `swift test --filter TwitchIRCClientTests` — noticeStream 配信 2 件通過
- [ ] `swift test --filter ChatViewModelTests` — エラー反映・rollback・非対応 msg-id 無視 5 件通過
- [ ] 手動: 認証接続後に同一メッセージを連投して `msg_duplicate` NOTICE と rollback を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * サーバー拒否時のエラーハンドリング機能を追加（レート制限、重複投稿、アカウント制限など）
  * メッセージ送信失敗時により詳細なエラーメッセージをユーザーに表示
  * サーバーから拒否されたメッセージを自動的にロールバックする最適化UIを実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->