### PR TITLE
feat: 入力欄エモートのアニメーション再生を実装する (#35)

### DIFF
--- a/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
+++ b/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
@@ -150,7 +150,9 @@ final class EmoteAnimationDriver {
         // フレームが実際に変化したかどうかを追跡する（変化がない場合は通知しない）
         var anyFrameChanged = false
 
-        for (emoteId, list) in registrations {
+        // 列挙中の辞書ミューテーションを避けるためキーのスナップショットで反復する
+        for emoteId in Array(registrations.keys) {
+            guard let list = registrations[emoteId] else { continue }
             let alive = list.filter { $0.value != nil }
             if alive.isEmpty {
                 emoteIdsToRemove.append(emoteId)

--- a/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
+++ b/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
@@ -14,6 +14,7 @@ import AppKit
 /// - 50ms（20fps）間隔の共有 Timer でアクティブな全アタッチメントのフレームを更新する
 /// - 同一 emoteId のアタッチメントはフレーム計算を共有して CPU コストを最小化する
 /// - フレームインデックスが変わらない場合は `image` 更新をスキップする
+/// - フレームが実際に変化した場合のみ `emoteFrameDidUpdate` 通知を post する
 /// - 全アタッチメント解除時にタイマーを自動停止する
 @MainActor
 final class EmoteAnimationDriver {
@@ -27,9 +28,9 @@ final class EmoteAnimationDriver {
     /// 実行中のタイマー（nil の場合はタイマー停止中）
     private var timer: Timer?
 
-    /// 登録中のアタッチメント（emoteId をキーとして、同一エモートの全アタッチメントを管理）
+    /// 登録中のアタッチメント（emoteId をキーとして、同一エモートの全アタッチメントを弱参照で管理）
     ///
-    /// 値の配列には弱参照は使わず、deinit / unregister で明示的に削除する。
+    /// 弱参照（`Weak` ラッパー）で保持し、デアロケート済みエントリは `tick()` の先頭でクリーンアップする。
     private var registrations: [String: [Weak<EmoteTextAttachment>]] = [:]
 
     /// emoteId ごとのフレームシーケンスキャッシュ（GIF データから生成、解放は registrations と連動）
@@ -47,6 +48,7 @@ final class EmoteAnimationDriver {
     /// アニメーションエモートのアタッチメントを登録する
     ///
     /// - 同一 emoteId の初回登録時に `GIFFrameSequence` を構築する
+    /// - 同じアタッチメントの二重登録を防ぐため、登録前に重複チェックを行う
     /// - アクティブなアタッチメントが 1 件以上になった時点でタイマーを起動する
     ///
     /// - Parameter attachment: 登録する `EmoteTextAttachment`
@@ -63,8 +65,10 @@ final class EmoteAnimationDriver {
             frameSequences[emoteId] = sequence
         }
 
-        // 弱参照リストに追加
-        var list = registrations[emoteId] ?? []
+        // 解放済みエントリを除去しつつ重複チェックを行う
+        var list = (registrations[emoteId] ?? []).filter { $0.value != nil }
+        let id = ObjectIdentifier(attachment)
+        guard !list.contains(where: { $0.objectIdentifier == id }) else { return }
         list.append(Weak(attachment))
         registrations[emoteId] = list
 
@@ -80,7 +84,6 @@ final class EmoteAnimationDriver {
         guard let emoteId = attachment.emoteId else { return }
 
         guard var list = registrations[emoteId] else { return }
-        // 対象の弱参照エントリを削除する
         let id = ObjectIdentifier(attachment)
         list.removeAll { $0.objectIdentifier == id || $0.value == nil }
 
@@ -112,16 +115,21 @@ final class EmoteAnimationDriver {
     // MARK: - プライベートメソッド
 
     /// タイマーを開始する（既に動作中の場合は何もしない）
+    ///
+    /// - Note: `.common` モードで登録することでスクロール中もタイマーが停止しない。
     private func startTimerIfNeeded() {
         guard timer == nil else { return }
         elapsed = 0
-        timer = Timer.scheduledTimer(withTimeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
+        let newTimer = Timer(timeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
             guard let self else { return }
             MainActor.assumeIsolated {
                 self.elapsed += Self.timerInterval
                 self.tick()
             }
         }
+        // .common モードで追加してスクロール中もタイマーが動作するようにする
+        RunLoop.main.add(newTimer, forMode: .common)
+        timer = newTimer
     }
 
     /// 登録アタッチメントが空の場合にタイマーを停止する
@@ -138,8 +146,9 @@ final class EmoteAnimationDriver {
 
     /// 全登録アタッチメントのフレームを現在の経過時間に基づいて更新する
     private func tick() {
-        // 解放済みの弱参照を一括クリーンアップする
         var emoteIdsToRemove: [String] = []
+        // フレームが実際に変化したかどうかを追跡する（変化がない場合は通知しない）
+        var anyFrameChanged = false
 
         for (emoteId, list) in registrations {
             let alive = list.filter { $0.value != nil }
@@ -164,6 +173,7 @@ final class EmoteAnimationDriver {
                 if attachment.currentFrameIndex == frameIndex { continue }
                 attachment.currentFrameIndex = frameIndex
                 attachment.image = frameImage
+                anyFrameChanged = true
             }
         }
 
@@ -175,9 +185,9 @@ final class EmoteAnimationDriver {
 
         stopTimerIfEmpty()
 
-        // NSTextView に再描画を要求する
-        if !registrations.isEmpty {
-            NotificationCenter.default.post(name: .emoteFrameDidUpdate, object: nil)
+        // フレームが実際に変化した場合のみ NSTextView に再描画を要求する
+        if anyFrameChanged {
+            NotificationCenter.default.post(name: .emoteFrameDidUpdate, object: self)
         }
     }
 
@@ -205,7 +215,8 @@ final class EmoteAnimationDriver {
 extension Notification.Name {
     /// EmoteAnimationDriver がフレームを更新した際に post する通知
     ///
-    /// `EmoteRichTextView.Coordinator` が受信し `textView.needsDisplay = true` を呼ぶ。
+    /// post 時の `object` は `EmoteAnimationDriver` インスタンス。
+    /// `EmoteRichTextView.Coordinator` は `object: EmoteAnimationDriver.shared` で購読する。
     static let emoteFrameDidUpdate = Notification.Name("emoteFrameDidUpdate")
 }
 

--- a/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
+++ b/Sources/TwitchChat/Services/EmoteAnimationDriver.swift
@@ -1,0 +1,226 @@
+// EmoteAnimationDriver.swift
+// 入力欄のアニメーションエモートを駆動する共有タイマーシングルトン
+// 登録された EmoteTextAttachment の image プロパティを GIF フレームに差し替えて疑似アニメーションを実現する
+
+import AppKit
+
+/// アニメーションエモートのフレーム更新を駆動する共有タイマー
+///
+/// `EmoteTextAttachment` を登録することで、GIF アニメーションのフレームを `image` プロパティ経由で
+/// NSTextView に反映する。`NSTextAttachmentViewProvider` を使わないため、ポップオーバー閉鎖時の
+/// TextKit 2 viewport 再計算によるビュー消失問題を回避できる。
+///
+/// ## 動作原理
+/// - 50ms（20fps）間隔の共有 Timer でアクティブな全アタッチメントのフレームを更新する
+/// - 同一 emoteId のアタッチメントはフレーム計算を共有して CPU コストを最小化する
+/// - フレームインデックスが変わらない場合は `image` 更新をスキップする
+/// - 全アタッチメント解除時にタイマーを自動停止する
+@MainActor
+final class EmoteAnimationDriver {
+
+    /// シングルトンインスタンス
+    static let shared = EmoteAnimationDriver()
+
+    /// タイマーの更新間隔（秒）。20fps = 0.05 秒
+    private static let timerInterval: TimeInterval = 0.05
+
+    /// 実行中のタイマー（nil の場合はタイマー停止中）
+    private var timer: Timer?
+
+    /// 登録中のアタッチメント（emoteId をキーとして、同一エモートの全アタッチメントを管理）
+    ///
+    /// 値の配列には弱参照は使わず、deinit / unregister で明示的に削除する。
+    private var registrations: [String: [Weak<EmoteTextAttachment>]] = [:]
+
+    /// emoteId ごとのフレームシーケンスキャッシュ（GIF データから生成、解放は registrations と連動）
+    private var frameSequences: [String: GIFFrameSequence] = [:]
+
+    /// タイマー起動からの累積経過時間（秒）
+    private var elapsed: TimeInterval = 0
+
+    // MARK: - 初期化
+
+    init() {}
+
+    // MARK: - 登録/解除
+
+    /// アニメーションエモートのアタッチメントを登録する
+    ///
+    /// - 同一 emoteId の初回登録時に `GIFFrameSequence` を構築する
+    /// - アクティブなアタッチメントが 1 件以上になった時点でタイマーを起動する
+    ///
+    /// - Parameter attachment: 登録する `EmoteTextAttachment`
+    func register(_ attachment: EmoteTextAttachment) {
+        guard let emoteId = attachment.emoteId else { return }
+
+        // フレームシーケンスを構築（未構築の場合のみ）
+        if frameSequences[emoteId] == nil {
+            guard let gifData = EmoteImageCache.shared.gifData(for: emoteId),
+                  let sequence = GIFFrameSequence(from: gifData) else {
+                // GIF データが存在しない・または静止画のため登録しない
+                return
+            }
+            frameSequences[emoteId] = sequence
+        }
+
+        // 弱参照リストに追加
+        var list = registrations[emoteId] ?? []
+        list.append(Weak(attachment))
+        registrations[emoteId] = list
+
+        startTimerIfNeeded()
+    }
+
+    /// アタッチメントの登録を解除する
+    ///
+    /// - 全アタッチメント解除時にタイマーを停止し、フレームシーケンスキャッシュも解放する
+    ///
+    /// - Parameter attachment: 解除する `EmoteTextAttachment`
+    func unregister(_ attachment: EmoteTextAttachment) {
+        guard let emoteId = attachment.emoteId else { return }
+
+        guard var list = registrations[emoteId] else { return }
+        // 対象の弱参照エントリを削除する
+        let id = ObjectIdentifier(attachment)
+        list.removeAll { $0.objectIdentifier == id || $0.value == nil }
+
+        if list.isEmpty {
+            registrations.removeValue(forKey: emoteId)
+            frameSequences.removeValue(forKey: emoteId)
+        } else {
+            registrations[emoteId] = list
+        }
+
+        stopTimerIfEmpty()
+    }
+
+    // MARK: - タイマー状態（テスト用公開プロパティ）
+
+    /// タイマーが動作中かどうか（テストから参照するための内部プロパティ）
+    var isTimerActive: Bool { timer != nil }
+
+    // MARK: - テスト用メソッド
+
+    /// タイマーの実動作を待たずに tick を手動実行する（テスト専用）
+    ///
+    /// - Parameter elapsed: 現在の累積経過時間（秒）として使用する値
+    func tickForTesting(elapsed: TimeInterval) {
+        self.elapsed = elapsed
+        tick()
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// タイマーを開始する（既に動作中の場合は何もしない）
+    private func startTimerIfNeeded() {
+        guard timer == nil else { return }
+        elapsed = 0
+        timer = Timer.scheduledTimer(withTimeInterval: Self.timerInterval, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.elapsed += Self.timerInterval
+                self.tick()
+            }
+        }
+    }
+
+    /// 登録アタッチメントが空の場合にタイマーを停止する
+    private func stopTimerIfEmpty() {
+        let hasActive = registrations.values.contains { list in
+            list.contains { $0.value != nil }
+        }
+        if !hasActive {
+            timer?.invalidate()
+            timer = nil
+            elapsed = 0
+        }
+    }
+
+    /// 全登録アタッチメントのフレームを現在の経過時間に基づいて更新する
+    private func tick() {
+        // 解放済みの弱参照を一括クリーンアップする
+        var emoteIdsToRemove: [String] = []
+
+        for (emoteId, list) in registrations {
+            let alive = list.filter { $0.value != nil }
+            if alive.isEmpty {
+                emoteIdsToRemove.append(emoteId)
+                continue
+            }
+            registrations[emoteId] = alive
+
+            guard let sequence = frameSequences[emoteId] else { continue }
+            guard sequence.totalDuration > 0 else { continue }
+
+            // 経過時間から現在フレームインデックスを計算する
+            let loopedElapsed = elapsed.truncatingRemainder(dividingBy: sequence.totalDuration)
+            let frameIndex = frameIndex(for: loopedElapsed, in: sequence)
+
+            // 同一 emoteId のアタッチメントは全て同じフレームに更新する
+            let frameImage = sequence.frames[frameIndex]
+            for weakRef in alive {
+                guard let attachment = weakRef.value else { continue }
+                // フレームインデックスが変わっていない場合は更新をスキップする
+                if attachment.currentFrameIndex == frameIndex { continue }
+                attachment.currentFrameIndex = frameIndex
+                attachment.image = frameImage
+            }
+        }
+
+        // 空になった emoteId のエントリを削除する
+        for emoteId in emoteIdsToRemove {
+            registrations.removeValue(forKey: emoteId)
+            frameSequences.removeValue(forKey: emoteId)
+        }
+
+        stopTimerIfEmpty()
+
+        // NSTextView に再描画を要求する
+        if !registrations.isEmpty {
+            NotificationCenter.default.post(name: .emoteFrameDidUpdate, object: nil)
+        }
+    }
+
+    /// 経過時間からフレームインデックスを計算する
+    ///
+    /// - Parameters:
+    ///   - elapsed: ループ内での経過時間（0 以上 totalDuration 未満）
+    ///   - sequence: フレームシーケンス
+    /// - Returns: 対応するフレームインデックス
+    private func frameIndex(for elapsed: TimeInterval, in sequence: GIFFrameSequence) -> Int {
+        var accumulated: TimeInterval = 0
+        for (index, duration) in sequence.durations.enumerated() {
+            accumulated += duration
+            if elapsed < accumulated {
+                return index
+            }
+        }
+        // 浮動小数点誤差で最終フレームを超えた場合は末尾フレームを返す
+        return sequence.frames.count - 1
+    }
+}
+
+// MARK: - Notification 名
+
+extension Notification.Name {
+    /// EmoteAnimationDriver がフレームを更新した際に post する通知
+    ///
+    /// `EmoteRichTextView.Coordinator` が受信し `textView.needsDisplay = true` を呼ぶ。
+    static let emoteFrameDidUpdate = Notification.Name("emoteFrameDidUpdate")
+}
+
+// MARK: - 弱参照ラッパー
+
+/// 弱参照ラッパー（`AnyObject` 準拠の型を弱参照で保持する）
+private struct Weak<T: AnyObject> {
+    /// 保持対象の ObjectIdentifier（解放後も比較に使用できる）
+    let objectIdentifier: ObjectIdentifier
+
+    /// 弱参照（解放済みの場合は nil）
+    weak var value: T?
+
+    init(_ value: T) {
+        self.objectIdentifier = ObjectIdentifier(value)
+        self.value = value
+    }
+}

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -37,6 +37,12 @@ final class EmoteImageCache: @unchecked Sendable {
     /// `GIFFrameSequence` の初期化に必要な生データを保持する。
     /// `NSImage(data:)` で変換済みの NSImage からは GIF バイナリを確実に復元できないため、
     /// ダウンロード時の生 `Data` を別途キャッシュする。
+    ///
+    /// - Note: `imageCache` と `gifDataCache` は独立した `NSCache` インスタンスのため、
+    ///   メモリプレッシャー時に片方のみが解放される場合がある。
+    ///   `EmoteAnimationDriver.register` は `gifData(for:)` が nil のとき登録をスキップするため
+    ///   `imageCache` のみ残存しても動作上の問題は生じないが、
+    ///   `gifDataCache` のみ残存するケースでは無駄なデータが残る点に注意する。
     private let gifDataCache: NSCache<NSString, NSData> = {
         let c = NSCache<NSString, NSData>()
         c.countLimit = 500
@@ -194,9 +200,10 @@ final class EmoteImageCache: @unchecked Sendable {
         }
     }
 
+    // MARK: - テスト用メソッド
+
+#if DEBUG
     /// テスト用: GIF 生データをキャッシュに直接登録する
-    ///
-    /// - Note: `#if DEBUG` でも良いが、テスト対象の `@testable import` から呼べるようにアクセス修飾子は internal のまま
     ///
     /// - Parameters:
     ///   - gifData: 登録する GIF バイナリデータ
@@ -204,4 +211,14 @@ final class EmoteImageCache: @unchecked Sendable {
     func storeForTesting(gifData: Data, for emoteId: String) {
         gifDataCache.setObject(gifData as NSData, forKey: emoteId as NSString)
     }
+
+    /// テスト用: 全キャッシュをクリアする
+    ///
+    /// テスト間の状態汚染を防ぐため、テスト終了時に呼び出す。
+    func clearForTesting() {
+        imageCache.removeAllObjects()
+        gifDataCache.removeAllObjects()
+        lock.withLock { animatedEmoteIds.removeAll() }
+    }
+#endif
 }

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -32,6 +32,17 @@ final class EmoteImageCache: @unchecked Sendable {
         return c
     }()
 
+    /// アニメーション GIF の生データキャッシュ（キー: エモートID）
+    ///
+    /// `GIFFrameSequence` の初期化に必要な生データを保持する。
+    /// `NSImage(data:)` で変換済みの NSImage からは GIF バイナリを確実に復元できないため、
+    /// ダウンロード時の生 `Data` を別途キャッシュする。
+    private let gifDataCache: NSCache<NSString, NSData> = {
+        let c = NSCache<NSString, NSData>()
+        c.countLimit = 500
+        return c
+    }()
+
     /// アニメーション版が存在するエモートIDの集合
     private var animatedEmoteIds: Set<String> = []
 
@@ -74,13 +85,13 @@ final class EmoteImageCache: @unchecked Sendable {
                 defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: emoteId) } }
 
                 // アニメーション版を先に試みる
-                if let image = await self.download(emoteId: emoteId, type: "animated") {
-                    self.store(image, for: emoteId, isAnimated: true)
+                if let (image, data) = await self.download(emoteId: emoteId, type: "animated") {
+                    self.store(image, gifData: data, for: emoteId, isAnimated: true)
                     return image
                 }
                 // スタティック版にフォールバック
-                if let image = await self.download(emoteId: emoteId, type: "default") {
-                    self.store(image, for: emoteId, isAnimated: false)
+                if let (image, _) = await self.download(emoteId: emoteId, type: "default") {
+                    self.store(image, gifData: nil, for: emoteId, isAnimated: false)
                     return image
                 }
                 return nil
@@ -98,6 +109,17 @@ final class EmoteImageCache: @unchecked Sendable {
     /// - Returns: アニメーション版が取得済みの場合 true
     func isAnimated(emoteId: String) -> Bool {
         lock.withLock { animatedEmoteIds.contains(emoteId) }
+    }
+
+    /// キャッシュ済みの GIF 生データを同期的に返す（ダウンロードは行わない）
+    ///
+    /// `GIFFrameSequence` の初期化など、非同期処理が使えない文脈で使用する。
+    /// スタティック PNG エモートや未キャッシュのエモートは nil を返す。
+    ///
+    /// - Parameter emoteId: Twitch エモートID
+    /// - Returns: キャッシュ済みの GIF バイナリデータ、未キャッシュまたはスタティック版の場合は nil
+    func gifData(for emoteId: String) -> Data? {
+        gifDataCache.object(forKey: emoteId as NSString) as Data?
     }
 
     /// キャッシュ済みのエモート画像を同期的に返す（ダウンロードは行わない）
@@ -140,30 +162,46 @@ final class EmoteImageCache: @unchecked Sendable {
     /// - Parameters:
     ///   - emoteId: Twitch エモートID
     ///   - type: 画像タイプ（`"default"` または `"animated"`）
-    /// - Returns: ダウンロード成功時は NSImage、HTTP 200 以外または解析失敗時は nil
-    private func download(emoteId: String, type: String) async -> NSImage? {
+    /// - Returns: ダウンロード成功時は `(NSImage, Data)` タプル、HTTP 200 以外または解析失敗時は nil
+    private func download(emoteId: String, type: String) async -> (NSImage, Data)? {
         let url = Self.emoteURL(emoteId: emoteId, type: type)
         guard let (data, response) = try? await URLSession.shared.data(from: url),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let image = NSImage(data: data) else { return nil }
-        return image
+        return (image, data)
     }
 
     /// 画像をキャッシュに保存し、表示サイズを設定する
     ///
     /// NSImage.size を設定することで、`Text(Image(nsImage:))` でのインライン表示サイズを
     /// `emoteDisplaySize` に揃える。ビットマップデータは変更しない。
+    /// アニメーション版の場合は GIF 生データも `gifDataCache` に保存する。
     ///
     /// - Parameters:
     ///   - image: 保存する NSImage
+    ///   - gifData: GIF バイナリデータ（アニメーション版のみ。スタティック版は nil）
     ///   - emoteId: Twitch エモートID
     ///   - isAnimated: アニメーション版かどうか
-    private func store(_ image: NSImage, for emoteId: String, isAnimated: Bool) {
+    private func store(_ image: NSImage, gifData: Data?, for emoteId: String, isAnimated: Bool) {
         image.size = NSSize(width: Self.emoteDisplaySize, height: Self.emoteDisplaySize)
         imageCache.setObject(image, forKey: emoteId as NSString)
         if isAnimated {
             _ = lock.withLock { animatedEmoteIds.insert(emoteId) }
+            if let data = gifData {
+                gifDataCache.setObject(data as NSData, forKey: emoteId as NSString)
+            }
         }
+    }
+
+    /// テスト用: GIF 生データをキャッシュに直接登録する
+    ///
+    /// - Note: `#if DEBUG` でも良いが、テスト対象の `@testable import` から呼べるようにアクセス修飾子は internal のまま
+    ///
+    /// - Parameters:
+    ///   - gifData: 登録する GIF バイナリデータ
+    ///   - emoteId: Twitch エモートID
+    func storeForTesting(gifData: Data, for emoteId: String) {
+        gifDataCache.setObject(gifData as NSData, forKey: emoteId as NSString)
     }
 }

--- a/Sources/TwitchChat/Services/GIFFrameSequence.swift
+++ b/Sources/TwitchChat/Services/GIFFrameSequence.swift
@@ -11,8 +11,8 @@ import ImageIO
 /// `EmoteAnimationDriver` がタイマー駆動でフレームを切り替えるために使用する。
 ///
 /// - Note: 静止画（フレーム数 1 以下）の場合は `init` が nil を返す
-/// - Note: `Sendable` 準拠により Swift Concurrency 環境で安全に共有できる
-struct GIFFrameSequence: Sendable {
+/// - Note: `NSImage` は `Sendable` 非準拠のため、このクラスは `@MainActor` 内でのみ使用する
+struct GIFFrameSequence {
 
     /// 各フレームの NSImage（`EmoteImageCache.emoteDisplaySize` にリサイズ済み）
     let frames: [NSImage]
@@ -47,11 +47,9 @@ struct GIFFrameSequence: Sendable {
             let duration = Self.frameDuration(source: source, index: index)
 
             // NSImage として格納し、表示サイズを設定する
-            let rep = NSBitmapImageRep(cgImage: cgImage)
-            let image = NSImage(size: NSSize(width: displaySize, height: displaySize))
-            image.addRepresentation(rep)
             // NSImage.size を emoteDisplaySize に設定してテキスト行高に揃える
-            image.size = NSSize(width: displaySize, height: displaySize)
+            let image = NSImage(size: NSSize(width: displaySize, height: displaySize))
+            image.addRepresentation(NSBitmapImageRep(cgImage: cgImage))
 
             extractedFrames.append(image)
             extractedDurations.append(duration)

--- a/Sources/TwitchChat/Services/GIFFrameSequence.swift
+++ b/Sources/TwitchChat/Services/GIFFrameSequence.swift
@@ -10,8 +10,11 @@ import ImageIO
 /// `CGImageSource` を使って GIF バイナリから全フレームを分解し、
 /// `EmoteAnimationDriver` がタイマー駆動でフレームを切り替えるために使用する。
 ///
+/// `NSImage` は `Sendable` 非準拠のため `@MainActor` に隔離する。
+/// これによりコンパイル時に MainActor 外からの誤用を防ぐ。
+///
 /// - Note: 静止画（フレーム数 1 以下）の場合は `init` が nil を返す
-/// - Note: `NSImage` は `Sendable` 非準拠のため、このクラスは `@MainActor` 内でのみ使用する
+@MainActor
 struct GIFFrameSequence {
 
     /// 各フレームの NSImage（`EmoteImageCache.emoteDisplaySize` にリサイズ済み）

--- a/Sources/TwitchChat/Services/GIFFrameSequence.swift
+++ b/Sources/TwitchChat/Services/GIFFrameSequence.swift
@@ -1,0 +1,96 @@
+// GIFFrameSequence.swift
+// GIF データからアニメーションフレーム配列と表示時間を抽出するデータ構造
+// ImageIO フレームワークの CGImageSource API を使用してフレームを分解する
+
+import AppKit
+import ImageIO
+
+/// GIF アニメーションのフレーム配列と表示時間を保持する不変データ構造
+///
+/// `CGImageSource` を使って GIF バイナリから全フレームを分解し、
+/// `EmoteAnimationDriver` がタイマー駆動でフレームを切り替えるために使用する。
+///
+/// - Note: 静止画（フレーム数 1 以下）の場合は `init` が nil を返す
+/// - Note: `Sendable` 準拠により Swift Concurrency 環境で安全に共有できる
+struct GIFFrameSequence: Sendable {
+
+    /// 各フレームの NSImage（`EmoteImageCache.emoteDisplaySize` にリサイズ済み）
+    let frames: [NSImage]
+
+    /// 各フレームの表示時間（秒）。`frames` と要素数が一致する
+    let durations: [TimeInterval]
+
+    /// 全フレームの合計表示時間（秒）
+    let totalDuration: TimeInterval
+
+    /// GIF バイナリデータからフレームを抽出して初期化する
+    ///
+    /// - Parameter data: GIF フォーマットのバイナリデータ
+    /// - Returns: フレーム数が 2 以上の場合はインスタンス、1 以下（静止画）または解析失敗時は nil
+    init?(from data: Data) {
+        // CGImageSource を生成する
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+
+        let frameCount = CGImageSourceGetCount(source)
+        // フレーム数が 1 以下は静止画のため対象外
+        guard frameCount > 1 else { return nil }
+
+        let displaySize = EmoteImageCache.emoteDisplaySize
+        var extractedFrames: [NSImage] = []
+        var extractedDurations: [TimeInterval] = []
+
+        for index in 0..<frameCount {
+            // 各フレームの CGImage を取得する
+            guard let cgImage = CGImageSourceCreateImageAtIndex(source, index, nil) else { continue }
+
+            // GIF フレームのデュレーションを取得する
+            let duration = Self.frameDuration(source: source, index: index)
+
+            // NSImage として格納し、表示サイズを設定する
+            let rep = NSBitmapImageRep(cgImage: cgImage)
+            let image = NSImage(size: NSSize(width: displaySize, height: displaySize))
+            image.addRepresentation(rep)
+            // NSImage.size を emoteDisplaySize に設定してテキスト行高に揃える
+            image.size = NSSize(width: displaySize, height: displaySize)
+
+            extractedFrames.append(image)
+            extractedDurations.append(duration)
+        }
+
+        guard !extractedFrames.isEmpty else { return nil }
+
+        self.frames = extractedFrames
+        self.durations = extractedDurations
+        self.totalDuration = extractedDurations.reduce(0, +)
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// CGImageSource から指定フレームのデュレーション（秒）を取得する
+    ///
+    /// 取得優先順位:
+    /// 1. `kCGImagePropertyGIFUnclampedDelayTime`（GIF 仕様準拠の正確な値）
+    /// 2. `kCGImagePropertyGIFDelayTime`（後方互換用）
+    /// 3. 取得不可の場合は 0.1 秒（GIF デファクトスタンダードのフォールバック）
+    ///
+    /// - Note: 0.01 秒未満（10ms 未満）は 0.01 秒にクランプする。
+    ///   一部の GIF は意図的に 0 を指定しているが、CPU 過負荷を防ぐために下限を設ける。
+    ///
+    /// - Parameters:
+    ///   - source: CGImageSource
+    ///   - index: フレームインデックス
+    /// - Returns: フレームの表示時間（秒）
+    private static func frameDuration(source: CGImageSource, index: Int) -> TimeInterval {
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any],
+              let gifDict = properties[kCGImagePropertyGIFDictionary] as? [CFString: Any] else {
+            return 0.1
+        }
+
+        let unclampedDelay = gifDict[kCGImagePropertyGIFUnclampedDelayTime] as? TimeInterval
+        let clampedDelay = gifDict[kCGImagePropertyGIFDelayTime] as? TimeInterval
+        let rawDelay = unclampedDelay ?? clampedDelay ?? 0.1
+
+        // 10ms 未満は 10ms にクランプして CPU 過負荷を防ぐ
+        return max(rawDelay, 0.01)
+    }
+}

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -166,11 +166,20 @@ struct EmoteRichTextView: NSViewRepresentable {
                 object: nil,
                 queue: .main
             ) { [weak textView] _ in
-                // TextKit 2 はレイアウトフラグメントをキャッシュするため、
-                // needsDisplay = true だけでは attachment.image が再描画に反映されない。
-                // layoutViewport() で再レイアウトを強制してから再描画を要求する。
-                textView?.textLayoutManager?.textViewportLayoutController.layoutViewport()
-                textView?.needsDisplay = true
+                guard let textView,
+                      let textStorage = textView.textStorage,
+                      textStorage.length > 0 else { return }
+                // attachment.image を変更しても TextKit 2 はフラグメントを有効と判断し続ける。
+                // textStorage.edited(.editedAttributes) でストレージレベルから「属性が変わった」と
+                // 通知することで、layout manager が該当範囲を無効化→再レイアウト→attachment.image
+                // を再取得する一連のパイプラインをトリガーする。
+                textStorage.beginEditing()
+                textStorage.edited(
+                    .editedAttributes,
+                    range: NSRange(location: 0, length: textStorage.length),
+                    changeInLength: 0
+                )
+                textStorage.endEditing()
             }
         }
 

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -170,20 +170,23 @@ struct EmoteRichTextView: NSViewRepresentable {
                 object: EmoteAnimationDriver.shared,
                 queue: .main
             ) { [weak textView] _ in
-                guard let textView,
-                      let textStorage = textView.textStorage,
-                      textStorage.length > 0 else { return }
-                // attachment.image を変更しても TextKit 2 はフラグメントを有効と判断し続ける。
-                // textStorage.edited(.editedAttributes) でストレージレベルから「属性が変わった」と
-                // 通知することで、layout manager が該当範囲を無効化→再レイアウト→attachment.image
-                // を再取得する一連のパイプラインをトリガーする。
-                textStorage.beginEditing()
-                textStorage.edited(
-                    .editedAttributes,
-                    range: NSRange(location: 0, length: textStorage.length),
-                    changeInLength: 0
-                )
-                textStorage.endEditing()
+                // queue: .main で呼ばれるため MainActor 上での実行を安全に前提できる
+                MainActor.assumeIsolated {
+                    guard let textView,
+                          let textStorage = textView.textStorage,
+                          textStorage.length > 0 else { return }
+                    // attachment.image を変更しても TextKit 2 はフラグメントを有効と判断し続ける。
+                    // textStorage.edited(.editedAttributes) でストレージレベルから「属性が変わった」と
+                    // 通知することで、layout manager が該当範囲を無効化→再レイアウト→attachment.image
+                    // を再取得する一連のパイプラインをトリガーする。
+                    textStorage.beginEditing()
+                    textStorage.edited(
+                        .editedAttributes,
+                        range: NSRange(location: 0, length: textStorage.length),
+                        changeInLength: 0
+                    )
+                    textStorage.endEditing()
+                }
             }
         }
 

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -152,7 +152,11 @@ struct EmoteRichTextView: NSViewRepresentable {
 
         deinit {
             if let observer = frameUpdateObserver {
-                NotificationCenter.default.removeObserver(observer)
+                // deinit は非 MainActor コンテキストから呼ばれる場合があるため
+                // NotificationCenter の解除処理をメインスレッドで非同期実行する
+                DispatchQueue.main.async {
+                    NotificationCenter.default.removeObserver(observer)
+                }
             }
         }
 
@@ -163,7 +167,7 @@ struct EmoteRichTextView: NSViewRepresentable {
         func subscribeToFrameUpdates(textView: NSTextView) {
             frameUpdateObserver = NotificationCenter.default.addObserver(
                 forName: .emoteFrameDidUpdate,
-                object: nil,
+                object: EmoteAnimationDriver.shared,
                 queue: .main
             ) { [weak textView] _ in
                 guard let textView,

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -81,6 +81,14 @@ struct EmoteRichTextView: NSViewRepresentable {
         Coordinator(draft: $draft, emoteStore: emoteStore, onSubmit: onSubmit)
     }
 
+    /// ビュー破棄前に呼ばれるクリーンアップ（@MainActor 上で実行される）
+    ///
+    /// `Coordinator.deinit` は任意スレッドから呼ばれる可能性があるため、
+    /// 代わりにここで通知購読を解除する。これにより `nonisolated(unsafe)` を使わずに済む。
+    static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        coordinator.unsubscribeFromFrameUpdates()
+    }
+
     // MARK: - NSTextView 設定
 
     private func configureTextView(_ textView: NSTextView, coordinator: Coordinator) {
@@ -140,9 +148,9 @@ struct EmoteRichTextView: NSViewRepresentable {
 
         /// アニメーションフレーム更新通知のオブザーバートークン
         ///
-        /// deinit（nonisolated）からアクセスするため `nonisolated(unsafe)` を使用する。
-        /// このプロパティへのアクセスは常に MainActor 上（subscribe / deinit の DispatchQueue.main 経由）で行う。
-        nonisolated(unsafe) private var frameUpdateObserver: NSObjectProtocol?
+        /// `dismantleNSView`（MainActor）で `unsubscribeFromFrameUpdates()` を呼ぶため
+        /// `nonisolated(unsafe)` は不要。プロパティは常に MainActor 上でアクセスされる。
+        private var frameUpdateObserver: NSObjectProtocol?
 
         init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void) {
             self._draft = draft
@@ -150,20 +158,11 @@ struct EmoteRichTextView: NSViewRepresentable {
             self.onSubmit = onSubmit
         }
 
-        deinit {
-            if let observer = frameUpdateObserver {
-                // deinit は非 MainActor コンテキストから呼ばれる場合があるため
-                // NotificationCenter の解除処理をメインスレッドで非同期実行する
-                DispatchQueue.main.async {
-                    NotificationCenter.default.removeObserver(observer)
-                }
-            }
-        }
-
         /// アニメーションフレーム更新通知を購読し、textView に再描画を要求する
         ///
-        /// `EmoteAnimationDriver` が `image` を新フレームに更新した後に通知が届き、
-        /// `needsDisplay = true` をセットして NSTextView に再描画をスケジュールする。
+        /// `EmoteAnimationDriver` がフレームを更新した後に通知が届き、
+        /// `textStorage.edited(.editedAttributes)` で TextKit 2 に属性変更を通知して
+        /// レイアウトフラグメントを無効化し、attachment.image の再取得をトリガーする。
         func subscribeToFrameUpdates(textView: NSTextView) {
             frameUpdateObserver = NotificationCenter.default.addObserver(
                 forName: .emoteFrameDidUpdate,
@@ -179,14 +178,34 @@ struct EmoteRichTextView: NSViewRepresentable {
                     // textStorage.edited(.editedAttributes) でストレージレベルから「属性が変わった」と
                     // 通知することで、layout manager が該当範囲を無効化→再レイアウト→attachment.image
                     // を再取得する一連のパイプラインをトリガーする。
+                    // パフォーマンス最適化: EmoteTextAttachment を持つ range のみを無効化する
+                    var attachmentRanges: [NSRange] = []
+                    textStorage.enumerateAttribute(
+                        .attachment,
+                        in: NSRange(location: 0, length: textStorage.length),
+                        options: []
+                    ) { value, range, _ in
+                        if value is EmoteTextAttachment {
+                            attachmentRanges.append(range)
+                        }
+                    }
+                    guard !attachmentRanges.isEmpty else { return }
                     textStorage.beginEditing()
-                    textStorage.edited(
-                        .editedAttributes,
-                        range: NSRange(location: 0, length: textStorage.length),
-                        changeInLength: 0
-                    )
+                    for range in attachmentRanges {
+                        textStorage.edited(.editedAttributes, range: range, changeInLength: 0)
+                    }
                     textStorage.endEditing()
                 }
+            }
+        }
+
+        /// アニメーションフレーム更新通知の購読を解除する
+        ///
+        /// `dismantleNSView` から呼ばれる（MainActor 上）。
+        func unsubscribeFromFrameUpdates() {
+            if let observer = frameUpdateObserver {
+                NotificationCenter.default.removeObserver(observer)
+                frameUpdateObserver = nil
             }
         }
 

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -34,6 +34,8 @@ struct EmoteRichTextView: NSViewRepresentable {
         guard let textView = scrollView.documentView as? NSTextView else { return scrollView }
 
         configureTextView(textView, coordinator: context.coordinator)
+        // アニメーションフレーム更新通知を購読して NSTextView を再描画する
+        context.coordinator.subscribeToFrameUpdates(textView: textView)
         return scrollView
     }
 
@@ -136,10 +138,36 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// binding 側からのリセット中フラグ（無限ループ防止）
         var isUpdatingFromBinding = false
 
+        /// アニメーションフレーム更新通知のオブザーバートークン
+        ///
+        /// deinit（nonisolated）からアクセスするため `nonisolated(unsafe)` を使用する。
+        /// このプロパティへのアクセスは常に MainActor 上（subscribe / deinit の DispatchQueue.main 経由）で行う。
+        nonisolated(unsafe) private var frameUpdateObserver: NSObjectProtocol?
+
         init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void) {
             self._draft = draft
             self.emoteStore = emoteStore
             self.onSubmit = onSubmit
+        }
+
+        deinit {
+            if let observer = frameUpdateObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        /// アニメーションフレーム更新通知を購読し、textView に再描画を要求する
+        ///
+        /// `EmoteAnimationDriver` が `image` を新フレームに更新した後に通知が届き、
+        /// `needsDisplay = true` をセットして NSTextView に再描画をスケジュールする。
+        func subscribeToFrameUpdates(textView: NSTextView) {
+            frameUpdateObserver = NotificationCenter.default.addObserver(
+                forName: .emoteFrameDidUpdate,
+                object: nil,
+                queue: .main
+            ) { [weak textView] _ in
+                textView?.needsDisplay = true
+            }
         }
 
         // MARK: - NSTextViewDelegate
@@ -234,7 +262,10 @@ struct EmoteRichTextView: NSViewRepresentable {
                 guard nsString.substring(with: range) == token else { return }
 
                 // NSAttributedString を変更
-                let attachment = EmoteTextAttachment(image: image, emoteName: token)
+                // emoteId を渡してアニメーション駆動に必要な情報を保持させる
+                let attachment = EmoteTextAttachment(image: image, emoteName: token, emoteId: emote.id)
+                // アニメーション版エモートの場合、EmoteAnimationDriver に登録してフレーム更新を開始する
+                EmoteAnimationDriver.shared.register(attachment)
                 let attachmentString = NSAttributedString(attachment: attachment)
 
                 // フォントを引き継ぐ

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -166,6 +166,10 @@ struct EmoteRichTextView: NSViewRepresentable {
                 object: nil,
                 queue: .main
             ) { [weak textView] _ in
+                // TextKit 2 はレイアウトフラグメントをキャッシュするため、
+                // needsDisplay = true だけでは attachment.image が再描画に反映されない。
+                // layoutViewport() で再レイアウトを強制してから再描画を要求する。
+                textView?.textLayoutManager?.textViewportLayoutController.layoutViewport()
                 textView?.needsDisplay = true
             }
         }

--- a/Sources/TwitchChat/Views/EmoteTextAttachment.swift
+++ b/Sources/TwitchChat/Views/EmoteTextAttachment.swift
@@ -10,9 +10,10 @@ import AppKit
 /// `emoteName` を保持することで、送信時に NSAttributedString からプレーンテキストを復元できる。
 ///
 /// TextKit 2（NSTextLayoutManager）環境では `image` プロパティを使った静止画インライン描画を使用する。
+/// アニメーション GIF は `EmoteAnimationDriver` が `image` を各フレームに差し替えて疑似アニメーションを実現する。
 /// `viewProvider(for:location:textContainer:)` のオーバーライドによる `NSTextAttachmentViewProvider` は、
 /// ポップオーバー閉鎖アニメーション中にビューポートが再計算されて NSImageView が誤配置される問題があるため
-/// 現時点では使用しない。
+/// 使用しない。
 ///
 /// - Note: 送信時は `EmoteRichTextView.plainText(from:)` で emoteName に変換する
 final class EmoteTextAttachment: NSTextAttachment {
@@ -20,14 +21,36 @@ final class EmoteTextAttachment: NSTextAttachment {
     /// 復元用エモート名（IRC 送信時にプレーンテキストとして使用する）
     let emoteName: String
 
+    /// アニメーション駆動に使用する Twitch エモートID（スタティック版は nil）
+    ///
+    /// `EmoteAnimationDriver` がフレームシーケンスをキャッシュから引くキーとして使用する。
+    let emoteId: String?
+
+    /// 現在表示中のフレームインデックス
+    ///
+    /// `EmoteAnimationDriver` がフレーム変更不要な場合の更新スキップ判定に使用する。
+    var currentFrameIndex: Int = 0
+
     /// エモートアタッチメントを初期化する
+    ///
+    /// - Note: アニメーション駆動は呼び出し元（`EmoteRichTextView.Coordinator`）が
+    ///   `EmoteAnimationDriver.shared.register(attachment)` を呼んで開始する。
+    ///   `EmoteAnimationDriver` は弱参照でアタッチメントを保持するため、
+    ///   明示的な `unregister` は不要（解放時に自動クリーンアップされる）。
     ///
     /// - Parameters:
     ///   - image: 表示するエモート画像（アニメーション GIF またはスタティック PNG）
     ///   - emoteName: IRC 送信時に復元するエモート名（例: "LUL"）
+    ///   - emoteId: Twitch エモートID（アニメーション駆動に使用）。スタティック版は nil
     ///   - size: 表示サイズ（デフォルトは EmoteImageCache.emoteDisplaySize）
-    init(image: NSImage, emoteName: String, size: CGFloat = EmoteImageCache.emoteDisplaySize) {
+    init(
+        image: NSImage,
+        emoteName: String,
+        emoteId: String? = nil,
+        size: CGFloat = EmoteImageCache.emoteDisplaySize
+    ) {
         self.emoteName = emoteName
+        self.emoteId = emoteId
         super.init(data: nil, ofType: nil)
         self.image = image
         self.bounds = CGRect(x: 0, y: -3, width: size, height: size)

--- a/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
+++ b/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
@@ -38,7 +38,9 @@ struct EmoteAnimationDriverTests {
             ] as CFDictionary)
         }
 
-        CGImageDestinationFinalize(destination)
+        guard CGImageDestinationFinalize(destination) else {
+            preconditionFailure("CGImageDestinationFinalize に失敗した")
+        }
         return mutableData as Data
     }
 
@@ -57,13 +59,6 @@ struct EmoteAnimationDriverTests {
         context.setFillColor(color.cgColor)
         context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
         return context.makeImage()
-    }
-
-    /// テスト用のダミー EmoteTextAttachment を生成する（アニメーション版・ドライバー未登録）
-    @MainActor
-    private static func makeTestAttachment(emoteId: String = "テストエモートID_\(UUID())") -> EmoteTextAttachment {
-        // ドライバーへの自動登録を避けるため、gifData キャッシュは空のまま使用する
-        return EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
     }
 
     // MARK: - タイマー開始/停止
@@ -89,6 +84,7 @@ struct EmoteAnimationDriverTests {
 
         // クリーンアップ
         driver.unregister(attachment)
+        EmoteImageCache.shared.clearForTesting()
     }
 
     @Test("全アタッチメントを解除するとタイマーが停止する")
@@ -108,6 +104,9 @@ struct EmoteAnimationDriverTests {
 
         // 検証: タイマーが停止している
         #expect(!driver.isTimerActive)
+
+        // クリーンアップ
+        EmoteImageCache.shared.clearForTesting()
     }
 
     @Test("gifData がないアタッチメントを登録してもタイマーは起動しない")
@@ -118,11 +117,14 @@ struct EmoteAnimationDriverTests {
         let emoteId = "gifDataなしエモート_\(UUID())"
         let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
 
-        // 実行: 登録する
+        // 実行: 登録する（GIF データなしのため内部的には登録されない）
         driver.register(attachment)
 
         // 検証: GIF データがないためフレームシーケンスを構築できず、タイマーは起動しない
         #expect(!driver.isTimerActive)
+
+        // クリーンアップ（登録失敗しているが念のため解除を試みる）
+        driver.unregister(attachment)
     }
 
     // MARK: - フレーム更新
@@ -138,18 +140,18 @@ struct EmoteAnimationDriverTests {
 
         let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
         driver.register(attachment)
-        let initialImage = attachment.image
 
-        // 実行: totalDuration 以上の時間を進めて全フレームを一周させる
-        driver.tickForTesting(elapsed: 0.16)
+        // 実行: フレーム 1 に切り替わる経過時間（0.05s 以上 0.10s 未満）で tick を呼ぶ
+        driver.tickForTesting(elapsed: 0.06)
 
-        // 検証: image が更新されている（フレームが切り替わっている）
-        // 3フレーム * 0.05s = 0.15s で一周するため、0.16s 進めると最初のフレームに戻る
-        // いずれかのフレームに更新されていれば十分
-        #expect(driver.isTimerActive)
+        // 検証: フレームインデックスが 1 に更新されている
+        #expect(attachment.currentFrameIndex == 1)
+        // 検証: image がフレームシーケンスのフレーム画像に更新されている（初期の NSImage() から変わっている）
+        #expect(attachment.image != nil)
 
         // クリーンアップ
         driver.unregister(attachment)
+        EmoteImageCache.shared.clearForTesting()
     }
 
     @Test("フレームインデックスが変わらない場合は image を更新しない")
@@ -176,6 +178,7 @@ struct EmoteAnimationDriverTests {
         #expect(imageAfterFirstTick === imageAfterSecondTick)
 
         driver.unregister(attachment)
+        EmoteImageCache.shared.clearForTesting()
     }
 
     // MARK: - 同一エモートのフレーム共有
@@ -202,5 +205,6 @@ struct EmoteAnimationDriverTests {
 
         driver.unregister(attachment1)
         driver.unregister(attachment2)
+        EmoteImageCache.shared.clearForTesting()
     }
 }

--- a/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
+++ b/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
@@ -23,7 +23,9 @@ struct EmoteAnimationDriverTests {
             "com.compuserve.gif" as CFString,
             frameCount,
             nil
-        ) else { return Data() }
+        ) else {
+            preconditionFailure("CGImageDestinationCreateWithData の作成に失敗した")
+        }
 
         CGImageDestinationSetProperties(destination, [
             kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]

--- a/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
+++ b/Tests/TwitchChatTests/EmoteAnimationDriverTests.swift
@@ -1,0 +1,206 @@
+// EmoteAnimationDriverTests.swift
+// EmoteAnimationDriver の単体テスト
+// タイマーの開始/停止・フレーム更新・同一エモートのフレーム共有を検証する
+
+import AppKit
+import ImageIO
+import Testing
+@testable import TwitchChat
+
+/// EmoteAnimationDriver のテストスイート
+///
+/// - Note: タイマーの実動作（実時間待機）は避け、`tickForTesting()` で tick を手動呼び出しする
+@Suite("EmoteAnimationDriver テスト")
+struct EmoteAnimationDriverTests {
+
+    // MARK: - テスト用ヘルパー
+
+    /// テスト用の 3フレームアニメーション GIF データを生成する
+    private static func makeTestGIFData(frameCount: Int = 3, delaySeconds: Double = 0.1) -> Data {
+        let mutableData = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData,
+            "com.compuserve.gif" as CFString,
+            frameCount,
+            nil
+        ) else { return Data() }
+
+        CGImageDestinationSetProperties(destination, [
+            kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]
+        ] as CFDictionary)
+
+        for index in 0..<frameCount {
+            guard let cgImage = makeSolidColorCGImage(
+                hue: CGFloat(index) / CGFloat(max(frameCount, 1))
+            ) else { continue }
+            CGImageDestinationAddImage(destination, cgImage, [
+                kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delaySeconds]
+            ] as CFDictionary)
+        }
+
+        CGImageDestinationFinalize(destination)
+        return mutableData as Data
+    }
+
+    private static func makeSolidColorCGImage(hue: CGFloat) -> CGImage? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        let color = NSColor(hue: hue, saturation: 0.8, brightness: 0.9, alpha: 1.0)
+        context.setFillColor(color.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+        return context.makeImage()
+    }
+
+    /// テスト用のダミー EmoteTextAttachment を生成する（アニメーション版・ドライバー未登録）
+    @MainActor
+    private static func makeTestAttachment(emoteId: String = "テストエモートID_\(UUID())") -> EmoteTextAttachment {
+        // ドライバーへの自動登録を避けるため、gifData キャッシュは空のまま使用する
+        return EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+    }
+
+    // MARK: - タイマー開始/停止
+
+    @Test("アタッチメントを登録するとタイマーが動作中になる")
+    @MainActor
+    func アタッチメント登録後にタイマーが動作中になる() {
+        // 前提: テスト用ドライバーインスタンスを生成する
+        let driver = EmoteAnimationDriver()
+
+        // 前提: gifData を用意してキャッシュに登録する
+        let emoteId = "タイマー開始テスト_\(UUID())"
+        let gifData = Self.makeTestGIFData()
+        EmoteImageCache.shared.storeForTesting(gifData: gifData, for: emoteId)
+
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+
+        // 実行: アタッチメントを登録する
+        driver.register(attachment)
+
+        // 検証: タイマーが動作中である
+        #expect(driver.isTimerActive)
+
+        // クリーンアップ
+        driver.unregister(attachment)
+    }
+
+    @Test("全アタッチメントを解除するとタイマーが停止する")
+    @MainActor
+    func 全アタッチメント解除後にタイマーが停止する() {
+        // 前提: アタッチメントを登録してタイマーを開始する
+        let driver = EmoteAnimationDriver()
+        let emoteId = "タイマー停止テスト_\(UUID())"
+        let gifData = Self.makeTestGIFData()
+        EmoteImageCache.shared.storeForTesting(gifData: gifData, for: emoteId)
+
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+        driver.register(attachment)
+
+        // 実行: 全アタッチメントを解除する
+        driver.unregister(attachment)
+
+        // 検証: タイマーが停止している
+        #expect(!driver.isTimerActive)
+    }
+
+    @Test("gifData がないアタッチメントを登録してもタイマーは起動しない")
+    @MainActor
+    func gifDataなしのアタッチメントはタイマーを起動しない() {
+        // 前提: gifData キャッシュにデータがない emoteId のアタッチメント
+        let driver = EmoteAnimationDriver()
+        let emoteId = "gifDataなしエモート_\(UUID())"
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+
+        // 実行: 登録する
+        driver.register(attachment)
+
+        // 検証: GIF データがないためフレームシーケンスを構築できず、タイマーは起動しない
+        #expect(!driver.isTimerActive)
+    }
+
+    // MARK: - フレーム更新
+
+    @Test("tick を呼ぶとアタッチメントの image が次のフレームに更新される")
+    @MainActor
+    func tick後にフレームが更新される() {
+        // 前提: 3フレームの GIF を持つアタッチメントを登録する
+        let driver = EmoteAnimationDriver()
+        let emoteId = "フレーム更新テスト_\(UUID())"
+        let gifData = Self.makeTestGIFData(frameCount: 3, delaySeconds: 0.05)
+        EmoteImageCache.shared.storeForTesting(gifData: gifData, for: emoteId)
+
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+        driver.register(attachment)
+        let initialImage = attachment.image
+
+        // 実行: totalDuration 以上の時間を進めて全フレームを一周させる
+        driver.tickForTesting(elapsed: 0.16)
+
+        // 検証: image が更新されている（フレームが切り替わっている）
+        // 3フレーム * 0.05s = 0.15s で一周するため、0.16s 進めると最初のフレームに戻る
+        // いずれかのフレームに更新されていれば十分
+        #expect(driver.isTimerActive)
+
+        // クリーンアップ
+        driver.unregister(attachment)
+    }
+
+    @Test("フレームインデックスが変わらない場合は image を更新しない")
+    @MainActor
+    func フレーム未変更時はimageを更新しない() {
+        // 前提: 3フレームの GIF を持つアタッチメントを登録する
+        let driver = EmoteAnimationDriver()
+        let emoteId = "スキップテスト_\(UUID())"
+        let gifData = Self.makeTestGIFData(frameCount: 3, delaySeconds: 0.5)
+        EmoteImageCache.shared.storeForTesting(gifData: gifData, for: emoteId)
+
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+        driver.register(attachment)
+
+        // 実行: 最初の tick（elapsed=0）でフレーム 0 に設定する
+        driver.tickForTesting(elapsed: 0)
+        let imageAfterFirstTick = attachment.image
+
+        // 実行: 経過時間をほとんど進めない（フレームが変わらない）
+        driver.tickForTesting(elapsed: 0.01)
+        let imageAfterSecondTick = attachment.image
+
+        // 検証: フレームインデックスが変わらないため同じ image が保持されている
+        #expect(imageAfterFirstTick === imageAfterSecondTick)
+
+        driver.unregister(attachment)
+    }
+
+    // MARK: - 同一エモートのフレーム共有
+
+    @Test("同一 emoteId の複数アタッチメントは同じフレームに同期される")
+    @MainActor
+    func 同一エモートの複数アタッチメントは同期される() {
+        // 前提: 同じ emoteId で 2つのアタッチメントを作成して登録する
+        let driver = EmoteAnimationDriver()
+        let emoteId = "同期テスト_\(UUID())"
+        let gifData = Self.makeTestGIFData(frameCount: 3, delaySeconds: 0.1)
+        EmoteImageCache.shared.storeForTesting(gifData: gifData, for: emoteId)
+
+        let attachment1 = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+        let attachment2 = EmoteTextAttachment(image: NSImage(), emoteName: "テストエモート", emoteId: emoteId)
+        driver.register(attachment1)
+        driver.register(attachment2)
+
+        // 実行: tick を呼び出してフレームを更新する
+        driver.tickForTesting(elapsed: 0.15)
+
+        // 検証: 同じフレームの NSImage インスタンスが設定されている
+        #expect(attachment1.image === attachment2.image)
+
+        driver.unregister(attachment1)
+        driver.unregister(attachment2)
+    }
+}

--- a/Tests/TwitchChatTests/EmoteImageCacheTests.swift
+++ b/Tests/TwitchChatTests/EmoteImageCacheTests.swift
@@ -72,4 +72,28 @@ struct EmoteImageCacheTests {
         let result = EmoteImageCache.shared.cachedImage(for: "未登録エモートID_テスト用_\(UUID())")
         #expect(result == nil)
     }
+
+    // MARK: - GIF 生データキャッシュ
+
+    @Test("キャッシュ未登録のエモートは gifData(for:) で nil を返す")
+    func gifDataReturnsNilForUncachedEmote() {
+        // 前提: キャッシュに登録されていないエモートID
+        // 検証: nil が返る（ダウンロードは発生しない）
+        let result = EmoteImageCache.shared.gifData(for: "未登録GIFエモートID_テスト用_\(UUID())")
+        #expect(result == nil)
+    }
+
+    @Test("storeForTesting で登録した GIF データが gifData(for:) で取得できる")
+    func gifDataReturnsCachedData() {
+        // 前提: テスト用エモートID と GIF データを直接キャッシュに登録する
+        let emoteId = "テスト用GIFエモートID_\(UUID())"
+        let testGIFData = Data([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]) // "GIF89a" バイト列
+        EmoteImageCache.shared.storeForTesting(gifData: testGIFData, for: emoteId)
+
+        // 実行: gifData(for:) で取得する
+        let result = EmoteImageCache.shared.gifData(for: emoteId)
+
+        // 検証: 登録したデータが取得できる
+        #expect(result == testGIFData)
+    }
 }

--- a/Tests/TwitchChatTests/EmoteTextAttachmentTests.swift
+++ b/Tests/TwitchChatTests/EmoteTextAttachmentTests.swift
@@ -1,5 +1,6 @@
 // EmoteTextAttachmentTests.swift
-// EmoteTextAttachment および AnimatedEmoteAttachmentViewProvider のテスト
+// EmoteTextAttachment のテスト
+// emoteName・emoteId・bounds の保持と currentFrameIndex の初期値を検証する
 
 import AppKit
 import Testing
@@ -51,5 +52,48 @@ struct EmoteTextAttachmentTests {
         // 検証: 指定したサイズで bounds が設定されている
         #expect(attachment.bounds.width == 32)
         #expect(attachment.bounds.height == 32)
+    }
+
+    // MARK: - emoteId 保持
+
+    @Test("emoteId を渡さない場合は nil が保持される")
+    func emoteIdなしの場合はnilが保持される() {
+        // 前提: emoteId を省略してアタッチメントを作成する
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "Kappa")
+
+        // 検証: emoteId が nil である
+        #expect(attachment.emoteId == nil)
+    }
+
+    @Test("emoteId を渡した場合は正しく保持される")
+    func emoteIdが正しく保持される() {
+        // 前提: emoteId "25"（Kappa）を指定してアタッチメントを作成する
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "Kappa", emoteId: "25")
+
+        // 検証: emoteId が "25" である
+        #expect(attachment.emoteId == "25")
+    }
+
+    // MARK: - currentFrameIndex
+
+    @Test("currentFrameIndex の初期値は 0 である")
+    func currentFrameIndexの初期値は0である() {
+        // 前提: アタッチメントを作成する
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "Kappa", emoteId: "25")
+
+        // 検証: 初期フレームインデックスが 0 である
+        #expect(attachment.currentFrameIndex == 0)
+    }
+
+    @Test("currentFrameIndex は書き換え可能である")
+    func currentFrameIndexは書き換え可能である() {
+        // 前提: アタッチメントを作成する
+        let attachment = EmoteTextAttachment(image: NSImage(), emoteName: "Kappa", emoteId: "25")
+
+        // 実行: currentFrameIndex を 2 に設定する
+        attachment.currentFrameIndex = 2
+
+        // 検証: 書き換えた値が保持されている
+        #expect(attachment.currentFrameIndex == 2)
     }
 }

--- a/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
+++ b/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
@@ -8,7 +8,10 @@ import Testing
 @testable import TwitchChat
 
 /// GIFFrameSequence のテストスイート
+///
+/// `GIFFrameSequence` は `@MainActor` 隔離のため、テストスイートも `@MainActor` で実行する。
 @Suite("GIFFrameSequence テスト")
+@MainActor
 struct GIFFrameSequenceTests {
 
     // MARK: - テスト用 GIF 生成ヘルパー

--- a/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
+++ b/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
@@ -1,0 +1,190 @@
+// GIFFrameSequenceTests.swift
+// GIFFrameSequence の単体テスト
+// GIF データからフレーム配列とデュレーションを正しく抽出できることを検証する
+
+import AppKit
+import ImageIO
+import Testing
+@testable import TwitchChat
+
+/// GIFFrameSequence のテストスイート
+@Suite("GIFFrameSequence テスト")
+struct GIFFrameSequenceTests {
+
+    // MARK: - テスト用 GIF 生成ヘルパー
+
+    /// テスト用アニメーション GIF データを生成する
+    ///
+    /// - Parameters:
+    ///   - frameCount: 生成するフレーム数
+    ///   - delaySeconds: 各フレームの表示時間（秒）。デフォルトは 0.1 秒
+    /// - Returns: アニメーション GIF のバイナリデータ
+    private static func makeAnimatedGIFData(frameCount: Int, delaySeconds: Double = 0.1) -> Data {
+        let mutableData = NSMutableData()
+        // "com.compuserve.gif" は GIF UTI の標準識別子
+        guard let destination = CGImageDestinationCreateWithData(
+            mutableData,
+            "com.compuserve.gif" as CFString,
+            frameCount,
+            nil
+        ) else {
+            return Data()
+        }
+
+        // ループ設定（0 = 無限ループ）
+        CGImageDestinationSetProperties(destination, [
+            kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]
+        ] as CFDictionary)
+
+        for index in 0..<frameCount {
+            // フレームごとに色相を変えた 1x1px の単色ビットマップを生成する
+            let hue = CGFloat(index) / CGFloat(max(frameCount, 1))
+            guard let cgImage = makeSolidColorCGImage(hue: hue, size: CGSize(width: 1, height: 1)) else {
+                continue
+            }
+            CGImageDestinationAddImage(destination, cgImage, [
+                kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delaySeconds]
+            ] as CFDictionary)
+        }
+
+        CGImageDestinationFinalize(destination)
+        return mutableData as Data
+    }
+
+    /// 指定した色相の 1x1px ビットマップ CGImage を生成するヘルパー
+    private static func makeSolidColorCGImage(hue: CGFloat, size: CGSize) -> CGImage? {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(
+            data: nil,
+            width: Int(size.width),
+            height: Int(size.height),
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        let color = NSColor(hue: hue, saturation: 0.8, brightness: 0.9, alpha: 1.0)
+        context.setFillColor(color.cgColor)
+        context.fill(CGRect(origin: .zero, size: size))
+        return context.makeImage()
+    }
+
+    // MARK: - フレーム数抽出
+
+    @Test("3フレームの GIF から 3 枚のフレームが抽出される")
+    func 三フレームGIFからフレームを抽出できる() {
+        // 前提: 3フレームのアニメーション GIF データを生成する
+        let data = Self.makeAnimatedGIFData(frameCount: 3)
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: フレーム数が 3 である
+        #expect(sequence != nil)
+        #expect(sequence?.frames.count == 3)
+    }
+
+    // MARK: - デュレーション抽出
+
+    @Test("GIF の各フレームのデュレーション配列が抽出される")
+    func GIFフレームのデュレーション配列が抽出される() {
+        // 前提: フレームデュレーション 0.2 秒の 2フレーム GIF を生成する
+        let data = Self.makeAnimatedGIFData(frameCount: 2, delaySeconds: 0.2)
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: デュレーション配列の要素数が 2 で、各要素が 0.2 秒に近い
+        guard let seq = sequence else {
+            Issue.record("GIFFrameSequence の生成に失敗した")
+            return
+        }
+        #expect(seq.durations.count == 2)
+        #expect(seq.durations[0] >= 0.19 && seq.durations[0] <= 0.21)
+        #expect(seq.durations[1] >= 0.19 && seq.durations[1] <= 0.21)
+    }
+
+    @Test("全フレームのデュレーション合計が totalDuration に格納される")
+    func 全フレームの合計表示時間が正しく計算される() {
+        // 前提: デュレーション 0.1 秒の 4フレーム GIF を生成する（合計 0.4 秒）
+        let data = Self.makeAnimatedGIFData(frameCount: 4, delaySeconds: 0.1)
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: totalDuration が各フレームのデュレーション合計と一致する
+        guard let seq = sequence else {
+            Issue.record("GIFFrameSequence の生成に失敗した")
+            return
+        }
+        let expectedTotal = seq.durations.reduce(0, +)
+        #expect(abs(seq.totalDuration - expectedTotal) < 0.001)
+    }
+
+    // MARK: - 静止画（1フレーム）
+
+    @Test("1フレームの GIF は静止画のため nil を返す")
+    func 一フレームGIFはnilを返す() {
+        // 前提: フレーム数 1 の GIF データを生成する（静止画相当）
+        let data = Self.makeAnimatedGIFData(frameCount: 1)
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: アニメーションフレームがないため nil が返る
+        #expect(sequence == nil)
+    }
+
+    // MARK: - 不正データ
+
+    @Test("空のデータは nil を返す")
+    func 空のデータはnilを返す() {
+        // 前提: 空の Data
+        let data = Data()
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: nil が返る
+        #expect(sequence == nil)
+    }
+
+    @Test("PNG データ（GIF でない）は nil を返す")
+    func PNGデータはnilを返す() {
+        // 前提: 1x1px の PNG データを生成する
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        NSColor.red.drawSwatch(in: NSRect(x: 0, y: 0, width: 1, height: 1))
+        image.unlockFocus()
+        let rep = image.representations.first as? NSBitmapImageRep
+        let data = rep?.representation(using: .png, properties: [:]) ?? Data()
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: PNG は単一フレームのため nil が返る
+        #expect(sequence == nil)
+    }
+
+    // MARK: - フレーム画像サイズ
+
+    @Test("抽出されたフレーム画像の NSImage.size が emoteDisplaySize に設定される")
+    func フレーム画像のサイズがemoteDisplaySizeに設定される() {
+        // 前提: 3フレームの GIF データを生成する
+        let data = Self.makeAnimatedGIFData(frameCount: 3)
+
+        // 実行: GIFFrameSequence を生成する
+        let sequence = GIFFrameSequence(from: data)
+
+        // 検証: 各フレームの NSImage.size が emoteDisplaySize × emoteDisplaySize
+        guard let seq = sequence else {
+            Issue.record("GIFFrameSequence の生成に失敗した")
+            return
+        }
+        let expectedSize = EmoteImageCache.emoteDisplaySize
+        for (index, frame) in seq.frames.enumerated() {
+            #expect(frame.size.width == expectedSize, "フレーム \(index) の幅が一致しない")
+            #expect(frame.size.height == expectedSize, "フレーム \(index) の高さが一致しない")
+        }
+    }
+}

--- a/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
+++ b/Tests/TwitchChatTests/GIFFrameSequenceTests.swift
@@ -28,7 +28,7 @@ struct GIFFrameSequenceTests {
             frameCount,
             nil
         ) else {
-            return Data()
+            preconditionFailure("CGImageDestinationCreateWithData の作成に失敗した")
         }
 
         // ループ設定（0 = 無限ループ）
@@ -39,20 +39,20 @@ struct GIFFrameSequenceTests {
         for index in 0..<frameCount {
             // フレームごとに色相を変えた 1x1px の単色ビットマップを生成する
             let hue = CGFloat(index) / CGFloat(max(frameCount, 1))
-            guard let cgImage = makeSolidColorCGImage(hue: hue, size: CGSize(width: 1, height: 1)) else {
-                continue
-            }
+            let cgImage = makeSolidColorCGImage(hue: hue, size: CGSize(width: 1, height: 1))
             CGImageDestinationAddImage(destination, cgImage, [
                 kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delaySeconds]
             ] as CFDictionary)
         }
 
-        CGImageDestinationFinalize(destination)
+        guard CGImageDestinationFinalize(destination) else {
+            preconditionFailure("CGImageDestinationFinalize に失敗した")
+        }
         return mutableData as Data
     }
 
     /// 指定した色相の 1x1px ビットマップ CGImage を生成するヘルパー
-    private static func makeSolidColorCGImage(hue: CGFloat, size: CGSize) -> CGImage? {
+    private static func makeSolidColorCGImage(hue: CGFloat, size: CGSize) -> CGImage {
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         guard let context = CGContext(
             data: nil,
@@ -62,11 +62,16 @@ struct GIFFrameSequenceTests {
             bytesPerRow: 0,
             space: colorSpace,
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return nil }
+        ) else {
+            preconditionFailure("CGContext の作成に失敗した")
+        }
         let color = NSColor(hue: hue, saturation: 0.8, brightness: 0.9, alpha: 1.0)
         context.setFillColor(color.cgColor)
         context.fill(CGRect(origin: .zero, size: size))
-        return context.makeImage()
+        guard let image = context.makeImage() else {
+            preconditionFailure("CGContext.makeImage に失敗した")
+        }
+        return image
     }
 
     // MARK: - フレーム数抽出
@@ -87,36 +92,28 @@ struct GIFFrameSequenceTests {
     // MARK: - デュレーション抽出
 
     @Test("GIF の各フレームのデュレーション配列が抽出される")
-    func GIFフレームのデュレーション配列が抽出される() {
+    func GIFフレームのデュレーション配列が抽出される() throws {
         // 前提: フレームデュレーション 0.2 秒の 2フレーム GIF を生成する
         let data = Self.makeAnimatedGIFData(frameCount: 2, delaySeconds: 0.2)
 
         // 実行: GIFFrameSequence を生成する
-        let sequence = GIFFrameSequence(from: data)
+        let seq = try #require(GIFFrameSequence(from: data), "GIFFrameSequence の生成に失敗した")
 
         // 検証: デュレーション配列の要素数が 2 で、各要素が 0.2 秒に近い
-        guard let seq = sequence else {
-            Issue.record("GIFFrameSequence の生成に失敗した")
-            return
-        }
         #expect(seq.durations.count == 2)
         #expect(seq.durations[0] >= 0.19 && seq.durations[0] <= 0.21)
         #expect(seq.durations[1] >= 0.19 && seq.durations[1] <= 0.21)
     }
 
     @Test("全フレームのデュレーション合計が totalDuration に格納される")
-    func 全フレームの合計表示時間が正しく計算される() {
+    func 全フレームの合計表示時間が正しく計算される() throws {
         // 前提: デュレーション 0.1 秒の 4フレーム GIF を生成する（合計 0.4 秒）
         let data = Self.makeAnimatedGIFData(frameCount: 4, delaySeconds: 0.1)
 
         // 実行: GIFFrameSequence を生成する
-        let sequence = GIFFrameSequence(from: data)
+        let seq = try #require(GIFFrameSequence(from: data), "GIFFrameSequence の生成に失敗した")
 
         // 検証: totalDuration が各フレームのデュレーション合計と一致する
-        guard let seq = sequence else {
-            Issue.record("GIFFrameSequence の生成に失敗した")
-            return
-        }
         let expectedTotal = seq.durations.reduce(0, +)
         #expect(abs(seq.totalDuration - expectedTotal) < 0.001)
     }
@@ -151,13 +148,10 @@ struct GIFFrameSequenceTests {
 
     @Test("PNG データ（GIF でない）は nil を返す")
     func PNGデータはnilを返す() {
-        // 前提: 1x1px の PNG データを生成する
-        let image = NSImage(size: NSSize(width: 1, height: 1))
-        image.lockFocus()
-        NSColor.red.drawSwatch(in: NSRect(x: 0, y: 0, width: 1, height: 1))
-        image.unlockFocus()
-        let rep = image.representations.first as? NSBitmapImageRep
-        let data = rep?.representation(using: .png, properties: [:]) ?? Data()
+        // 前提: 1x1px の PNG データを CGContext で生成する（lockFocus は描画コンテキストが必要なため使用しない）
+        let cgImage = Self.makeSolidColorCGImage(hue: 0.0, size: CGSize(width: 1, height: 1))
+        let rep = NSBitmapImageRep(cgImage: cgImage)
+        let data = rep.representation(using: .png, properties: [:]) ?? Data()
 
         // 実行: GIFFrameSequence を生成する
         let sequence = GIFFrameSequence(from: data)
@@ -169,18 +163,14 @@ struct GIFFrameSequenceTests {
     // MARK: - フレーム画像サイズ
 
     @Test("抽出されたフレーム画像の NSImage.size が emoteDisplaySize に設定される")
-    func フレーム画像のサイズがemoteDisplaySizeに設定される() {
+    func フレーム画像のサイズがemoteDisplaySizeに設定される() throws {
         // 前提: 3フレームの GIF データを生成する
         let data = Self.makeAnimatedGIFData(frameCount: 3)
 
         // 実行: GIFFrameSequence を生成する
-        let sequence = GIFFrameSequence(from: data)
+        let seq = try #require(GIFFrameSequence(from: data), "GIFFrameSequence の生成に失敗した")
 
         // 検証: 各フレームの NSImage.size が emoteDisplaySize × emoteDisplaySize
-        guard let seq = sequence else {
-            Issue.record("GIFFrameSequence の生成に失敗した")
-            return
-        }
         let expectedSize = EmoteImageCache.emoteDisplaySize
         for (index, frame) in seq.frames.enumerated() {
             #expect(frame.size.width == expectedSize, "フレーム \(index) の幅が一致しない")


### PR DESCRIPTION
## Summary

- `GIFFrameSequence`: ImageIO の `CGImageSource` で GIF を全フレーム分解し、フレーム画像と表示時間を保持するデータ構造を追加
- `EmoteAnimationDriver`: 50ms（20fps）間隔の共有 Timer で全アニメーションエモートのフレームを更新するシングルトンを追加
- `EmoteImageCache`: GIF 生データ（`gifDataCache`）を追加し `gifData(for:)` を公開
- `EmoteTextAttachment`: `emoteId` / `currentFrameIndex` プロパティを追加
- `EmoteRichTextView`: `subscribeToFrameUpdates` で `emoteFrameDidUpdate` 通知を購読し、`textStorage.edited(.editedAttributes)` でフレーム変化を TextKit 2 に伝達

## 技術的背景

- `NSTextAttachmentViewProvider` 方式は NSPopover 閉鎖時の TextKit 2 `layoutViewport()` 再計算で NSImageView が消える問題のため不採用
- TextKit 2 はレイアウトフラグメントをキャッシュするため `needsDisplay = true` や `layoutViewport()` のみでは画像更新を認識しない
- `textStorage.edited(.editedAttributes)` によりストレージレベルから「属性が変わった」と通知することでフレームが正しく再取得される

## Test plan

- [ ] `swift test` — `GIFFrameSequence テスト`（7件）、`EmoteAnimationDriver テスト`（6件）、`EmoteImageCache テスト`（9件）、`EmoteTextAttachment テスト`（8件）がすべてパスすること
- [ ] `swift build` — ビルドエラーがないこと
- [ ] 手動テスト: アプリ起動 → 入力欄にアニメーションエモートを入力してスペースで確定 → GIF アニメーションが連続再生されること
- [ ] 手動テスト: エモートピッカーからエモートを選択 → ピッカー閉鎖後もエモートが消えず、アニメーションが継続すること
- [ ] 手動テスト: 複数のアニメーションエモートを配置しても CPU 使用率が許容範囲内であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)