### PR TITLE
feat: チャット返信機能を実装する（reply-parent-msg-id タグ付き PRIVMSG）

### DIFF
--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -72,6 +72,20 @@ struct ChatMessage: Sendable, Identifiable {
     /// メッセージの受信時刻
     let receivedAt: Date
 
+    /// 返信先メッセージの一意な識別子（`reply-parent-msg-id` タグ）
+    ///
+    /// このメッセージが他のメッセージへの返信である場合に設定される。通常メッセージは nil。
+    let replyParentMsgId: String?
+
+    /// 返信先ユーザーのログイン名（`reply-parent-user-login` タグ）
+    let replyParentUserLogin: String?
+
+    /// 返信先ユーザーの表示名（`reply-parent-display-name` タグ）
+    let replyParentDisplayName: String?
+
+    /// 返信先メッセージの本文（`reply-parent-msg-body` タグ）
+    let replyParentMsgBody: String?
+
     /// 楽観的 UI 表示のためのローカル ChatMessage を生成する
     ///
     /// Twitch IRC は自分が送信した PRIVMSG をエコーバックしないため、
@@ -86,6 +100,7 @@ struct ChatMessage: Sendable, Identifiable {
     ///   - roomId: 接続中チャンネルの room-id（既知の場合は渡す、省略可）
     ///   - colorHex: チャット文字色（#RRGGBB 形式、USERSTATE から取得した場合に指定）
     ///   - badges: バッジ一覧（USERSTATE から取得した場合に指定）
+    ///   - replyParentMsgId: 返信先メッセージの ID（返信送信時に指定、省略可）
     init(
         localUsername username: String,
         displayName: String? = nil,
@@ -93,7 +108,8 @@ struct ChatMessage: Sendable, Identifiable {
         isAction: Bool = false,
         roomId: String? = nil,
         colorHex: String? = nil,
-        badges: [Badge] = []
+        badges: [Badge] = [],
+        replyParentMsgId: String? = nil
     ) {
         self.id = UUID().uuidString
         self.username = username
@@ -106,6 +122,10 @@ struct ChatMessage: Sendable, Identifiable {
         self.segments = MessageSegment.segments(from: text, emotePositions: [])
         self.roomId = roomId
         self.receivedAt = Date()
+        self.replyParentMsgId = replyParentMsgId
+        self.replyParentUserLogin = nil
+        self.replyParentDisplayName = nil
+        self.replyParentMsgBody = nil
     }
 
     /// IRCMessage から ChatMessage を生成する
@@ -148,5 +168,9 @@ struct ChatMessage: Sendable, Identifiable {
         self.emotes = parsedEmotes
         self.segments = MessageSegment.segments(from: parsedText, emotePositions: parsedEmotes)
         self.receivedAt = Date()
+        self.replyParentMsgId = ircMessage.tags["reply-parent-msg-id"].flatMap { $0.isEmpty ? nil : $0 }
+        self.replyParentUserLogin = ircMessage.tags["reply-parent-user-login"].flatMap { $0.isEmpty ? nil : $0 }
+        self.replyParentDisplayName = ircMessage.tags["reply-parent-display-name"].flatMap { $0.isEmpty ? nil : $0 }
+        self.replyParentMsgBody = ircMessage.tags["reply-parent-msg-body"].flatMap { $0.isEmpty ? nil : $0 }
     }
 }

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -77,6 +77,12 @@ struct ChatMessage: Sendable, Identifiable {
     /// このメッセージが他のメッセージへの返信である場合に設定される。通常メッセージは nil。
     let replyParentMsgId: String?
 
+    /// 楽観的 UI メッセージかどうか（送信直後にローカルで生成したメッセージ）
+    ///
+    /// true の場合は Twitch サーバーが認識する本物の message ID を持たないため、
+    /// このメッセージへの返信機能を無効化する必要がある。
+    let isOptimistic: Bool
+
     /// 返信先ユーザーのログイン名（`reply-parent-user-login` タグ）
     let replyParentUserLogin: String?
 
@@ -126,6 +132,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentUserLogin = nil
         self.replyParentDisplayName = nil
         self.replyParentMsgBody = nil
+        self.isOptimistic = true
     }
 
     /// IRCMessage から ChatMessage を生成する
@@ -172,5 +179,6 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentUserLogin = ircMessage.tags["reply-parent-user-login"].flatMap { $0.isEmpty ? nil : $0 }
         self.replyParentDisplayName = ircMessage.tags["reply-parent-display-name"].flatMap { $0.isEmpty ? nil : $0 }
         self.replyParentMsgBody = ircMessage.tags["reply-parent-msg-body"].flatMap { $0.isEmpty ? nil : $0 }
+        self.isOptimistic = false
     }
 }

--- a/Sources/TwitchChat/Services/TwitchIRCClient.swift
+++ b/Sources/TwitchChat/Services/TwitchIRCClient.swift
@@ -106,9 +106,11 @@ protocol TwitchIRCClientProtocol: Actor {
 
     /// 接続中チャンネルに PRIVMSG を送信する
     ///
-    /// - Parameter text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    /// - Parameters:
+    ///   - text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    ///   - replyTo: 返信先メッセージの ID（省略時は nil。指定時は `@reply-parent-msg-id` タグ付きで送信）
     /// - Throws: `.notConnected`（未接続）、`.notAuthenticated`（匿名接続中）
-    func sendPrivmsg(_ text: String) async throws
+    func sendPrivmsg(_ text: String, replyTo parentMsgId: String?) async throws
 }
 
 // MARK: - TwitchIRCClient
@@ -300,10 +302,12 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
 
     /// 接続中チャンネルに PRIVMSG を送信する
     ///
-    /// - Parameter text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    /// - Parameters:
+    ///   - text: 送信する本文（呼び出し元でサニタイズ済みである前提）
+    ///   - replyTo: 返信先メッセージの ID（省略時は nil。指定時は `@reply-parent-msg-id` タグ付きで送信）
     /// - Throws: `.notConnected`（未接続）、`.notAuthenticated`（匿名接続中）、
     ///           `.rateLimited(retryAfter:)`（クライアント側レートリミット超過）
-    func sendPrivmsg(_ text: String) async throws {
+    func sendPrivmsg(_ text: String, replyTo parentMsgId: String? = nil) async throws {
         guard let channel = joinedChannel else {
             throw TwitchIRCClientError.notConnected
         }
@@ -312,8 +316,15 @@ actor TwitchIRCClient: TwitchIRCClientProtocol {
         }
         // クライアント側レートリミット事前チェック（30秒あたり30メッセージ）
         try rateLimiter.checkAndRecord()
+        // 返信先 ID が指定されている場合は @reply-parent-msg-id タグをプレフィックスとして付加する
+        let command: String
+        if let parentMsgId {
+            command = "@reply-parent-msg-id=\(parentMsgId) PRIVMSG #\(channel) :\(text)"
+        } else {
+            command = "PRIVMSG #\(channel) :\(text)"
+        }
         do {
-            try await webSocketClient.send("PRIVMSG #\(channel) :\(text)")
+            try await webSocketClient.send(command)
         } catch {
             // 送信失敗時はレートリミットスロットを返却する（実際には送られていないため）
             rateLimiter.rollbackLast()

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -314,28 +314,7 @@ final class ChatViewModel {
         guard sanitized.count <= 500 else { throw ChatSendError.tooLong }
         guard canSendMessage else { throw ChatSendError.notReady }
 
-        // /me コマンドの検出: "/me" または "/me " で始まる場合は ACTION 形式に変換して送信する
-        // 大文字小文字は区別しない（/Me, /ME なども検出する）
-        // sanitize() により末尾空白はトリム済みのため "/me   " は "/me" になる
-        let lowerSanitized = sanitized.lowercased()
-        let ircText: String
-        let isAction: Bool
-        let displayText: String
-        if lowerSanitized == "/me" || lowerSanitized.hasPrefix("/me ") {
-            let body = lowerSanitized.hasPrefix("/me ")
-                ? String(sanitized.dropFirst("/me ".count)).trimmingCharacters(in: .whitespaces)
-                : ""
-            guard !body.isEmpty else { throw ChatSendError.empty }
-            ircText = "\u{1}ACTION \(body)\u{1}"
-            // ACTION 変換後の IRC 送信文字列でサーバー制限（500文字）を再チェックする
-            guard ircText.count <= 500 else { throw ChatSendError.tooLong }
-            isAction = true
-            displayText = body
-        } else {
-            ircText = sanitized
-            isAction = false
-            displayText = sanitized
-        }
+        let (ircText, isAction, displayText) = try Self.prepareIRCText(sanitized)
 
         isSending = true
         sendError = nil
@@ -346,26 +325,8 @@ final class ChatViewModel {
 
         do {
             try await ircClient.sendPrivmsg(ircText, replyTo: parentMsgId)
-            // 返信送信成功後は返信モードを解除する
             replyingTo = nil
-            // 楽観的 UI: 自分の PRIVMSG はサーバーからエコーバックされないのでローカルで追加する
-            if case .loggedIn(let login) = authState.status {
-                // USERSTATE 受信済みなら displayName / colorHex / badges に反映する
-                // ACTION の場合は本文のみを text に設定し isAction を true にする
-                let localMessage = ChatMessage(
-                    localUsername: login,
-                    displayName: currentUserState?.displayName ?? login,
-                    text: displayText,
-                    isAction: isAction,
-                    roomId: currentRoomId,
-                    colorHex: currentUserState?.colorHex,
-                    badges: currentUserState?.badges ?? [],
-                    replyParentMsgId: parentMsgId
-                )
-                appendMessage(localMessage)
-                // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する
-                optimisticPendingMessages[localMessage.id] = Date()
-            }
+            appendOptimisticMessage(displayText: displayText, isAction: isAction, parentMsgId: parentMsgId)
         } catch TwitchIRCClientError.rateLimited(let retryAfter) {
             // クライアント側レートリミットエラーを ChatSendError に変換して上位に伝える
             let sendError = ChatSendError.clientRateLimited(retryAfter: retryAfter)
@@ -375,6 +336,51 @@ final class ChatViewModel {
             sendError = error.localizedDescription
             throw error
         }
+    }
+
+    /// IRC 送信用のテキストを準備する
+    ///
+    /// `/me` コマンドを検出して ACTION 形式に変換し、IRC 送信文字列・isAction フラグ・表示テキストを返す。
+    ///
+    /// - Parameter sanitized: サニタイズ済みの入力テキスト
+    /// - Returns: `(ircText, isAction, displayText)` のタプル
+    /// - Throws: `ChatSendError.empty`（/me 本文なし）、`.tooLong`（ACTION 変換後500文字超）
+    private static func prepareIRCText(_ sanitized: String) throws -> (ircText: String, isAction: Bool, displayText: String) {
+        // /me コマンドの検出: "/me" または "/me " で始まる場合は ACTION 形式に変換して送信する
+        // 大文字小文字は区別しない（/Me, /ME なども検出する）
+        let lower = sanitized.lowercased()
+        if lower == "/me" || lower.hasPrefix("/me ") {
+            let body = lower.hasPrefix("/me ")
+                ? String(sanitized.dropFirst("/me ".count)).trimmingCharacters(in: .whitespaces)
+                : ""
+            guard !body.isEmpty else { throw ChatSendError.empty }
+            let ircText = "\u{1}ACTION \(body)\u{1}"
+            // ACTION 変換後の IRC 送信文字列でサーバー制限（500文字）を再チェックする
+            guard ircText.count <= 500 else { throw ChatSendError.tooLong }
+            return (ircText, true, body)
+        }
+        return (sanitized, false, sanitized)
+    }
+
+    /// 楽観的 UI メッセージを生成して追加する
+    ///
+    /// 送信直後に自分のメッセージをローカルで表示するために使用する。
+    private func appendOptimisticMessage(displayText: String, isAction: Bool, parentMsgId: String?) {
+        guard case .loggedIn(let login) = authState.status else { return }
+        // USERSTATE 受信済みなら displayName / colorHex / badges に反映する
+        let localMessage = ChatMessage(
+            localUsername: login,
+            displayName: currentUserState?.displayName ?? login,
+            text: displayText,
+            isAction: isAction,
+            roomId: currentRoomId,
+            colorHex: currentUserState?.colorHex,
+            badges: currentUserState?.badges ?? [],
+            replyParentMsgId: parentMsgId
+        )
+        appendMessage(localMessage)
+        // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する
+        optimisticPendingMessages[localMessage.id] = Date()
     }
 
     /// 送信エラーをリセットする（UI でエラー表示を消す際に呼ぶ）

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -63,6 +63,9 @@ final class ChatViewModel {
     /// 最後の送信エラーメッセージ（UI 表示用、成功時は nil にリセット）
     private(set) var sendError: String?
 
+    /// 現在返信対象として選択されているメッセージ（nil の場合は通常送信）
+    private(set) var replyingTo: ChatMessage?
+
     // MARK: - プライベートプロパティ
 
     private let ircClient: any TwitchIRCClientProtocol
@@ -271,6 +274,20 @@ final class ChatViewModel {
         }
     }
 
+    // MARK: - 返信
+
+    /// 指定メッセージへの返信モードを開始する
+    ///
+    /// - Parameter message: 返信先のメッセージ
+    func startReply(to message: ChatMessage) {
+        replyingTo = message
+    }
+
+    /// 返信モードをキャンセルし、通常送信モードに戻る
+    func cancelReply() {
+        replyingTo = nil
+    }
+
     // MARK: - 送信
 
     /// コメント投稿が可能かどうか
@@ -324,8 +341,13 @@ final class ChatViewModel {
         sendError = nil
         defer { isSending = false }
 
+        // 送信時点の返信先 ID を取得し、送信成功後にリセットするために保持する
+        let parentMsgId = replyingTo?.id
+
         do {
-            try await ircClient.sendPrivmsg(ircText)
+            try await ircClient.sendPrivmsg(ircText, replyTo: parentMsgId)
+            // 返信送信成功後は返信モードを解除する
+            replyingTo = nil
             // 楽観的 UI: 自分の PRIVMSG はサーバーからエコーバックされないのでローカルで追加する
             if case .loggedIn(let login) = authState.status {
                 // USERSTATE 受信済みなら displayName / colorHex / badges に反映する
@@ -337,7 +359,8 @@ final class ChatViewModel {
                     isAction: isAction,
                     roomId: currentRoomId,
                     colorHex: currentUserState?.colorHex,
-                    badges: currentUserState?.badges ?? []
+                    badges: currentUserState?.badges ?? [],
+                    replyParentMsgId: parentMsgId
                 )
                 appendMessage(localMessage)
                 // サーバー拒否（NOTICE）が来た場合の rollback のために ID と時刻を記録する

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -44,6 +44,15 @@ struct ChatDetailView: View {
                     ForEach(viewModel.messages) { message in
                         ChatMessageView(message: message, badgeStore: viewModel.badgeStore)
                             .id(message.id)
+                            .contextMenu {
+                                if viewModel.canSendMessage {
+                                    Button {
+                                        viewModel.startReply(to: message)
+                                    } label: {
+                                        Label("返信", systemImage: "arrowshape.turn.up.left")
+                                    }
+                                }
+                            }
                     }
                 }
             }

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -45,7 +45,9 @@ struct ChatDetailView: View {
                         ChatMessageView(message: message, badgeStore: viewModel.badgeStore)
                             .id(message.id)
                             .contextMenu {
-                                if viewModel.canSendMessage {
+                                // 楽観的UIメッセージ（自分が送信した未確認メッセージ）には返信不可
+                                // Twitch サーバーが認識する本物の message ID を持たないため
+                                if viewModel.canSendMessage && !message.isOptimistic {
                                     Button {
                                         viewModel.startReply(to: message)
                                     } label: {

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -21,6 +21,11 @@ struct ChatInputBar: View {
             // 認証エラーバナー（chat:edit スコープ不足またはログアウト）
             authBanner
 
+            // 返信先バナー（返信モード中のみ表示）
+            if let replyTarget = viewModel.replyingTo {
+                replyBanner(target: replyTarget)
+            }
+
             // 入力フォーム（接続中のみ表示、送信不可の場合は disabled）
             if isConnected {
                 inputForm
@@ -77,6 +82,33 @@ struct ChatInputBar: View {
 
         default:
             EmptyView()
+        }
+    }
+
+    /// 返信先バナー（返信モード中に表示）
+    ///
+    /// - Parameter target: 返信先の ChatMessage
+    private func replyBanner(target: ChatMessage) -> some View {
+        HStack {
+            Image(systemName: "arrowshape.turn.up.left")
+                .foregroundStyle(.secondary)
+            Text("\(target.displayName) に返信中")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button {
+                viewModel.cancelReply()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(Color(.windowBackgroundColor))
+        .overlay(alignment: .bottom) {
+            Divider()
         }
     }
 

--- a/Sources/TwitchChat/Views/ChatMessageView.swift
+++ b/Sources/TwitchChat/Views/ChatMessageView.swift
@@ -23,7 +23,22 @@ struct ChatMessageView: View {
     @State private var emoteImages: [String: NSImage] = [:]
 
     var body: some View {
-        HStack(alignment: .top, spacing: 4) {
+        VStack(alignment: .leading, spacing: 0) {
+            // 返信先ヘッダー（返信メッセージの場合のみ表示）
+            if let replyDisplayName = message.replyParentDisplayName {
+                HStack(spacing: 4) {
+                    Image(systemName: "arrowshape.turn.up.left.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text("@\(replyDisplayName) への返信")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .padding(.leading, 12)
+                .padding(.top, 2)
+            }
+            HStack(alignment: .top, spacing: 4) {
             // バッジ表示
             if !message.badges.isEmpty {
                 badgesView
@@ -68,11 +83,12 @@ struct ChatMessageView: View {
                     }
                 }
             }
+            }
+            .font(.system(size: 13))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
         }
-        .font(.system(size: 13))
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 3)
         .task(id: message.id) {
             await loadEmoteImages()
         }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -379,4 +379,72 @@ struct ChatMessageTests {
         #expect(chatMessage.colorHex == nil)
         #expect(chatMessage.badges.isEmpty)
     }
+
+    // MARK: - 返信（Reply）
+
+    @Test("返信タグ付き PRIVMSG から返信メタデータが読み取れる")
+    func 返信タグ付きPRIVMSGから返信メタデータが読み取れる() {
+        // 前提: reply-parent-* タグを含む PRIVMSG
+        let rawMessage = "@reply-parent-msg-id=親メッセージid-123;reply-parent-user-login=oyausername;reply-parent-display-name=親ユーザー;reply-parent-msg-body=元のメッセージ内容;display-name=返信者;id=reply-001 :henshinsha!henshinsha@henshinsha.tmi.twitch.tv PRIVMSG #ch :返信テキスト"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: 4つの返信メタデータが正しく読み取られる
+        guard let chatMessage = ChatMessage(from: ircMessage) else {
+            Issue.record("ChatMessage への変換に失敗しました")
+            return
+        }
+        #expect(chatMessage.replyParentMsgId == "親メッセージid-123")
+        #expect(chatMessage.replyParentUserLogin == "oyausername")
+        #expect(chatMessage.replyParentDisplayName == "親ユーザー")
+        #expect(chatMessage.replyParentMsgBody == "元のメッセージ内容")
+    }
+
+    @Test("返信タグがない PRIVMSG では返信メタデータが全て nil になる")
+    func 返信タグがないPRIVMSGでは返信メタデータが全てnilになる() {
+        // 前提: 通常のタグ付き PRIVMSG（reply タグなし）
+        let rawMessage = "@badges=subscriber/6;color=#FF0000;display-name=山田太郎;id=abc-123 :yamadataro!yamadataro@yamadataro.tmi.twitch.tv PRIVMSG #ch :通常メッセージ"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: 返信メタデータが全て nil になる
+        guard let chatMessage = ChatMessage(from: ircMessage) else {
+            Issue.record("ChatMessage への変換に失敗しました")
+            return
+        }
+        #expect(chatMessage.replyParentMsgId == nil)
+        #expect(chatMessage.replyParentUserLogin == nil)
+        #expect(chatMessage.replyParentDisplayName == nil)
+        #expect(chatMessage.replyParentMsgBody == nil)
+    }
+
+    @Test("楽観的 UI 用イニシャライザで replyParentMsgId を指定できる")
+    func 楽観的UI用イニシャライザでreplyParentMsgIdを指定できる() {
+        // 前提: 返信送信時に返信先メッセージ ID を指定
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            displayName: "山田太郎",
+            text: "返信メッセージ",
+            replyParentMsgId: "親メッセージid-456"
+        )
+
+        // 検証: replyParentMsgId が設定される
+        #expect(chatMessage.replyParentMsgId == "親メッセージid-456")
+    }
+
+    @Test("楽観的 UI 用イニシャライザで replyParentMsgId を省略すると nil になる")
+    func 楽観的UI用イニシャライザでreplyParentMsgIdを省略するとnilになる() {
+        // 前提: replyParentMsgId を省略して生成（通常メッセージ、後方互換）
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            text: "通常メッセージ"
+        )
+
+        // 検証: replyParentMsgId が nil になる
+        #expect(chatMessage.replyParentMsgId == nil)
+    }
 }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -416,6 +416,7 @@ struct ChatMessageTests {
     @Test("返信タグ付き PRIVMSG から返信メタデータが読み取れる")
     func 返信タグ付きPRIVMSGから返信メタデータが読み取れる() {
         // 前提: reply-parent-* タグを含む PRIVMSG
+        // swiftlint:disable:next line_length
         let rawMessage = "@reply-parent-msg-id=親メッセージid-123;reply-parent-user-login=oyausername;reply-parent-display-name=親ユーザー;reply-parent-msg-body=元のメッセージ内容;display-name=返信者;id=reply-001 :henshinsha!henshinsha@henshinsha.tmi.twitch.tv PRIVMSG #ch :返信テキスト"
         guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
             Issue.record("IRCMessage のパースに失敗しました")

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -380,6 +380,37 @@ struct ChatMessageTests {
         #expect(chatMessage.badges.isEmpty)
     }
 
+    // MARK: - 楽観的 UI フラグ
+
+    @Test("IRCMessage から変換した ChatMessage は isOptimistic が false になる")
+    func IRCMessageから変換したChatMessageはisOptimisticがfalseになる() {
+        // 前提: 通常の PRIVMSG（Twitch サーバーから受信したメッセージ）
+        let rawMessage = "@badges=subscriber/6;color=#FF0000;display-name=山田太郎;id=abc-123 :yamadataro!yamadataro@yamadataro.tmi.twitch.tv PRIVMSG #ch :こんにちは"
+        guard let ircMessage = IRCMessageParser.parse(rawMessage) else {
+            Issue.record("IRCMessage のパースに失敗しました")
+            return
+        }
+
+        // 検証: サーバー受信メッセージは isOptimistic が false（本物の message ID を持つ）
+        guard let chatMessage = ChatMessage(from: ircMessage) else {
+            Issue.record("ChatMessage への変換に失敗しました")
+            return
+        }
+        #expect(chatMessage.isOptimistic == false)
+    }
+
+    @Test("楽観的 UI 用イニシャライザで生成した ChatMessage は isOptimistic が true になる")
+    func 楽観的UI用イニシャライザで生成したChatMessageはisOptimisticがtrueになる() {
+        // 前提: 送信直後にローカルで生成する楽観的 UI メッセージ
+        let chatMessage = ChatMessage(
+            localUsername: "yamadataro",
+            text: "送信したメッセージ"
+        )
+
+        // 検証: 楽観的 UI メッセージは isOptimistic が true（Twitch が認識できない UUID を持つ）
+        #expect(chatMessage.isOptimistic == true)
+    }
+
     // MARK: - 返信（Reply）
 
     @Test("返信タグ付き PRIVMSG から返信メタデータが読み取れる")

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -26,6 +26,9 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
     /// sendPrivmsg() で送信されたメッセージのログ（テスト検証用）
     private(set) var sentPrivmsgs: [String] = []
 
+    /// sendPrivmsg() で渡された返信先 ID のログ（テスト検証用）
+    private(set) var sentReplyToIds: [String?] = []
+
     /// sendPrivmsg() が throw するエラー（nil の場合は成功）
     private var sendPrivmsgError: (any Error)?
 
@@ -68,7 +71,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
         userStateContinuation?.finish()
     }
 
-    func sendPrivmsg(_ text: String) async throws {
+    func sendPrivmsg(_ text: String, replyTo parentMsgId: String? = nil) async throws {
         if let error = sendPrivmsgError {
             throw error
         }
@@ -76,6 +79,7 @@ actor MockTwitchIRCClient: TwitchIRCClientProtocol {
             throw TwitchIRCClientError.notConnected
         }
         sentPrivmsgs.append(text)
+        sentReplyToIds.append(parentMsgId)
     }
 
     /// テスト用にメッセージを流し込む
@@ -738,5 +742,100 @@ struct ChatViewModelTests {
         #expect(optimisticMessage?.displayName == "新しい表示名")
         #expect(optimisticMessage?.colorHex == "#00FF7F")
         #expect(optimisticMessage?.badges == [Badge(name: "subscriber", version: "6")])
+    }
+
+    // MARK: - 返信（Reply）状態管理
+
+    @Test("replyingTo の初期値が nil である")
+    func replyingToの初期値がnilである() async throws {
+        // 前提: 接続済み ViewModel
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "視聴者001")
+
+        // 検証: replyingTo の初期値が nil
+        #expect(viewModel.replyingTo == nil)
+    }
+
+    @Test("startReply で replyingTo にメッセージがセットされる")
+    func startReplyでreplyingToにメッセージがセットされる() async throws {
+        // 前提: 接続済み ViewModel と返信先メッセージ
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "視聴者001")
+        let parentMessage = makeTestChatMessage(displayName: "配信者", text: "元のメッセージ")
+
+        // 実行: startReply を呼ぶ
+        viewModel.startReply(to: parentMessage)
+
+        // 検証: replyingTo に返信先メッセージがセットされる
+        #expect(viewModel.replyingTo?.id == parentMessage.id)
+    }
+
+    @Test("cancelReply で replyingTo が nil にリセットされる")
+    func cancelReplyでreplyingToがnilにリセットされる() async throws {
+        // 前提: 返信先がセットされた状態
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "視聴者001")
+        let parentMessage = makeTestChatMessage(displayName: "配信者", text: "元のメッセージ")
+        viewModel.startReply(to: parentMessage)
+
+        // 実行: cancelReply を呼ぶ
+        viewModel.cancelReply()
+
+        // 検証: replyingTo が nil にリセットされる
+        #expect(viewModel.replyingTo == nil)
+    }
+
+    @Test("replyingTo セット状態で sendMessage すると replyTo 付きで IRC 送信される")
+    func replyingToセット状態でsendMessageするとreplyTo付きでIRC送信される() async throws {
+        // 前提: 返信先がセットされた状態で接続・ログイン済み
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者001")
+        let parentMessage = makeTestChatMessage(displayName: "配信者", text: "元のメッセージ")
+        viewModel.startReply(to: parentMessage)
+
+        // 実行: sendMessage を呼ぶ
+        try await viewModel.sendMessage("返信テキスト")
+
+        // 検証: 返信先 ID が sendPrivmsg に渡される
+        let replyToIds = await mockClient.sentReplyToIds
+        #expect(replyToIds.last == parentMessage.id)
+    }
+
+    @Test("sendMessage 成功後に replyingTo が nil にリセットされる")
+    func sendMessage成功後にreplyingToがnilにリセットされる() async throws {
+        // 前提: 返信先がセットされた状態で接続・ログイン済み
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "視聴者001")
+        let parentMessage = makeTestChatMessage(displayName: "配信者", text: "元のメッセージ")
+        viewModel.startReply(to: parentMessage)
+
+        // 実行: sendMessage を呼ぶ
+        try await viewModel.sendMessage("返信テキスト")
+
+        // 検証: 送信成功後に replyingTo が nil にリセットされる
+        #expect(viewModel.replyingTo == nil)
+    }
+
+    @Test("replyingTo がセットされた状態の楽観的 UI メッセージに replyParentMsgId がセットされる")
+    func replyingToがセットされた状態の楽観的UIメッセージにreplyParentMsgIdがセットされる() async throws {
+        // 前提: 返信先がセットされた状態で接続・ログイン済み
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "視聴者001")
+        let parentMessage = makeTestChatMessage(displayName: "配信者", text: "元のメッセージ")
+        viewModel.startReply(to: parentMessage)
+
+        // 実行: sendMessage を呼ぶ
+        try await viewModel.sendMessage("返信テキスト")
+        await waitFor { viewModel.messages.count >= 1 }
+
+        // 検証: 楽観的 UI メッセージの replyParentMsgId が返信先の id と一致する
+        #expect(viewModel.messages.first?.replyParentMsgId == parentMessage.id)
+    }
+
+    @Test("replyingTo が nil の状態で sendMessage すると replyTo なしで送信される")
+    func replyingToがnilの状態でsendMessageするとreplyToなしで送信される() async throws {
+        // 前提: 返信先がセットされていない状態で接続・ログイン済み
+        let (viewModel, mockClient) = try await makeConnectedViewModel(userLogin: "視聴者001")
+
+        // 実行: sendMessage を呼ぶ
+        try await viewModel.sendMessage("通常メッセージ")
+
+        // 検証: 返信先 ID が nil で送信される（通常メッセージ）
+        let replyToIds = await mockClient.sentReplyToIds
+        #expect(replyToIds.last == .some(nil))
     }
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -1,6 +1,7 @@
 // ChatViewModelTests.swift
 // ChatViewModel の単体テスト
 // MockTwitchIRCClient を使用してネットワーク通信なしで ViewModel の振る舞いを検証する
+// swiftlint:disable file_length
 
 import Foundation
 import Testing

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -671,4 +671,49 @@ struct TwitchIRCClientTests {
         }
         return false
     }
+
+    // MARK: - 返信（Reply）送信
+
+    @Test("replyTo 指定時に @reply-parent-msg-id タグ付きで PRIVMSG が送信される")
+    func replyTo指定時にreplyParentMsgIdタグ付きでPRIVMSGが送信される() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 認証接続でチャンネルに参加
+        let connectTask = Task {
+            try await client.connect(to: "haishinshaA", accessToken: "テスト用トークン", userLogin: "視聴者001")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: replyTo に親メッセージ ID を指定すると @reply-parent-msg-id タグ付きで送信される
+        try await client.sendPrivmsg("返信テキスト", replyTo: "親メッセージid-123")
+
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("@reply-parent-msg-id=親メッセージid-123 PRIVMSG #haishinshaa :返信テキスト"))
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
+
+    @Test("replyTo が nil の場合はタグなしで従来通り PRIVMSG が送信される")
+    func replyToがnilの場合はタグなしで従来通りPRIVMSGが送信される() async throws {
+        let mockWS = MockWebSocketClient()
+        let client = TwitchIRCClient(webSocketClient: mockWS)
+
+        // 前提: 認証接続でチャンネルに参加
+        let connectTask = Task {
+            try await client.connect(to: "haishinshaB", accessToken: "テスト用トークン", userLogin: "視聴者002")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        // 検証: replyTo が nil（省略）の場合はタグなしで送信される（後方互換）
+        try await client.sendPrivmsg("通常メッセージ", replyTo: nil)
+
+        let sent = await mockWS.sentMessages
+        #expect(sent.contains("PRIVMSG #haishinshab :通常メッセージ"))
+        #expect(!sent.contains { $0.hasPrefix("@reply-parent-msg-id=") && $0.contains("通常メッセージ") })
+
+        await client.disconnect()
+        connectTask.cancel()
+    }
 }


### PR DESCRIPTION
## 概要

Closes #22

Twitch IRC の返信機能（`reply-parent-msg-id` タグ付き PRIVMSG）を実装しました。

## 変更内容

- **Model層**: `ChatMessage` に返信メタデータプロパティを4つ追加（`replyParentMsgId` / `replyParentUserLogin` / `replyParentDisplayName` / `replyParentMsgBody`）
- **Service層**: `TwitchIRCClientProtocol.sendPrivmsg` に `replyTo` オプション引数を追加し、指定時は `@reply-parent-msg-id=<id> PRIVMSG` 形式で送信
- **ViewModel層**: `replyingTo` 状態プロパティと `startReply(to:)` / `cancelReply()` メソッドを追加。送信成功後に返信状態をリセット
- **View層**:
  - `ChatMessageView`: 返信メッセージに返信先ヘッダーを表示
  - `ChatInputBar`: 返信モード中に返信先バナー（キャンセルボタン付き）を表示
  - `ChatDetailView`: メッセージに右クリックコンテキストメニュー「返信」を追加

## テスト

TDD（RED→GREEN→REFACTOR）で実装しています。

| テストスイート | 件数 |
|---|---|
| ChatMessageTests（返信タグテスト4件追加） | 29件 |
| IRCMessageParserTests（変更なし） | 15件 |
| TwitchIRCClientTests（返信送信フォーマットテスト2件追加） | 22件 |
| ChatViewModelTests（Mock更新 + 返信状態管理テスト7件追加） | 34件 |

## テスト計画

- [ ] メッセージを右クリック → 「返信」でバナーが表示されること
- [ ] 返信送信後にバナーが消えること
- [ ] キャンセル（×ボタン）でバナーが消えること
- [ ] 他ユーザーの返信メッセージ受信時に返信先ヘッダーが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * メッセージへの返信機能を追加しました。チャットメッセージのコンテキストメニューから返信を開始でき、返信対象のメッセージ情報が入力バーに表示されます。返信をキャンセルボタンでキャンセルできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->