### PR TITLE
feat: USERSTATE パースで楽観 UI の displayName / color / badges を正確に表示する

### DIFF
--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -77,18 +77,22 @@ struct ChatMessage: Sendable, Identifiable {
     ///   - displayName: 表示名（省略時は username と同じ値を使用）
     ///   - text: 送信したメッセージ本文
     ///   - roomId: 接続中チャンネルの room-id（既知の場合は渡す、省略可）
+    ///   - colorHex: チャット文字色（#RRGGBB 形式、USERSTATE から取得した場合に指定）
+    ///   - badges: バッジ一覧（USERSTATE から取得した場合に指定）
     init(
         localUsername username: String,
         displayName: String? = nil,
         text: String,
-        roomId: String? = nil
+        roomId: String? = nil,
+        colorHex: String? = nil,
+        badges: [Badge] = []
     ) {
         self.id = UUID().uuidString
         self.username = username
         self.displayName = displayName ?? username
         self.text = text
-        self.colorHex = nil
-        self.badges = []
+        self.colorHex = colorHex
+        self.badges = badges
         self.emotes = []
         self.segments = MessageSegment.segments(from: text, emotePositions: [])
         self.roomId = roomId

--- a/Sources/TwitchChat/Models/TwitchUserState.swift
+++ b/Sources/TwitchChat/Models/TwitchUserState.swift
@@ -1,0 +1,41 @@
+// TwitchUserState.swift
+// Twitch IRC USERSTATE コマンドを表すモデル
+// 認証接続後に届く自分のユーザー情報（表示名・チャット色・バッジ）を保持する
+
+/// Twitch IRC の USERSTATE コマンドから抽出したユーザー状態
+///
+/// 認証接続後、チャンネルに JOIN した直後やメッセージ送信後に
+/// サーバーから自分のユーザー情報を含む USERSTATE が届く。
+/// 楽観的 UI で自分のメッセージを正確に表示するために使用する。
+///
+/// 実際の IRC 形式:
+/// `@badges=moderator/1;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1 :tmi.twitch.tv USERSTATE #channel`
+struct TwitchUserState: Sendable, Equatable {
+    /// 表示名（日本語名や大文字入りの名前）
+    ///
+    /// Twitch アカウントの大文字・小文字混在の表示名。
+    /// サーバーから送られた `display-name` タグが空の場合は nil。
+    let displayName: String?
+
+    /// ユーザーのチャット文字色（16進数 #RRGGBB 形式）
+    ///
+    /// ユーザーが色を設定していない場合は nil。
+    /// クライアント側でデフォルト色を決定する。
+    let colorHex: String?
+
+    /// バッジ一覧（broadcaster / moderator / subscriber 等）
+    let badges: [Badge]
+
+    /// IRCMessage から TwitchUserState を生成する
+    ///
+    /// USERSTATE コマンド以外の場合は nil を返す。
+    ///
+    /// - Parameter ircMessage: パース済みの IRCMessage
+    init?(from ircMessage: IRCMessage) {
+        guard ircMessage.command == "USERSTATE" else { return nil }
+        // 空文字は未設定として nil に変換する
+        self.displayName = ircMessage.tags["display-name"].flatMap { $0.isEmpty ? nil : $0 }
+        self.colorHex = ircMessage.tags["color"].flatMap { $0.isEmpty ? nil : $0 }
+        self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
+    }
+}

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -87,6 +87,12 @@ protocol TwitchIRCClientProtocol: Actor {
     /// ViewModel はこれを購読して UI の接続インジケータを更新する。
     var connectionStateStream: AsyncStream<ClientConnectionState> { get }
 
+    /// 認証接続時に受信する USERSTATE を配信する AsyncStream
+    ///
+    /// チャンネル JOIN 後およびメッセージ送信後に、自分の display-name / color / badges が届く。
+    /// ViewModel はこれを購読して楽観的 UI の表示情報を更新する。
+    var userStateStream: AsyncStream<TwitchUserState> { get }
+
     /// 指定チャンネルに接続する
     ///
     /// - Parameters:
@@ -141,12 +147,16 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
     /// 接続状態の変化を配信する AsyncStream
     let connectionStateStream: AsyncStream<ClientConnectionState>
 
+    /// 認証接続時に受信する USERSTATE を配信する AsyncStream
+    let userStateStream: AsyncStream<TwitchUserState>
+
     // MARK: - プライベートプロパティ
 
     private let webSocketClient: any WebSocketClientProtocol
     private var messageContinuation: AsyncStream<ChatMessage>.Continuation?
     private var noticeContinuation: AsyncStream<TwitchNotice>.Continuation?
     private var connectionStateContinuation: AsyncStream<ClientConnectionState>.Continuation?
+    private var userStateContinuation: AsyncStream<TwitchUserState>.Continuation?
 
     /// 受信ループのタスク（disconnect() でキャンセルするために保持）
     private var receiveLoopTask: Task<Void, Never>?
@@ -216,6 +226,10 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         var stateContinuation: AsyncStream<ClientConnectionState>.Continuation?
         self.connectionStateStream = AsyncStream { stateContinuation = $0 }
         self.connectionStateContinuation = stateContinuation
+
+        var usContinuation: AsyncStream<TwitchUserState>.Continuation?
+        self.userStateStream = AsyncStream { usContinuation = $0 }
+        self.userStateContinuation = usContinuation
 
         self.webSocketClient = webSocketClient
         self.backoffConfig = backoffConfig
@@ -398,6 +412,13 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
                 message: ircMessage.trailing ?? ""
             )
             noticeContinuation?.yield(notice)
+
+        case "USERSTATE":
+            // 認証接続後に届く自分のユーザー状態（表示名・色・バッジ）を配信
+            // JOIN 直後とメッセージ送信後に届き、楽観的 UI の精度向上に使用する
+            if let userState = TwitchUserState(from: ircMessage) {
+                userStateContinuation?.yield(userState)
+            }
 
         case "RECONNECT":
             // Twitch サーバーがメンテナンス等で再接続を要求してきた場合

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -151,45 +151,7 @@ final class ChatViewModel {
         // グローバルバッジ定義を並行フェッチ（切断時にキャンセルできるよう保持）
         globalBadgeFetchTask = Task { await badgeStore.fetchGlobalBadges() }
 
-        receiveTask = Task { [weak self] in
-            // メッセージ受信ループを別タスクで開始
-            // weak self で循環参照を回避する
-            guard let self else { return }
-            let stream = await self.ircClient.messageStream
-            for await message in stream {
-                guard !Task.isCancelled else { break }
-                self.appendMessage(message)
-            }
-        }
-
-        noticeReceiveTask = Task { [weak self] in
-            guard let self else { return }
-            let stream = await self.ircClient.noticeStream
-            for await notice in stream {
-                guard !Task.isCancelled else { break }
-                self.handleIncomingNotice(notice)
-            }
-        }
-
-        // IRC クライアントの接続状態変化（再接続 / 再接続成功）を ViewModel の状態に反映する
-        connectionStateReceiveTask = Task { [weak self] in
-            guard let self else { return }
-            let stream = await self.ircClient.connectionStateStream
-            for await state in stream {
-                guard !Task.isCancelled else { break }
-                self.applyClientConnectionState(state)
-            }
-        }
-
-        // USERSTATE を購読して自分のユーザー情報を更新する（楽観的 UI の精度向上）
-        userStateReceiveTask = Task { [weak self] in
-            guard let self else { return }
-            let stream = await self.ircClient.userStateStream
-            for await userState in stream {
-                guard !Task.isCancelled else { break }
-                self.currentUserState = userState
-            }
-        }
+        startStreamTasks()
 
         do {
             // ログイン済みなら認証接続、ログアウト中なら匿名接続にフォールバック
@@ -209,6 +171,48 @@ final class ChatViewModel {
             connectionStateReceiveTask?.cancel()
             userStateReceiveTask?.cancel()
             globalBadgeFetchTask?.cancel()
+        }
+    }
+
+    /// メッセージ・NOTICE・接続状態・USERSTATE の受信ループタスクをすべて開始する
+    ///
+    /// connect() の本体長を抑えるために切り出したヘルパーメソッド。
+    /// 各タスクは weak self で循環参照を防ぎ、disconnect() でキャンセルされる。
+    private func startStreamTasks() {
+        receiveTask = Task { [weak self] in
+            // メッセージ受信ループ（weak self で循環参照を回避する）
+            guard let self else { return }
+            let stream = await self.ircClient.messageStream
+            for await message in stream {
+                guard !Task.isCancelled else { break }
+                self.appendMessage(message)
+            }
+        }
+        noticeReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.noticeStream
+            for await notice in stream {
+                guard !Task.isCancelled else { break }
+                self.handleIncomingNotice(notice)
+            }
+        }
+        // IRC クライアントの接続状態変化（再接続 / 再接続成功）を ViewModel の状態に反映する
+        connectionStateReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.connectionStateStream
+            for await state in stream {
+                guard !Task.isCancelled else { break }
+                self.applyClientConnectionState(state)
+            }
+        }
+        // USERSTATE を購読して自分のユーザー情報を更新する（楽観的 UI の精度向上）
+        userStateReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.userStateStream
+            for await userState in stream {
+                guard !Task.isCancelled else { break }
+                self.currentUserState = userState
+            }
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -92,7 +92,8 @@ final class ChatViewModel {
     /// USERSTATE から取得した自分のユーザー状態（楽観的 UI 生成に使用）
     ///
     /// JOIN 後とメッセージ送信後に更新される。nil の場合は login 名にフォールバックする。
-    private var currentUserState: TwitchUserState?
+    /// テストからポーリング条件として参照できるよう `private(set)` で公開する。
+    private(set) var currentUserState: TwitchUserState?
 
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -86,6 +86,14 @@ final class ChatViewModel {
     /// IRC クライアントの接続状態変化を購読するタスク（切断時にキャンセル）
     private var connectionStateReceiveTask: Task<Void, Never>?
 
+    /// USERSTATE 受信ループタスク（切断時にキャンセル）
+    private var userStateReceiveTask: Task<Void, Never>?
+
+    /// USERSTATE から取得した自分のユーザー状態（楽観的 UI 生成に使用）
+    ///
+    /// JOIN 後とメッセージ送信後に更新される。nil の場合は login 名にフォールバックする。
+    private var currentUserState: TwitchUserState?
+
     /// チャンネルバッジ取得済みフラグ
     private var channelBadgesFetched = false
 
@@ -172,6 +180,16 @@ final class ChatViewModel {
             }
         }
 
+        // USERSTATE を購読して自分のユーザー情報を更新する（楽観的 UI の精度向上）
+        userStateReceiveTask = Task { [weak self] in
+            guard let self else { return }
+            let stream = await self.ircClient.userStateStream
+            for await userState in stream {
+                guard !Task.isCancelled else { break }
+                self.currentUserState = userState
+            }
+        }
+
         do {
             // ログイン済みなら認証接続、ログアウト中なら匿名接続にフォールバック
             let token = await authState.validAccessToken()
@@ -188,6 +206,7 @@ final class ChatViewModel {
             receiveTask?.cancel()
             noticeReceiveTask?.cancel()
             connectionStateReceiveTask?.cancel()
+            userStateReceiveTask?.cancel()
             globalBadgeFetchTask?.cancel()
         }
     }
@@ -197,6 +216,7 @@ final class ChatViewModel {
         receiveTask?.cancel()
         noticeReceiveTask?.cancel()
         connectionStateReceiveTask?.cancel()
+        userStateReceiveTask?.cancel()
         globalBadgeFetchTask?.cancel()
         channelBadgeFetchTask?.cancel()
         // BadgeStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
@@ -204,6 +224,7 @@ final class ChatViewModel {
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil
+        currentUserState = nil
         optimisticPendingMessages.removeAll()
     }
 
@@ -279,11 +300,14 @@ final class ChatViewModel {
             try await ircClient.sendPrivmsg(sanitized)
             // 楽観的 UI: 自分の PRIVMSG はサーバーからエコーバックされないのでローカルで追加する
             if case .loggedIn(let login) = authState.status {
+                // USERSTATE 受信済みなら displayName / colorHex / badges に反映する
                 let localMessage = ChatMessage(
                     localUsername: login,
-                    displayName: login,
+                    displayName: currentUserState?.displayName ?? login,
                     text: sanitized,
-                    roomId: currentRoomId
+                    roomId: currentRoomId,
+                    colorHex: currentUserState?.colorHex,
+                    badges: currentUserState?.badges ?? []
                 )
                 appendMessage(localMessage)
                 // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -246,4 +246,36 @@ struct ChatMessageTests {
         #expect(message1.id != message2.id)
         #expect(!message1.id.isEmpty)
     }
+
+    @Test("楽観的 UI 用イニシャライザで colorHex と badges を渡した場合にセットされる")
+    func 楽観的UI用イニシャライザでcolorHexとbadgesを渡した場合にセットされる() {
+        // 前提: USERSTATE から取得した color と badges を指定して生成
+        let badges = [Badge(name: "moderator", version: "1"), Badge(name: "subscriber", version: "12")]
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            displayName: "山田太郎",
+            text: "こんにちは！",
+            roomId: "12345678",
+            colorHex: "#1E90FF",
+            badges: badges
+        )
+
+        // 検証: colorHex と badges が正しくセットされる
+        #expect(chatMessage.colorHex == "#1E90FF")
+        #expect(chatMessage.badges == badges)
+    }
+
+    @Test("楽観的 UI 用イニシャライザで colorHex と badges を省略した場合はデフォルト値になる")
+    func 楽観的UI用イニシャライザでcolorHexとbadgesを省略した場合はデフォルト値になる() {
+        // 前提: colorHex / badges を省略して生成（従来の呼び出し方）
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            displayName: "山田太郎",
+            text: "こんにちは！"
+        )
+
+        // 検証: colorHex は nil、badges は空配列（後方互換）
+        #expect(chatMessage.colorHex == nil)
+        #expect(chatMessage.badges.isEmpty)
+    }
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -589,9 +589,10 @@ struct ChatViewModelTests {
         let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "yamadataro")
 
         // USERSTATE を流し込み、ViewModel に反映されるまでポーリング
-        let userState = TwitchUserState(from: IRCMessageParser.parse(
-            "@badges=moderator/1;color=#1E90FF;display-name=山田太郎;emote-sets=0;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
-        )!)!
+        let rawUserState = "@badges=moderator/1;color=#1E90FF;display-name=山田太郎;"
+            + "emote-sets=0;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        let ircMsg = try #require(IRCMessageParser.parse(rawUserState), "IRCMessage のパースに失敗しました")
+        let userState = try #require(TwitchUserState(from: ircMsg), "TwitchUserState の生成に失敗しました")
         await mockClient.sendUserState(userState)
         await waitFor { viewModel.currentUserState != nil }
 
@@ -613,16 +614,22 @@ struct ChatViewModelTests {
         let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "testuser")
 
         // 1回目の USERSTATE（古い情報）を流し込み、ViewModel への反映をポーリング
-        let firstUserState = TwitchUserState(from: IRCMessageParser.parse(
-            "@badges=;color=#FF0000;display-name=古い表示名;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
-        )!)!
+        let rawFirst = "@badges=;color=#FF0000;display-name=古い表示名;"
+            + "emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        let firstIrcMsg = try #require(IRCMessageParser.parse(rawFirst), "IRCMessage のパースに失敗しました")
+        let firstUserState = try #require(
+            TwitchUserState(from: firstIrcMsg), "TwitchUserState の生成に失敗しました"
+        )
         await mockClient.sendUserState(firstUserState)
         await waitFor { viewModel.currentUserState?.displayName == "古い表示名" }
 
         // 2回目の USERSTATE（最新の情報）を流し込み、更新をポーリング
-        let secondUserState = TwitchUserState(from: IRCMessageParser.parse(
-            "@badges=subscriber/6;color=#00FF7F;display-name=新しい表示名;emote-sets=0;mod=0;subscriber=1;user-type= :tmi.twitch.tv USERSTATE #testchannel"
-        )!)!
+        let rawSecond = "@badges=subscriber/6;color=#00FF7F;display-name=新しい表示名;"
+            + "emote-sets=0;mod=0;subscriber=1;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        let secondIrcMsg = try #require(IRCMessageParser.parse(rawSecond), "IRCMessage のパースに失敗しました")
+        let secondUserState = try #require(
+            TwitchUserState(from: secondIrcMsg), "TwitchUserState の生成に失敗しました"
+        )
         await mockClient.sendUserState(secondUserState)
         await waitFor { viewModel.currentUserState?.displayName == "新しい表示名" }
 

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -20,6 +20,8 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     let noticeStream: AsyncStream<TwitchNotice>
     private var connectionStateContinuation: AsyncStream<ClientConnectionState>.Continuation?
     let connectionStateStream: AsyncStream<ClientConnectionState>
+    private var userStateContinuation: AsyncStream<TwitchUserState>.Continuation?
+    let userStateStream: AsyncStream<TwitchUserState>
 
     /// sendPrivmsg() で送信されたメッセージのログ（テスト検証用）
     private(set) var sentPrivmsgs: [String] = []
@@ -44,6 +46,10 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         var stateContinuation: AsyncStream<ClientConnectionState>.Continuation?
         self.connectionStateStream = AsyncStream { stateContinuation = $0 }
         self.connectionStateContinuation = stateContinuation
+
+        var usContinuation: AsyncStream<TwitchUserState>.Continuation?
+        self.userStateStream = AsyncStream { usContinuation = $0 }
+        self.userStateContinuation = usContinuation
     }
 
     func connect(to channel: String, accessToken: String?, userLogin: String?) async throws {
@@ -59,6 +65,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         messageContinuation?.finish()
         noticeContinuation?.finish()
         connectionStateContinuation?.finish()
+        userStateContinuation?.finish()
     }
 
     func sendPrivmsg(_ text: String) async throws {
@@ -84,6 +91,11 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     /// テスト用に接続状態を流し込む（再接続シミュレーション用）
     func sendConnectionState(_ state: ClientConnectionState) {
         connectionStateContinuation?.yield(state)
+    }
+
+    /// テスト用に USERSTATE を流し込む
+    func sendUserState(_ userState: TwitchUserState) {
+        userStateContinuation?.yield(userState)
     }
 }
 
