### PR TITLE
feat: 自動再接続（切断検知 + 指数バックオフ）を実装する

### DIFF
--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -1,8 +1,72 @@
 // TwitchIRCClient.swift
 // Twitch IRC 接続を管理するクライアント
 // 匿名接続（justinfan 方式）と認証接続（OAuth トークン）の両方をサポートする
+// 予期せぬ切断時は指数バックオフで自動再接続する
 
 import Foundation
+
+// MARK: - 接続状態
+
+/// IRC クライアントの接続状態
+///
+/// `TwitchIRCClientProtocol.connectionStateStream` で配信される。
+/// ViewModel はこのストリームを購読して UI 上の接続状態インジケータを更新する。
+enum ClientConnectionState: Sendable, Equatable {
+    /// 接続済み（初回接続・再接続成功の両方）
+    case connected
+    /// 再接続中（指数バックオフでリトライ中）
+    ///
+    /// - Parameter attempt: 現在の再接続試行回数（1 始まり）
+    case reconnecting(attempt: Int)
+    /// 切断済み（意図的な disconnect() 後）
+    case disconnected
+}
+
+// MARK: - バックオフ設定
+
+/// 指数バックオフの設定
+///
+/// テスト時は `.fastTest` を注入して待機時間を短縮できる
+struct BackoffConfiguration: Sendable {
+    /// 初回遅延（秒）
+    let initialDelay: TimeInterval
+    /// 最大遅延（秒）
+    let maxDelay: TimeInterval
+    /// 遅延を増加させる倍率
+    let multiplier: Double
+    /// ジッタ率（0.0 〜 1.0）。計算遅延の ±jitterRatio 分がランダムに加減算される
+    let jitterRatio: Double
+
+    /// 本番環境向けデフォルト設定（1s → 2s → 4s → … 最大 60s、±20% ジッタ）
+    static let `default` = BackoffConfiguration(
+        initialDelay: 1.0, maxDelay: 60.0, multiplier: 2.0, jitterRatio: 0.2
+    )
+
+    /// テスト用の極小バックオフ（即時再接続、ジッタなし）
+    static let fastTest = BackoffConfiguration(
+        initialDelay: 0.01, maxDelay: 0.05, multiplier: 2.0, jitterRatio: 0.0
+    )
+}
+
+// MARK: - PING keepalive 設定
+
+/// 能動的 PING keepalive の設定
+///
+/// テスト時は間隔・タイムアウトを短縮した設定を注入して検証を高速化できる
+struct PingConfiguration: Sendable {
+    /// PING 送信間隔（秒）
+    let interval: TimeInterval
+    /// PONG 受信猶予（秒）。interval + timeout を過ぎても PONG が来なければタイムアウト扱い
+    let timeout: TimeInterval
+
+    /// 本番環境向けデフォルト設定（60 秒ごとに送信、30 秒で PONG タイムアウト）
+    static let `default` = PingConfiguration(interval: 60.0, timeout: 30.0)
+
+    /// テスト用の極小設定（即タイムアウト）
+    static let fastTest = PingConfiguration(interval: 0.05, timeout: 0.05)
+}
+
+// MARK: - プロトコル
 
 /// Twitch IRC クライアントの抽象化プロトコル
 ///