@@ -550,5 +562,78 @@ struct ChatViewModelTests {
         try await Task.sleep(nanoseconds: 50_000_000)
 
         return (viewModel, mockClient)
+    }
+
+    // MARK: - USERSTATE 購読と楽観的 UI
+
+    @Test("USERSTATE 未受信の場合は楽観的 UI に login 名・nil・空バッジが使われる")
+    func USERSTATE未受信の場合は楽観的UIにlogin名nilと空バッジが使われる() async throws {
+        // 前提: USERSTATE を受信していない状態で接続済み
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "yamadataro")
+
+        // 実行: メッセージ送信
+        try await viewModel.sendMessage("こんにちは！")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: 楽観的 UI メッセージが login 名を displayName に使い、color は nil、badges は空
+        let optimisticMessage = viewModel.messages.first
+        #expect(optimisticMessage?.username == "yamadataro")
+        #expect(optimisticMessage?.displayName == "yamadataro")
+        #expect(optimisticMessage?.colorHex == nil)
+        #expect(optimisticMessage?.badges.isEmpty == true)
+    }
+
+    @Test("USERSTATE 受信後の楽観的 UI に displayName / color / badges が反映される")
+    func USERSTATE受信後の楽観的UIにdisplayNameとcolorとbadgesが反映される() async throws {
+        // 前提: USERSTATE を受信済みの状態で接続
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "yamadataro")
+
+        // USERSTATE を流し込む（表示名・色・バッジを持つ）
+        let userState = TwitchUserState(from: IRCMessageParser.parse(
+            "@badges=moderator/1;color=#1E90FF;display-name=山田太郎;emote-sets=0;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        )!)!
+        await mockClient.sendUserState(userState)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 実行: USERSTATE 受信後にメッセージ送信
+        try await viewModel.sendMessage("こんにちは！")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: 楽観的 UI メッセージに USERSTATE の情報が反映されている
+        let optimisticMessage = viewModel.messages.first
+        #expect(optimisticMessage?.username == "yamadataro")
+        #expect(optimisticMessage?.displayName == "山田太郎")
+        #expect(optimisticMessage?.colorHex == "#1E90FF")
+        #expect(optimisticMessage?.badges == [Badge(name: "moderator", version: "1")])
+    }
+
+    @Test("USERSTATE を複数回受信した場合は最新の情報が楽観的 UI に使われる")
+    func USERSTATE複数回受信した場合は最新の情報が楽観的UIに使われる() async throws {
+        // 前提: 接続済み
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "testuser")
+
+        // 1回目の USERSTATE（古い情報）
+        let firstUserState = TwitchUserState(from: IRCMessageParser.parse(
+            "@badges=;color=#FF0000;display-name=古い表示名;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        )!)!
+        await mockClient.sendUserState(firstUserState)
+        try await Task.sleep(nanoseconds: 30_000_000)
+
+        // 2回目の USERSTATE（最新の情報）
+        let secondUserState = TwitchUserState(from: IRCMessageParser.parse(
+            "@badges=subscriber/6;color=#00FF7F;display-name=新しい表示名;emote-sets=0;mod=0;subscriber=1;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        )!)!
+        await mockClient.sendUserState(secondUserState)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 実行: 最新 USERSTATE 受信後にメッセージ送信
+        try await viewModel.sendMessage("テストメッセージ")
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: 最新の USERSTATE 情報が使われる
+        let optimisticMessage = viewModel.messages.first
+        #expect(optimisticMessage?.displayName == "新しい表示名")
+        #expect(optimisticMessage?.colorHex == "#00FF7F")
+        #expect(optimisticMessage?.badges == [Badge(name: "subscriber", version: "6")])
     }
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -571,9 +571,9 @@ struct ChatViewModelTests {
         // 前提: USERSTATE を受信していない状態で接続済み
         let (viewModel, _) = try await makeConnectedViewModel(userLogin: "yamadataro")
 
-        // 実行: メッセージ送信
+        // 実行: メッセージ送信（USERSTATE 未受信のため messages が増えることをポーリング）
         try await viewModel.sendMessage("こんにちは！")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.messages.count >= 1 }
 
         // 検証: 楽観的 UI メッセージが login 名を displayName に使い、color は nil、badges は空
         let optimisticMessage = viewModel.messages.first
@@ -588,16 +588,16 @@ struct ChatViewModelTests {
         // 前提: USERSTATE を受信済みの状態で接続
         let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "yamadataro")
 
-        // USERSTATE を流し込む（表示名・色・バッジを持つ）
+        // USERSTATE を流し込み、ViewModel に反映されるまでポーリング
         let userState = TwitchUserState(from: IRCMessageParser.parse(
             "@badges=moderator/1;color=#1E90FF;display-name=山田太郎;emote-sets=0;mod=1;subscriber=0;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
         )!)!
         await mockClient.sendUserState(userState)
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.currentUserState != nil }
 
-        // 実行: USERSTATE 受信後にメッセージ送信
+        // 実行: USERSTATE 反映済み状態でメッセージ送信
         try await viewModel.sendMessage("こんにちは！")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.messages.count >= 1 }
 
         // 検証: 楽観的 UI メッセージに USERSTATE の情報が反映されている
         let optimisticMessage = viewModel.messages.first
@@ -612,23 +612,23 @@ struct ChatViewModelTests {
         // 前提: 接続済み
         let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "testuser")
 
-        // 1回目の USERSTATE（古い情報）
+        // 1回目の USERSTATE（古い情報）を流し込み、ViewModel への反映をポーリング
         let firstUserState = TwitchUserState(from: IRCMessageParser.parse(
             "@badges=;color=#FF0000;display-name=古い表示名;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
         )!)!
         await mockClient.sendUserState(firstUserState)
-        try await Task.sleep(nanoseconds: 30_000_000)
+        await waitFor { viewModel.currentUserState?.displayName == "古い表示名" }
 
-        // 2回目の USERSTATE（最新の情報）
+        // 2回目の USERSTATE（最新の情報）を流し込み、更新をポーリング
         let secondUserState = TwitchUserState(from: IRCMessageParser.parse(
             "@badges=subscriber/6;color=#00FF7F;display-name=新しい表示名;emote-sets=0;mod=0;subscriber=1;user-type= :tmi.twitch.tv USERSTATE #testchannel"
         )!)!
         await mockClient.sendUserState(secondUserState)
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.currentUserState?.displayName == "新しい表示名" }
 
-        // 実行: 最新 USERSTATE 受信後にメッセージ送信
+        // 実行: 最新 USERSTATE 反映済み状態でメッセージ送信
         try await viewModel.sendMessage("テストメッセージ")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await waitFor { viewModel.messages.count >= 1 }
 
         // 検証: 最新の USERSTATE 情報が使われる
         let optimisticMessage = viewModel.messages.first

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -614,6 +614,44 @@ struct TwitchIRCClientTests {
         connectTask.cancel()
     }
 
+    // MARK: - USERSTATE ハンドリング
+
+    @Test("USERSTATE を受信すると userStateStream に TwitchUserState が流れる")
+    func USERSTATEを受信するとuserStateStreamにTwitchUserStateが流れる() async {
+        // 前提: USERSTATE メッセージを事前にキューに投入
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        let userstateMessage = "@badges=moderator/1,subscriber/12;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        await mockWS.enqueueMessage(userstateMessage)
+
+        // userStateStream を取得してから接続開始
+        var receivedUserStates: [TwitchUserState] = []
+        let userStateStream = await client.userStateStream
+
+        let connectTask = Task {
+            try await client.connect(to: "testchannel", accessToken: "テスト用トークン", userLogin: "testuser")
+        }
+
+        // 最初の USERSTATE を受信する
+        for await userState in userStateStream {
+            receivedUserStates.append(userState)
+            break
+        }
+
+        await client.disconnect()
+        connectTask.cancel()
+
+        // 検証: TwitchUserState が正しいプロパティで届く
+        #expect(receivedUserStates.count == 1)
+        #expect(receivedUserStates[0].displayName == "テストユーザー")
+        #expect(receivedUserStates[0].colorHex == "#1E90FF")
+        #expect(receivedUserStates[0].badges == [
+            Badge(name: "moderator", version: "1"),
+            Badge(name: "subscriber", version: "12")
+        ])
+    }
+
     // MARK: - テストヘルパー
 
     /// 条件が満たされるまで最大 `timeout` 秒ポーリングする（10ms 間隔）

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -617,7 +617,7 @@ struct TwitchIRCClientTests {
     // MARK: - USERSTATE ハンドリング
 
     @Test("USERSTATE を受信すると userStateStream に TwitchUserState が流れる")
-    func USERSTATEを受信するとuserStateStreamにTwitchUserStateが流れる() async {
+    func USERSTATEを受信するとuserStateStreamにTwitchUserStateが流れる() async throws {
         // 前提: USERSTATE メッセージを事前にキューに投入
         let mockWS = MockWebSocketClient()
         let client = TwitchIRCClient(webSocketClient: mockWS)

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -622,7 +622,9 @@ struct TwitchIRCClientTests {
         let mockWS = MockWebSocketClient()
         let client = TwitchIRCClient(webSocketClient: mockWS)
 
-        let userstateMessage = "@badges=moderator/1,subscriber/12;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        let userstateMessage = "@badges=moderator/1,subscriber/12;color=#1E90FF;"
+            + "display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;"
+            + "user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
         await mockWS.enqueueMessage(userstateMessage)
 
         // userStateStream を取得してから接続開始

--- a/Tests/TwitchChatTests/TwitchUserStateTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserStateTests.swift
@@ -14,7 +14,9 @@ struct TwitchUserStateTests {
     @Test("USERSTATE から displayName / color / badges を正しく抽出できる")
     func USERSTATEからすべてのフィールドを抽出できる() throws {
         // 前提: バッジ・色・表示名が揃った USERSTATE メッセージ
-        let rawMessage = "@badge-info=subscriber/12;badges=moderator/1,subscriber/12;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        let rawMessage = "@badge-info=subscriber/12;badges=moderator/1,subscriber/12;"
+            + "color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;"
+            + "subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
         let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: TwitchUserState に正しく変換される

--- a/Tests/TwitchChatTests/TwitchUserStateTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserStateTests.swift
@@ -1,0 +1,124 @@
+// TwitchUserStateTests.swift
+// TwitchUserState モデルの単体テスト
+// USERSTATE IRCメッセージからのパースを検証する
+
+import Testing
+@testable import TwitchChat
+
+/// TwitchUserState モデルのテストスイート
+@Suite("TwitchUserState テスト")
+struct TwitchUserStateTests {
+
+    // MARK: - 正常系: USERSTATE のパース
+
+    @Test("USERSTATE から displayName / color / badges を正しく抽出できる")
+    func USERSTATEからすべてのフィールドを抽出できる() {
+        // 前提: バッジ・色・表示名が揃った USERSTATE メッセージ
+        let rawMessage = "@badge-info=subscriber/12;badges=moderator/1,subscriber/12;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: TwitchUserState に正しく変換される
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState != nil)
+        #expect(userState?.displayName == "テストユーザー")
+        #expect(userState?.colorHex == "#1E90FF")
+        #expect(userState?.badges == [
+            Badge(name: "moderator", version: "1"),
+            Badge(name: "subscriber", version: "12")
+        ])
+    }
+
+    @Test("display-name が空の場合は nil になる")
+    func displayNameが空の場合はnilになる() {
+        // 前提: display-name が空文字の USERSTATE
+        let rawMessage = "@badges=;color=#FF0000;display-name=;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: displayName は nil になる
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState?.displayName == nil)
+    }
+
+    @Test("color が空の場合は nil になる")
+    func colorが空の場合はnilになる() {
+        // 前提: color が空文字の USERSTATE（色未設定ユーザー）
+        let rawMessage = "@badges=;color=;display-name=山田太郎;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: colorHex は nil になる
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState?.colorHex == nil)
+    }
+
+    @Test("badges が空の場合は空配列になる")
+    func badgesが空の場合は空配列になる() {
+        // 前提: badges が空文字の USERSTATE（バッジなしユーザー）
+        let rawMessage = "@badges=;color=#FF0000;display-name=山田太郎;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: badges は空配列になる
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState?.badges == [])
+    }
+
+    // MARK: - 正常系: タグなし USERSTATE
+
+    @Test("タグが一切ない USERSTATE でも初期化できる")
+    func タグなしUSERSTATEでも初期化できる() {
+        // 前提: タグなしの USERSTATE（匿名接続の場合など）
+        let rawMessage = ":tmi.twitch.tv USERSTATE #testchannel"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: nil を返さず、各フィールドがデフォルト値になる
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState != nil)
+        #expect(userState?.displayName == nil)
+        #expect(userState?.colorHex == nil)
+        #expect(userState?.badges == [])
+    }
+
+    // MARK: - 異常系: USERSTATE 以外のコマンド
+
+    @Test("PRIVMSG の IRCMessage からは nil を返す")
+    func PRIVMSGからはnilを返す() {
+        // 前提: PRIVMSG メッセージ（USERSTATE ではない）
+        let rawMessage = "@color=#FF0000;display-name=山田太郎 :yamadataro!yamadataro@yamadataro.tmi.twitch.tv PRIVMSG #testchannel :こんにちは"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: USERSTATE 以外は nil を返す
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState == nil)
+    }
+
+    @Test("NOTICE の IRCMessage からは nil を返す")
+    func NOTICEからはnilを返す() {
+        // 前提: NOTICE メッセージ（USERSTATE ではない）
+        let rawMessage = "@msg-id=msg_ratelimit :tmi.twitch.tv NOTICE #testchannel :You are sending messages too quickly."
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: USERSTATE 以外は nil を返す
+        let userState = TwitchUserState(from: ircMessage)
+        #expect(userState == nil)
+    }
+}

--- a/Tests/TwitchChatTests/TwitchUserStateTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserStateTests.swift
@@ -12,13 +12,10 @@ struct TwitchUserStateTests {
     // MARK: - 正常系: USERSTATE のパース
 
     @Test("USERSTATE から displayName / color / badges を正しく抽出できる")
-    func USERSTATEからすべてのフィールドを抽出できる() {
+    func USERSTATEからすべてのフィールドを抽出できる() throws {
         // 前提: バッジ・色・表示名が揃った USERSTATE メッセージ
         let rawMessage = "@badge-info=subscriber/12;badges=moderator/1,subscriber/12;color=#1E90FF;display-name=テストユーザー;emote-sets=0;mod=1;subscriber=1;user-type=mod :tmi.twitch.tv USERSTATE #testchannel"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: TwitchUserState に正しく変換される
         let userState = TwitchUserState(from: ircMessage)
@@ -32,76 +29,60 @@ struct TwitchUserStateTests {
     }
 
     @Test("display-name が空の場合は nil になる")
-    func displayNameが空の場合はnilになる() {
+    func displayNameが空の場合はnilになる() throws {
         // 前提: display-name が空文字の USERSTATE
         let rawMessage = "@badges=;color=#FF0000;display-name=;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
-        // 検証: displayName は nil になる
-        let userState = TwitchUserState(from: ircMessage)
-        #expect(userState?.displayName == nil)
+        // 検証: userState が存在し、displayName が nil になる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.displayName == nil)
     }
 
     @Test("color が空の場合は nil になる")
-    func colorが空の場合はnilになる() {
+    func colorが空の場合はnilになる() throws {
         // 前提: color が空文字の USERSTATE（色未設定ユーザー）
         let rawMessage = "@badges=;color=;display-name=山田太郎;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
-        // 検証: colorHex は nil になる
-        let userState = TwitchUserState(from: ircMessage)
-        #expect(userState?.colorHex == nil)
+        // 検証: userState が存在し、colorHex が nil になる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.colorHex == nil)
     }
 
     @Test("badges が空の場合は空配列になる")
-    func badgesが空の場合は空配列になる() {
+    func badgesが空の場合は空配列になる() throws {
         // 前提: badges が空文字の USERSTATE（バッジなしユーザー）
         let rawMessage = "@badges=;color=#FF0000;display-name=山田太郎;emote-sets=0;mod=0;subscriber=0;user-type= :tmi.twitch.tv USERSTATE #testchannel"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
-        // 検証: badges は空配列になる
-        let userState = TwitchUserState(from: ircMessage)
-        #expect(userState?.badges == [])
+        // 検証: userState が存在し、badges が空配列になる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.badges == [])
     }
 
     // MARK: - 正常系: タグなし USERSTATE
 
     @Test("タグが一切ない USERSTATE でも初期化できる")
-    func タグなしUSERSTATEでも初期化できる() {
+    func タグなしUSERSTATEでも初期化できる() throws {
         // 前提: タグなしの USERSTATE（匿名接続の場合など）
         let rawMessage = ":tmi.twitch.tv USERSTATE #testchannel"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: nil を返さず、各フィールドがデフォルト値になる
-        let userState = TwitchUserState(from: ircMessage)
-        #expect(userState != nil)
-        #expect(userState?.displayName == nil)
-        #expect(userState?.colorHex == nil)
-        #expect(userState?.badges == [])
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.displayName == nil)
+        #expect(userState.colorHex == nil)
+        #expect(userState.badges == [])
     }
 
     // MARK: - 異常系: USERSTATE 以外のコマンド
 
     @Test("PRIVMSG の IRCMessage からは nil を返す")
-    func PRIVMSGからはnilを返す() {
+    func PRIVMSGからはnilを返す() throws {
         // 前提: PRIVMSG メッセージ（USERSTATE ではない）
         let rawMessage = "@color=#FF0000;display-name=山田太郎 :yamadataro!yamadataro@yamadataro.tmi.twitch.tv PRIVMSG #testchannel :こんにちは"
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: USERSTATE 以外は nil を返す
         let userState = TwitchUserState(from: ircMessage)
@@ -109,13 +90,10 @@ struct TwitchUserStateTests {
     }
 
     @Test("NOTICE の IRCMessage からは nil を返す")
-    func NOTICEからはnilを返す() {
+    func NOTICEからはnilを返す() throws {
         // 前提: NOTICE メッセージ（USERSTATE ではない）
         let rawMessage = "@msg-id=msg_ratelimit :tmi.twitch.tv NOTICE #testchannel :You are sending messages too quickly."
-        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
-            Issue.record("IRCMessage のパースに失敗しました")
-            return
-        }
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: USERSTATE 以外は nil を返す
         let userState = TwitchUserState(from: ircMessage)


### PR DESCRIPTION
## Summary

- Closes #20
- 認証接続後に届く USERSTATE コマンドをパースして自分の表示名・チャット色・バッジをキャッシュ
- `sendMessage()` の楽観的 UI メッセージに USERSTATE 情報を反映（従来は login 名・nil・空バッジ）
- TDD で全ての変更をカバーするテストを先行作成

## 変更内容

| ファイル | 変更 |
|---|---|
| `Sources/TwitchChat/Models/TwitchUserState.swift` | 新規: USERSTATE モデル |
| `Sources/TwitchChat/Models/ChatMessage.swift` | 楽観 UI init に `colorHex` / `badges` パラメータ追加（後方互換） |
| `Sources/TwitchChat/Services/TwitchIRCClient.swift` | プロトコル・実装に `userStateStream` 追加、`handleLine` に USERSTATE case 追加 |
| `Sources/TwitchChat/ViewModels/ChatViewModel.swift` | `userStateStream` 購読・`currentUserState` キャッシュ・楽観 UI 改善 |

## Test plan

- [ ] `swift test --filter TwitchUserStateTests` — モデルのパーステスト（7件）
- [ ] `swift test --filter ChatMessageTests` — 楽観 UI init 拡張テスト（2件追加）
- [ ] `swift test --filter "TwitchIRCClientTests/USERSTATE"` — ストリーム配信テスト（1件）
- [ ] `swift test --filter "ChatViewModelTests/USERSTATE"` — ViewModel 統合テスト（3件）
- [ ] `swift build` でコンパイルエラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャットメッセージにユーザーの色とバッジを表示するようになりました。Twitchの認証ユーザー情報を取得し、送信するメッセージに自動的に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->