@@ -16,6 +80,12 @@ protocol TwitchIRCClientProtocol: Actor {
     /// レートリミット超過・BAN・スローモードなどのエラー通知が流れる。
     /// `CAP REQ :twitch.tv/commands` が有効な場合のみ `msg-id` タグ付きで届く。
     var noticeStream: AsyncStream<TwitchNotice> { get }
+
+    /// 接続状態の変化を配信する AsyncStream
+    ///
+    /// `.connected` / `.reconnecting(attempt:)` / `.disconnected` を順に yield する。
+    /// ViewModel はこれを購読して UI の接続インジケータを更新する。
+    var connectionStateStream: AsyncStream<ClientConnectionState> { get }
 
     /// 指定チャンネルに接続する
     ///
@@ -34,6 +104,8 @@ protocol TwitchIRCClientProtocol: Actor {
     /// - Throws: `.notConnected`（未接続）、`.notAuthenticated`（匿名接続中）
     func sendPrivmsg(_ text: String) async throws
 }
+
+// MARK: - TwitchIRCClient
 
 /// Twitch IRC クライアント
 ///
@@ -58,13 +130,32 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// 匿名接続で使用するニックネーム
     private static let anonymousNick = "justinfan12345"
 
-    // MARK: - プロパティ
+    // MARK: - ストリームプロパティ
+
+    /// 受信した ChatMessage を配信する AsyncStream
+    let messageStream: AsyncStream<ChatMessage>
+
+    /// サーバーから受信した NOTICE を配信する AsyncStream
+    let noticeStream: AsyncStream<TwitchNotice>
+
+    /// 接続状態の変化を配信する AsyncStream
+    let connectionStateStream: AsyncStream<ClientConnectionState>
+
+    // MARK: - プライベートプロパティ
 
     private let webSocketClient: any WebSocketClientProtocol
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
     private var noticeContinuation: AsyncStream<TwitchNotice>.Continuation?
+    private var connectionStateContinuation: AsyncStream<ClientConnectionState>.Continuation?
+
     /// 受信ループのタスク（disconnect() でキャンセルするために保持）
     private var receiveLoopTask: Task<Void, Never>?
+
+    /// PING keepalive タイマータスク
+    private var pingKeepaliveTask: Task<Void, Never>?
+
+    /// 最終 PONG 受信時刻（keepalive タイムアウト検知用）
+    private var lastPongAt: Date?
 
     /// 現在 JOIN しているチャンネル名（小文字正規化済み）
     ///
@@ -76,18 +167,39 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// true のときのみ PRIVMSG 送信が許可される（匿名接続では false）
     private var isAuthenticated: Bool = false
 
-    /// 受信した ChatMessage を配信する AsyncStream
-    let messageStream: AsyncStream<ChatMessage>
+    /// 再接続用に保持する接続引数
+    private var lastChannel: String?
+    private var lastAccessToken: String?
+    private var lastUserLogin: String?
 
-    /// サーバーから受信した NOTICE を配信する AsyncStream
-    let noticeStream: AsyncStream<TwitchNotice>
+    /// 意図的切断フラグ
+    ///
+    /// `disconnect()` で true にセットし、`connect()` で false にリセットする。
+    /// receiveLoop の catch ではこのフラグが false のときのみ再接続を行う。
+    private var isIntentionallyDisconnected: Bool = true
+
+    /// 現在の再接続試行回数（初回接続時は 0、再接続のたびに +1）
+    private var reconnectAttempt: Int = 0
+
+    /// バックオフ設定
+    private let backoffConfig: BackoffConfiguration
+
+    /// PING keepalive 設定
+    private let pingConfig: PingConfiguration
 
     // MARK: - 初期化
 
     /// TwitchIRCClient を初期化する
     ///
-    /// - Parameter webSocketClient: WebSocket クライアント実装（テスト時はモックを注入）
-    init(webSocketClient: any WebSocketClientProtocol = URLSessionWebSocketClient()) {
+    /// - Parameters:
+    ///   - webSocketClient: WebSocket クライアント実装（テスト時はモックを注入）
+    ///   - backoffConfig: 指数バックオフ設定（テスト時は `.fastTest` を指定して待機を短縮）
+    ///   - pingConfig: PING keepalive 設定（テスト時は `.fastTest` を指定）
+    init(
+        webSocketClient: any WebSocketClientProtocol = URLSessionWebSocketClient(),
+        backoffConfig: BackoffConfiguration = .default,
+        pingConfig: PingConfiguration = .default
+    ) {
         var msgContinuation: AsyncStream<ChatMessage>.Continuation?
         self.messageStream = AsyncStream { msgContinuation = $0 }
         self.messageContinuation = msgContinuation
@@ -96,7 +208,13 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         self.noticeStream = AsyncStream { ntcContinuation = $0 }
         self.noticeContinuation = ntcContinuation
 
+        var stateContinuation: AsyncStream<ClientConnectionState>.Continuation?
+        self.connectionStateStream = AsyncStream { stateContinuation = $0 }
+        self.connectionStateContinuation = stateContinuation
+
         self.webSocketClient = webSocketClient
+        self.backoffConfig = backoffConfig
+        self.pingConfig = pingConfig
     }
 
     // MARK: - 接続・切断
@@ -110,22 +228,50 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// - Throws: WebSocket 接続エラー
     func connect(to channel: String, accessToken: String? = nil, userLogin: String? = nil) async throws {
         let normalizedChannel = channel.lowercased()
+
+        // 再接続用に引数を保持する
+        lastChannel = normalizedChannel
+        lastAccessToken = accessToken
+        lastUserLogin = userLogin
+
+        // 意図的切断フラグをクリアし、試行回数をリセットする
+        isIntentionallyDisconnected = false
+        reconnectAttempt = 0
+
         try await webSocketClient.connect(to: Self.websocketURL)
         // 認証接続かどうかを記録してから認証シーケンスを送信
         isAuthenticated = (accessToken != nil && userLogin != nil)
         try await sendAuthSequence(channel: normalizedChannel, accessToken: accessToken, userLogin: userLogin)
         joinedChannel = normalizedChannel
+
+        // 接続成功を通知
+        connectionStateContinuation?.yield(.connected)
+
+        // PING keepalive タイマーを開始
+        startPingKeepalive()
+
         // receiveLoop を別タスクで起動し、connect() がブロックされないようにする
         receiveLoopTask = Task { await receiveLoop() }
     }
 
     /// IRC 接続を切断する
     func disconnect() async {
+        // 意図的切断フラグを立てて再接続を抑止する
+        isIntentionallyDisconnected = true
+
         receiveLoopTask?.cancel()
         receiveLoopTask = nil
+        stopPingKeepalive()
+
         await webSocketClient.disconnect()
         joinedChannel = nil
         isAuthenticated = false
+        lastChannel = nil
+        lastAccessToken = nil
+        lastUserLogin = nil
+
+        // 切断状態を通知
+        connectionStateContinuation?.yield(.disconnected)
         // messageContinuation?.finish() を呼ばない → 再接続時に同じストリームを再利用できる
     }
 
@@ -173,8 +319,9 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
     /// メッセージ受信ループ
     ///
-    /// WebSocket からメッセージを連続受信し、IRC メッセージを解析して配信する
-    /// 接続が切断されるまでループを継続する
+    /// WebSocket からメッセージを連続受信し、IRC メッセージを解析して配信する。
+    /// 予期せぬ切断（意図的切断・タスクキャンセル以外）が発生した場合は
+    /// `performReconnect()` を呼んでバックオフ付き再接続を試みる。
     private func receiveLoop() async {
         while true {
             do {
@@ -185,7 +332,16 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
                     await handleLine(line)
                 }
             } catch {
-                // 切断またはキャンセル時はループ終了
+                // 意図的切断またはタスクキャンセル時はループ終了（再接続しない）
+                // Task.isCancelled は receiveLoopTask?.cancel() で立つフラグ。
+                // webSocketClient.disconnect() が CancellationError を throw しても
+                // Task.isCancelled は立たないため、RECONNECT / PING タイムアウト起因の
+                // 切断を正しく再接続パスに誘導できる。
+                if isIntentionallyDisconnected || Task.isCancelled {
+                    break
+                }
+                // 予期せぬ切断 → バックオフ付き再接続を試みる
+                await performReconnect()
                 break
             }
         }
@@ -200,6 +356,10 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
             // PING に対して PONG を返してコネクションを維持する
             let server = ircMessage.trailing ?? "tmi.twitch.tv"
             try? await webSocketClient.send("PONG :\(server)")
+
+        case "PONG":
+            // keepalive の PONG 受信時刻を更新してタイムアウトをリセットする
+            lastPongAt = Date()
 
         case "PRIVMSG":
             // チャットメッセージを ChatMessage に変換して配信
@@ -221,9 +381,114 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
             )
             noticeContinuation?.yield(notice)
 
+        case "RECONNECT":
+            // Twitch サーバーがメンテナンス等で再接続を要求してきた場合
+            // webSocketClient を切断して receiveLoop の catch 経由でバックオフ再接続する
+            // （isIntentionallyDisconnected は立てないため再接続が走る）
+            await webSocketClient.disconnect()
+
         default:
             break
         }
+    }
+
+    // MARK: - 自動再接続
+
+    /// 指数バックオフで再接続を繰り返し試行する
+    ///
+    /// `isIntentionallyDisconnected` が false の間、バックオフ遅延を増やしながら
+    /// WebSocket 再接続と認証シーケンスの再送を試みる。
+    /// 成功したら `receiveLoop` と PING keepalive を再起動する。
+    private func performReconnect() async {
+        guard !isIntentionallyDisconnected, let channel = lastChannel else { return }
+
+        stopPingKeepalive()
+        await webSocketClient.disconnect() // 念のため既存接続を閉じる
+
+        while !isIntentionallyDisconnected {
+            reconnectAttempt += 1
+            connectionStateContinuation?.yield(.reconnecting(attempt: reconnectAttempt))
+
+            let delay = computeBackoffDelay(attempt: reconnectAttempt)
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                // キャンセル時は終了
+                return
+            }
+
+            if isIntentionallyDisconnected { return }
+
+            do {
+                try await webSocketClient.connect(to: Self.websocketURL)
+                isAuthenticated = (lastAccessToken != nil && lastUserLogin != nil)
+                try await sendAuthSequence(
+                    channel: channel,
+                    accessToken: lastAccessToken,
+                    userLogin: lastUserLogin
+                )
+                // 再接続成功
+                reconnectAttempt = 0
+                joinedChannel = channel
+                connectionStateContinuation?.yield(.connected)
+                receiveLoopTask = Task { await receiveLoop() }
+                startPingKeepalive()
+                return
+            } catch {
+                // 次のイテレーションで再試行（バックオフ増加）
+            }
+        }
+    }
+
+    /// 指数バックオフ遅延を計算する
+    ///
+    /// - Parameter attempt: 試行回数（1 始まり）
+    /// - Returns: 遅延秒数（上限 `maxDelay`、±`jitterRatio` のジッタ付き）
+    private func computeBackoffDelay(attempt: Int) -> TimeInterval {
+        let base = backoffConfig.initialDelay * pow(backoffConfig.multiplier, Double(attempt - 1))
+        let capped = min(base, backoffConfig.maxDelay)
+        let jitter = capped * backoffConfig.jitterRatio
+        return capped + Double.random(in: -jitter...jitter)
+    }
+
+    // MARK: - PING keepalive
+
+    /// 能動的 PING keepalive タイマーを開始する
+    ///
+    /// `pingConfig.interval` ごとに PING を送信し、PONG が来なければ
+    /// `interval + timeout` 経過でタイムアウトとして WebSocket を切断する。
+    private func startPingKeepalive() {
+        stopPingKeepalive()
+        lastPongAt = Date() // 接続直後は「今 PONG が来た」と同等に扱う
+        // pingConfig.interval を actor コンテキスト内でキャプチャしてから Task に渡す
+        let intervalNs = UInt64(pingConfig.interval * 1_000_000_000)
+        pingKeepaliveTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: intervalNs)
+                if Task.isCancelled { break }
+                await self?.performKeepalivePing()
+            }
+        }
+    }
+
+    /// keepalive タイマーを停止する
+    private func stopPingKeepalive() {
+        pingKeepaliveTask?.cancel()
+        pingKeepaliveTask = nil
+    }
+
+    /// keepalive 用の PING を送信し、PONG タイムアウトを検知する
+    ///
+    /// `lastPongAt` から `interval + timeout` 秒以上経過していれば、
+    /// ゾンビ接続とみなして webSocketClient を切断する（→ receiveLoop の catch → 再接続）。
+    private func performKeepalivePing() async {
+        if let last = lastPongAt,
+           Date().timeIntervalSince(last) > pingConfig.interval + pingConfig.timeout {
+            // PONG タイムアウト → 切断して receiveLoop の catch 経由で再接続をトリガー
+            await webSocketClient.disconnect()
+            return
+        }
+        try? await webSocketClient.send("PING :tmi.twitch.tv")
     }
 }
 

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -174,9 +174,11 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
     /// 意図的切断フラグ
     ///
-    /// `disconnect()` で true にセットし、`connect()` で false にリセットする。
-    /// receiveLoop の catch ではこのフラグが false のときのみ再接続を行う。
-    private var isIntentionallyDisconnected: Bool = true
+    /// 初回 `connect()` 呼び出しで false にリセットされ、`disconnect()` で true に戻る。
+    /// `receiveLoop` / `performReconnect` はこのフラグが false のときのみ再接続を行う。
+    /// 初期値 false は connect() 前に receiveLoop / performReconnect が起動しないため
+    /// 実質的に観測可能な影響はないが、意味的に「まだ接続していない」状態と整合させる。
+    private var isIntentionallyDisconnected: Bool = false
 
     /// 現在の再接続試行回数（初回接続時は 0、再接続のたびに +1）
     private var reconnectAttempt: Int = 0
@@ -421,12 +423,16 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
             do {
                 try await webSocketClient.connect(to: Self.websocketURL)
+                // 接続成功後に意図的切断が呼ばれた場合は即リターン
+                if isIntentionallyDisconnected { await webSocketClient.disconnect(); return }
                 isAuthenticated = (lastAccessToken != nil && lastUserLogin != nil)
                 try await sendAuthSequence(
                     channel: channel,
                     accessToken: lastAccessToken,
                     userLogin: lastUserLogin
                 )
+                // 認証シーケンス送信後に意図的切断が呼ばれた場合は即リターン
+                if isIntentionallyDisconnected { await webSocketClient.disconnect(); return }
                 // 再接続成功
                 reconnectAttempt = 0
                 joinedChannel = channel
@@ -448,7 +454,7 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         let base = backoffConfig.initialDelay * pow(backoffConfig.multiplier, Double(attempt - 1))
         let capped = min(base, backoffConfig.maxDelay)
         let jitter = capped * backoffConfig.jitterRatio
-        return capped + Double.random(in: -jitter...jitter)
+        return max(0, capped + Double.random(in: -jitter...jitter))
     }
 
     // MARK: - PING keepalive
@@ -484,7 +490,9 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     private func performKeepalivePing() async {
         if let last = lastPongAt,
            Date().timeIntervalSince(last) > pingConfig.interval + pingConfig.timeout {
-            // PONG タイムアウト → 切断して receiveLoop の catch 経由で再接続をトリガー
+            // PONG タイムアウト → keepalive タイマーを停止してから切断し、
+            // receiveLoop の catch 経由で再接続をトリガーする
+            stopPingKeepalive()
             await webSocketClient.disconnect()
             return
         }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -13,6 +13,10 @@ enum ConnectionState: Equatable {
     case connecting
     /// 接続済み
     case connected
+    /// 再接続中（切断検知後、指数バックオフでリトライ中）
+    ///
+    /// - Parameter attempt: 現在の再接続試行回数（1 始まり）
+    case reconnecting(attempt: Int)
     /// エラー
     case error(String)
 
@@ -21,6 +25,7 @@ enum ConnectionState: Equatable {
         case (.disconnected, .disconnected): return true
         case (.connecting, .connecting): return true
         case (.connected, .connected): return true
+        case (.reconnecting(let l), .reconnecting(let r)): return l == r
         case (.error(let l), .error(let r)): return l == r
         default: return false
         }
@@ -77,6 +82,9 @@ final class ChatViewModel {
 
     /// NOTICE 受信ループタスク（切断時にキャンセル）
     private var noticeReceiveTask: Task<Void, Never>?
+
+    /// IRC クライアントの接続状態変化を購読するタスク（切断時にキャンセル）
+    private var connectionStateReceiveTask: Task<Void, Never>?
 
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false
@@ -154,6 +162,16 @@ final class ChatViewModel {
             }
         }
 
+        // IRC クライアントの接続状態変化（再接続 / 再接続成功）を ViewModel の状態に反映する
+        connectionStateReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.connectionStateStream
+            for await state in stream {
+                guard !Task.isCancelled else { break }
+                self.applyClientConnectionState(state)
+            }
+        }
+
         do {
             // ログイン済みなら認証接続、ログアウト中なら匿名接続にフォールバック
             let token = await authState.validAccessToken()
@@ -177,6 +195,7 @@ final class ChatViewModel {
     func disconnect() async {
         receiveTask?.cancel()
         noticeReceiveTask?.cancel()
+        connectionStateReceiveTask?.cancel()
         globalBadgeFetchTask?.cancel()
         channelBadgeFetchTask?.cancel()
         // BadgeStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
@@ -203,6 +222,23 @@ final class ChatViewModel {
         messages.append(message)
         if messages.count > Self.maxMessages {
             messages.removeFirst(messages.count - Self.maxMessages)
+        }
+    }
+
+    /// IRC クライアントから通知された接続状態を ViewModel の ConnectionState に反映する
+    ///
+    /// - `.connected` → `.connected`（再接続成功時も含む。`messages` はリセットしない）
+    /// - `.reconnecting(attempt:)` → `.reconnecting(attempt:)`
+    /// - `.disconnected` → 無視（`disconnect()` で明示的に遷移させるため）
+    private func applyClientConnectionState(_ state: ClientConnectionState) {
+        switch state {
+        case .connected:
+            connectionState = .connected
+        case .reconnecting(let attempt):
+            connectionState = .reconnecting(attempt: attempt)
+        case .disconnected:
+            // ViewModel.disconnect() で明示的に .disconnected へ遷移させるので無視
+            break
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -187,6 +187,7 @@ final class ChatViewModel {
             connectionState = .error(error.localizedDescription)
             receiveTask?.cancel()
             noticeReceiveTask?.cancel()
+            connectionStateReceiveTask?.cancel()
             globalBadgeFetchTask?.cancel()
         }
     }
@@ -231,6 +232,8 @@ final class ChatViewModel {
     /// - `.reconnecting(attempt:)` → `.reconnecting(attempt:)`
     /// - `.disconnected` → 無視（`disconnect()` で明示的に遷移させるため）
     private func applyClientConnectionState(_ state: ClientConnectionState) {
+        // 切断済み状態に遅延到達した通知が上書きしないようにガードする
+        guard connectionState != .disconnected else { return }
         switch state {
         case .connected:
             connectionState = .connected

--- a/Sources/TwitchChat/Views/ConnectionState+Color.swift
+++ b/Sources/TwitchChat/Views/ConnectionState+Color.swift
@@ -15,6 +15,7 @@ extension ConnectionState {
         switch self {
         case .connected: .green
         case .connecting: .yellow
+        case .reconnecting: .orange
         case .error: .red
         case .disconnected: .gray
         }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -132,12 +132,12 @@ struct ChatViewModelTests {
 
         // 前提: チャンネルに接続する
         await viewModel.connect(to: "テストチャンネル")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .connected }
         #expect(viewModel.connectionState == .connected)
 
         // IRC クライアントが再接続中を通知する
         await mockClient.sendConnectionState(.reconnecting(attempt: 1))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .reconnecting(attempt: 1) }
 
         // 検証: ViewModel が .reconnecting(attempt: 1) 状態になる
         #expect(viewModel.connectionState == .reconnecting(attempt: 1))
@@ -150,15 +150,15 @@ struct ChatViewModelTests {
 
         // 前提: チャンネルに接続してメッセージを受信する
         await viewModel.connect(to: "テストチャンネル")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .connected }
         let message = makeTestChatMessage(displayName: "視聴者001", text: "再接続テスト前のメッセージ")
         await mockClient.sendMessage(message)
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.messages.count == 1 }
         #expect(viewModel.messages.count == 1)
 
         // 再接続中を通知する
         await mockClient.sendConnectionState(.reconnecting(attempt: 1))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .reconnecting(attempt: 1) }
 
         // 検証: メッセージ履歴がリセットされていない
         #expect(viewModel.messages.count == 1)
@@ -172,15 +172,15 @@ struct ChatViewModelTests {
 
         // 前提: 接続 → 再接続中 → 再接続成功の遷移
         await viewModel.connect(to: "テストチャンネル")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .connected }
 
         await mockClient.sendConnectionState(.reconnecting(attempt: 1))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .reconnecting(attempt: 1) }
         #expect(viewModel.connectionState == .reconnecting(attempt: 1))
 
         // 再接続成功を通知する
         await mockClient.sendConnectionState(.connected)
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.connectionState == .connected }
 
         // 検証: .connected に戻る
         #expect(viewModel.connectionState == .connected)

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -18,6 +18,8 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     let messageStream: AsyncStream<ChatMessage>
     private var noticeContinuation: AsyncStream<TwitchNotice>.Continuation?
     let noticeStream: AsyncStream<TwitchNotice>
+    private var connectionStateContinuation: AsyncStream<ClientConnectionState>.Continuation?
+    let connectionStateStream: AsyncStream<ClientConnectionState>
 
     /// sendPrivmsg() で送信されたメッセージのログ（テスト検証用）
     private(set) var sentPrivmsgs: [String] = []
@@ -33,11 +35,17 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         var ntcContinuation: AsyncStream<TwitchNotice>.Continuation?
         self.noticeStream = AsyncStream { ntcContinuation = $0 }
         self.noticeContinuation = ntcContinuation
+
+        var stateContinuation: AsyncStream<ClientConnectionState>.Continuation?
+        self.connectionStateStream = AsyncStream { stateContinuation = $0 }
+        self.connectionStateContinuation = stateContinuation
     }
 
     func connect(to channel: String, accessToken: String?, userLogin: String?) async throws {
         connectCallCount += 1
         connectedChannel = channel
+        // 接続成功を connectionStateStream に通知する
+        connectionStateContinuation?.yield(.connected)
     }
 
     func disconnect() async {
@@ -45,6 +53,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         connectedChannel = nil
         messageContinuation?.finish()
         noticeContinuation?.finish()
+        connectionStateContinuation?.finish()
     }
 
     func sendPrivmsg(_ text: String) async throws {
@@ -65,6 +74,11 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     /// テスト用に NOTICE を流し込む
     func sendNotice(_ notice: TwitchNotice) {
         noticeContinuation?.yield(notice)
+    }
+
+    /// テスト用に接続状態を流し込む（再接続シミュレーション用）
+    func sendConnectionState(_ state: ClientConnectionState) {
+        connectionStateContinuation?.yield(state)
     }
 }
 
@@ -109,6 +123,67 @@ struct ChatViewModelTests {
         await viewModel.disconnect()
 
         #expect(viewModel.connectionState == .disconnected)
+    }
+
+    @Test("IRC クライアントが reconnecting を通知すると ViewModel も reconnecting 状態になる")
+    func IRCクライアントがreconnectingを通知するとViewModelもreconnecting状態になる() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        // 前提: チャンネルに接続する
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(viewModel.connectionState == .connected)
+
+        // IRC クライアントが再接続中を通知する
+        await mockClient.sendConnectionState(.reconnecting(attempt: 1))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: ViewModel が .reconnecting(attempt: 1) 状態になる
+        #expect(viewModel.connectionState == .reconnecting(attempt: 1))
+    }
+
+    @Test("再接続中にメッセージ履歴がリセットされない")
+    func 再接続中にメッセージ履歴がリセットされない() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        // 前提: チャンネルに接続してメッセージを受信する
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let message = makeTestChatMessage(displayName: "視聴者001", text: "再接続テスト前のメッセージ")
+        await mockClient.sendMessage(message)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(viewModel.messages.count == 1)
+
+        // 再接続中を通知する
+        await mockClient.sendConnectionState(.reconnecting(attempt: 1))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: メッセージ履歴がリセットされていない
+        #expect(viewModel.messages.count == 1)
+        #expect(viewModel.messages[0].displayName == "視聴者001")
+    }
+
+    @Test("再接続成功（connected 通知）で ViewModel が connected 状態に戻る")
+    func 再接続成功でViewModelがconnected状態に戻る() async throws {
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+
+        // 前提: 接続 → 再接続中 → 再接続成功の遷移
+        await viewModel.connect(to: "テストチャンネル")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        await mockClient.sendConnectionState(.reconnecting(attempt: 1))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(viewModel.connectionState == .reconnecting(attempt: 1))
+
+        // 再接続成功を通知する
+        await mockClient.sendConnectionState(.connected)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: .connected に戻る
+        #expect(viewModel.connectionState == .connected)
     }
 
     // MARK: - メッセージ受信

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -561,10 +561,11 @@ struct TwitchIRCClientTests {
         }
 
         // PING が 2 回以上送信されるまで待機（最大 2 秒、並行テスト実行時の遅延を許容）
-        await waitFor(timeout: 2.0) {
+        let waitSucceeded = await waitFor(timeout: 2.0) {
             let sent = await mockWS.sentMessages
             return sent.filter { $0 == "PING :tmi.twitch.tv" }.count >= 2
         }
+        #expect(waitSucceeded, "タイムアウト前に PING が 2 回送信されなかった")
 
         // 検証: keepalive PING が少なくとも 2 回送信されている
         let sent = await mockWS.sentMessages

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -581,8 +581,8 @@ struct TwitchIRCClientTests {
         let client = TwitchIRCClient(
             webSocketClient: mockWS,
             backoffConfig: .fastTest,
-            // 前提: interval=0.05s, timeout=0.05s → 0.1s 後にタイムアウト検知
-            pingConfig: PingConfiguration(interval: 0.05, timeout: 0.05)
+            // 前提: interval=0.05s, timeout=0.1s → 0.15s 後にタイムアウト検知
+            pingConfig: PingConfiguration(interval: 0.05, timeout: 0.1)
         )
 
         // チャンネルに接続する（PONG は返さない）

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -21,10 +21,17 @@ actor MockWebSocketClient: WebSocketClientProtocol {
     /// 接続済みフラグ
     private(set) var isConnected = false
 
+    /// connect(to:) の呼び出し回数（再接続検証用）
+    private(set) var connectCallCount = 0
+
     /// 受信を待機する継続
     private var pendingReceiveContinuations: [CheckedContinuation<String, Error>] = []
 
+    /// 次の receive() で throw するエラーのキュー
+    private var scheduledErrors: [any Error] = []
+
     func connect(to url: URL) async throws {
+        connectCallCount += 1
         isConnected = true
     }
 
@@ -33,6 +40,10 @@ actor MockWebSocketClient: WebSocketClientProtocol {
     }
 
     func receive() async throws -> String {
+        // 予約エラーがあれば throw する
+        if !scheduledErrors.isEmpty {
+            throw scheduledErrors.removeFirst()
+        }
         // キューにメッセージがあれば即返す
         if !receivableMessages.isEmpty {
             return receivableMessages.removeFirst()
@@ -59,6 +70,17 @@ actor MockWebSocketClient: WebSocketClientProtocol {
             continuation.resume(returning: message)
         } else {
             receivableMessages.append(message)
+        }
+    }
+
+    /// 次の receive() でエラーを throw するように予約する（予期せぬ切断のシミュレーション用）
+    func throwOnNextReceive(_ error: any Error) {
+        if let continuation = pendingReceiveContinuations.first {
+            // 既に receive() で待機中なら即時エラー
+            pendingReceiveContinuations.removeFirst()
+            continuation.resume(throwing: error)
+        } else {
+            scheduledErrors.append(error)
         }
     }
 }
@@ -341,5 +363,258 @@ struct TwitchIRCClientTests {
         #expect(receivedNotices[0].msgId == nil)
         #expect(receivedNotices[0].channel == nil)
         #expect(receivedNotices[0].message == "Login unsuccessful")
+    }
+
+    // MARK: - 自動再接続
+
+    @Test("予期せぬ切断後にバックオフ付きで再接続シーケンスが再送される")
+    func 予期せぬ切断後にバックオフ付きで再接続シーケンスが再送される() async throws {
+        let mockWS = MockWebSocketClient()
+        // 前提: テスト用に極小バックオフを注入（0.01s で即再接続）
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            pingConfig: .fastTest
+        )
+
+        // チャンネル接続
+        let connectTask = Task {
+            try await client.connect(to: "haishinshaB", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000) // 接続完了を待つ
+
+        // 1回目の接続で JOIN が送られていることを確認
+        let sentBeforeDisconnect = await mockWS.sentMessages
+        #expect(sentBeforeDisconnect.contains("JOIN #haishinshab"))
+
+        // 予期せぬ切断をシミュレート（ネットワーク喪失エラー）
+        await mockWS.throwOnNextReceive(URLError(.networkConnectionLost))
+
+        // 再接続が走るまで待機（connectCallCount が 2 以上になるまでポーリング）
+        await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+
+        try await Task.sleep(nanoseconds: 100_000_000) // 再接続後の認証シーケンス送信を待つ
+
+        // 検証: 再接続後に JOIN が再送されている
+        let sentAfterReconnect = await mockWS.sentMessages
+        let joinCount = sentAfterReconnect.filter { $0 == "JOIN #haishinshab" }.count
+        #expect(joinCount >= 2)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("意図的な disconnect() の後は再接続しない")
+    func 意図的なdisconnect後は再接続しない() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            pingConfig: .fastTest
+        )
+
+        // 前提: チャンネルに接続する
+        let connectTask = Task {
+            try await client.connect(to: "視聴者ちゃんねる", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 初回接続が1回であることを確認
+        let countAfterConnect = await mockWS.connectCallCount
+        #expect(countAfterConnect == 1)
+
+        // 意図的に切断する
+        await client.disconnect()
+        connectTask.cancel()
+
+        // 十分な時間待っても再接続が走らないことを確認（fastTest でも 200ms は十分）
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        // 検証: connectCallCount が 1 のまま（再接続していない）
+        let countAfterDisconnect = await mockWS.connectCallCount
+        #expect(countAfterDisconnect == 1)
+    }
+
+    @Test("RECONNECT コマンド受信時に再接続が走る")
+    func RECONNECTコマンド受信時に再接続が走る() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            pingConfig: .fastTest
+        )
+
+        // 前提: チャンネルに接続する
+        let connectTask = Task {
+            try await client.connect(to: "配信者ABC", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let countAfterConnect = await mockWS.connectCallCount
+        #expect(countAfterConnect == 1)
+
+        // Twitch からの RECONNECT コマンドを送り込む
+        await mockWS.enqueueMessage(":tmi.twitch.tv RECONNECT")
+
+        // 再接続が走るまで待機
+        await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+
+        // 検証: 再接続が走っている
+        let countAfterReconnect = await mockWS.connectCallCount
+        #expect(countAfterReconnect >= 2)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("再接続中は connectionStateStream に reconnecting(attempt:) が流れる")
+    func 再接続中はconnectionStateStreamにreconnectingが流れる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            pingConfig: .fastTest
+        )
+
+        // 前提: connectionStateStream を購読して reconnecting を待機
+        let stateStream = await client.connectionStateStream
+
+        // チャンネルに接続する
+        let connectTask = Task {
+            try await client.connect(to: "配信者XYZ", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 予期せぬ切断をシミュレート
+        await mockWS.throwOnNextReceive(URLError(.networkConnectionLost))
+
+        // connectionStateStream から .connected → .reconnecting の遷移を受け取る
+        var receivedConnected = false
+        var receivedReconnecting = false
+        for await state in stateStream {
+            if state == .connected { receivedConnected = true }
+            if case .reconnecting(1) = state { receivedReconnecting = true; break }
+        }
+
+        // 検証: connected の後に reconnecting(attempt: 1) が流れる
+        #expect(receivedConnected)
+        #expect(receivedReconnecting)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("再接続成功後は connectionStateStream に connected が流れる")
+    func 再接続成功後はconnectionStateStreamにconnectedが流れる() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            pingConfig: .fastTest
+        )
+
+        // 前提: connectionStateStream を購読
+        let stateStream = await client.connectionStateStream
+
+        // チャンネルに接続する
+        let connectTask = Task {
+            try await client.connect(to: "配信者DDD", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 予期せぬ切断をシミュレート
+        await mockWS.throwOnNextReceive(URLError(.networkConnectionLost))
+
+        // .reconnecting の後の .connected を待つ
+        var seenReconnecting = false
+        var seenConnectedAfterReconnect = false
+        for await state in stateStream {
+            if case .reconnecting = state { seenReconnecting = true }
+            if seenReconnecting && state == .connected {
+                seenConnectedAfterReconnect = true
+                break
+            }
+        }
+
+        // 検証: 再接続成功で .connected に戻っている
+        #expect(seenConnectedAfterReconnect)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("PING keepalive の PING が周期的に送信される")
+    func PING_keepaliveのPINGが周期的に送信される() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .default,
+            // 前提: PING 間隔を短縮（0.05s ごとに送信）
+            pingConfig: PingConfiguration(interval: 0.05, timeout: 30.0)
+        )
+
+        // チャンネルに接続する
+        let connectTask = Task {
+            try await client.connect(to: "配信者EEE", accessToken: nil, userLogin: nil)
+        }
+
+        // PING が 2 回以上送信されるまで待機（最大 2 秒、並行テスト実行時の遅延を許容）
+        await waitFor(timeout: 2.0) {
+            let sent = await mockWS.sentMessages
+            return sent.filter { $0 == "PING :tmi.twitch.tv" }.count >= 2
+        }
+
+        // 検証: keepalive PING が少なくとも 2 回送信されている
+        let sent = await mockWS.sentMessages
+        let pingCount = sent.filter { $0 == "PING :tmi.twitch.tv" }.count
+        #expect(pingCount >= 2)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("PONG が届かなければ PING タイムアウトで切断→再接続が走る")
+    func PONGが届かなければPINGタイムアウトで切断後再接続が走る() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(
+            webSocketClient: mockWS,
+            backoffConfig: .fastTest,
+            // 前提: interval=0.05s, timeout=0.05s → 0.1s 後にタイムアウト検知
+            pingConfig: PingConfiguration(interval: 0.05, timeout: 0.05)
+        )
+
+        // チャンネルに接続する（PONG は返さない）
+        let connectTask = Task {
+            try await client.connect(to: "配信者FFF", accessToken: nil, userLogin: nil)
+        }
+        try await Task.sleep(nanoseconds: 50_000_000) // 接続完了を待つ
+
+        let countAfterConnect = await mockWS.connectCallCount
+        #expect(countAfterConnect == 1)
+
+        // PONG を返さずに待機 → interval + timeout 経過でタイムアウト → 再接続
+        await waitFor(timeout: 3.0) { await mockWS.connectCallCount >= 2 }
+
+        // 検証: 再接続が走っている
+        let countAfterTimeout = await mockWS.connectCallCount
+        #expect(countAfterTimeout >= 2)
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    // MARK: - テストヘルパー
+
+    /// 条件が満たされるまで最大 `timeout` 秒ポーリングする（10ms 間隔）
+    ///
+    /// - Parameters:
+    ///   - timeout: 最大待機秒数（デフォルト 1.0 秒）
+    ///   - condition: 満たされるべき非同期条件
+    private func waitFor(timeout: TimeInterval = 1.0, condition: () async -> Bool) async {
+        let start = Date()
+        while Date().timeIntervalSince(start) < timeout {
+            if await condition() { return }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms ポーリング
+        }
     }
 }

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -391,7 +391,8 @@ struct TwitchIRCClientTests {
         await mockWS.throwOnNextReceive(URLError(.networkConnectionLost))
 
         // 再接続が走るまで待機（connectCallCount が 2 以上になるまでポーリング）
-        await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+        let reconnected = await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+        #expect(reconnected, "タイムアウト前に再接続が完了しなかった")
 
         try await Task.sleep(nanoseconds: 100_000_000) // 再接続後の認証シーケンス送信を待つ
 
@@ -457,7 +458,8 @@ struct TwitchIRCClientTests {
         await mockWS.enqueueMessage(":tmi.twitch.tv RECONNECT")
 
         // 再接続が走るまで待機
-        await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+        let reconnected = await waitFor(timeout: 2.0) { await mockWS.connectCallCount >= 2 }
+        #expect(reconnected, "タイムアウト前に再接続が完了しなかった")
 
         // 検証: 再接続が走っている
         let countAfterReconnect = await mockWS.connectCallCount
@@ -593,7 +595,8 @@ struct TwitchIRCClientTests {
         #expect(countAfterConnect == 1)
 
         // PONG を返さずに待機 → interval + timeout 経過でタイムアウト → 再接続
-        await waitFor(timeout: 3.0) { await mockWS.connectCallCount >= 2 }
+        let reconnected = await waitFor(timeout: 3.0) { await mockWS.connectCallCount >= 2 }
+        #expect(reconnected, "タイムアウト前に PING タイムアウト再接続が完了しなかった")
 
         // 検証: 再接続が走っている
         let countAfterTimeout = await mockWS.connectCallCount
@@ -610,11 +613,14 @@ struct TwitchIRCClientTests {
     /// - Parameters:
     ///   - timeout: 最大待機秒数（デフォルト 1.0 秒）
     ///   - condition: 満たされるべき非同期条件
-    private func waitFor(timeout: TimeInterval = 1.0, condition: () async -> Bool) async {
+    /// - Returns: 条件が満たされた場合は `true`、タイムアウトした場合は `false`
+    @discardableResult
+    private func waitFor(timeout: TimeInterval = 1.0, condition: () async -> Bool) async -> Bool {
         let start = Date()
         while Date().timeIntervalSince(start) < timeout {
-            if await condition() { return }
+            if await condition() { return true }
             try? await Task.sleep(nanoseconds: 10_000_000) // 10ms ポーリング
         }
+        return false
     }
 }


### PR DESCRIPTION
## Summary

- `TwitchIRCClient` に指数バックオフ自動再接続ロジックを追加（1s→2s→4s…最大 60s、±20% ジッタ）
- 意図的切断（`disconnect()` 呼び出し）と予期せぬ切断を `isIntentionallyDisconnected` フラグで区別
- Twitch の `RECONNECT` コマンド受信時に再接続をトリガー
- 能動的 PING keepalive タイマー（60s 間隔、30s PONG タイムアウト）を追加
- `ClientConnectionState` / `BackoffConfiguration` / `PingConfiguration` 型を追加（DI でテスト短縮可能）
- `ChatViewModel` に `ConnectionState.reconnecting(attempt:)` を追加し、IRC クライアントの `connectionStateStream` を購読
- 再接続時にメッセージ履歴（`messages`）をリセットしない

## Test plan

- [ ] `swift test` — 177 テスト全パス（新規 +10 件）
- [ ] `swift build` — 警告ゼロ
- [ ] 手動検証: Wi-Fi を切断 → 接続インジケータがオレンジ（`.reconnecting`）に変わる
- [ ] 手動検証: Wi-Fi を復帰 → 緑（`.connected`）に戻りチャットが流れる
- [ ] 手動検証: アプリから手動切断 → 灰色のまま（再接続が走らない）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 自動再接続（指数バックオフ）を実装。再接続試行の状態がストリームで通知されるように
  * アクティブなキープアライブ（PING/PONG）で接続健全性を監視

* **改善**
  * 再接続中の状態をオレンジで表示
  * 再接続中もメッセージ履歴を保持
  * 再接続/キープアライブの挙動を調整できる設定プリセットを追加

* **テスト**
  * 再接続・キープアライブ・状態遷移を検証する包括的なテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->