### PR TITLE
feat: @メンション補完機能を実装する (#24)

### DIFF
--- a/Sources/TwitchChat/Services/MentionStore.swift
+++ b/Sources/TwitchChat/Services/MentionStore.swift
@@ -9,6 +9,7 @@ import Observation
 /// - `recordUser(username:displayName:)` でメッセージ受信のたびにユーザーを記録する
 /// - 同一ユーザーは重複排除し、最新発言者が先頭に来る順序で管理する
 /// - `candidates(matching:)` で前方一致フィルタリングした候補一覧を取得する
+/// - メモリ使用量を抑えるため最大 `maxMentionsCount` 件のみ保持する
 @Observable
 @MainActor
 final class MentionStore {
@@ -16,17 +17,29 @@ final class MentionStore {
     // MARK: - 型定義
 
     /// ユーザー候補の一件分
-    struct UserCandidate {
+    struct UserCandidate: Identifiable {
+        /// SwiftUI リスト用の安定識別子（username を使用）
+        var id: String { username }
         /// IRC ログイン名（小文字）
         let username: String
         /// 表示名（大文字・日本語を含む場合あり）
         let displayName: String
     }
 
+    // MARK: - 定数
+
+    /// ユーザー名リストの最大保持件数
+    ///
+    /// メモリ肥大化を防ぐため、超過分は最も古い発言者から削除する。
+    static let maxMentionsCount = 200
+
     // MARK: - プライベートプロパティ
 
     /// 最新発言順のユーザー名リスト（先頭が最新）
     private var orderedUsernames: [String] = []
+
+    /// O(1) 重複チェック用の Set
+    private var usernameSet: Set<String> = []
 
     /// username → displayName のマッピング
     private var displayNames: [String: String] = [:]
@@ -36,23 +49,37 @@ final class MentionStore {
     /// ユーザーを記録する
     ///
     /// 同一 username が既に存在する場合は先頭に移動する。
+    /// `maxMentionsCount` を超えた場合は末尾（最も古い発言者）を削除する。
     ///
     /// - Parameters:
     ///   - username: IRC ログイン名（小文字）
     ///   - displayName: 表示名
     func recordUser(username: String, displayName: String) {
-        // 既存のエントリを削除して先頭に追加（最新発言順を維持）
-        orderedUsernames.removeAll { $0 == username }
+        // 既存エントリの削除（O(1) で存在確認してから O(n) で除去）
+        if usernameSet.contains(username) {
+            orderedUsernames.removeAll { $0 == username }
+        } else {
+            usernameSet.insert(username)
+        }
+
+        // 先頭に追加（最新発言順を維持）
         orderedUsernames.insert(username, at: 0)
         displayNames[username] = displayName
+
+        // 上限超過分を末尾から削除
+        while orderedUsernames.count > Self.maxMentionsCount {
+            let old = orderedUsernames.removeLast()
+            usernameSet.remove(old)
+            displayNames.removeValue(forKey: old)
+        }
     }
 
     /// クエリに前方一致するユーザー候補を返す
     ///
-    /// username または displayName の先頭がクエリに一致するユーザーを最新発言順で返す。
+    /// username または displayName の先頭がクエリと一致するユーザーを最新発言順で返す。
     /// クエリが空の場合は全件を返す。大文字小文字は区別しない。
     ///
-    /// - Parameter query: フィルタリング文字列
+    /// - Parameter query: フィルタリング文字列（前方一致）
     /// - Returns: マッチしたユーザー候補の配列（最新発言順）
     func candidates(matching query: String) -> [UserCandidate] {
         orderedUsernames
@@ -62,8 +89,14 @@ final class MentionStore {
             }
             .filter { candidate in
                 guard !query.isEmpty else { return true }
-                return candidate.username.localizedCaseInsensitiveContains(query)
-                    || candidate.displayName.localizedCaseInsensitiveContains(query)
+                // 前方一致（大文字小文字非区別）
+                let usernameMatch = candidate.username.range(
+                    of: query, options: [.caseInsensitive, .anchored]
+                ) != nil
+                let displayNameMatch = candidate.displayName.range(
+                    of: query, options: [.caseInsensitive, .anchored]
+                ) != nil
+                return usernameMatch || displayNameMatch
             }
     }
 }

--- a/Sources/TwitchChat/Services/MentionStore.swift
+++ b/Sources/TwitchChat/Services/MentionStore.swift
@@ -1,0 +1,69 @@
+// MentionStore.swift
+// @メンション補完用のユーザー名リストを管理するサービス
+// 受信メッセージからユーザーを記録し、クエリによるフィルタリングを提供する
+
+import Observation
+
+/// @メンション補完用ユーザー名リスト管理サービス
+///
+/// - `recordUser(username:displayName:)` でメッセージ受信のたびにユーザーを記録する
+/// - 同一ユーザーは重複排除し、最新発言者が先頭に来る順序で管理する
+/// - `candidates(matching:)` で前方一致フィルタリングした候補一覧を取得する
+@Observable
+@MainActor
+final class MentionStore {
+
+    // MARK: - 型定義
+
+    /// ユーザー候補の一件分
+    struct UserCandidate {
+        /// IRC ログイン名（小文字）
+        let username: String
+        /// 表示名（大文字・日本語を含む場合あり）
+        let displayName: String
+    }
+
+    // MARK: - プライベートプロパティ
+
+    /// 最新発言順のユーザー名リスト（先頭が最新）
+    private var orderedUsernames: [String] = []
+
+    /// username → displayName のマッピング
+    private var displayNames: [String: String] = [:]
+
+    // MARK: - パブリックメソッド
+
+    /// ユーザーを記録する
+    ///
+    /// 同一 username が既に存在する場合は先頭に移動する。
+    ///
+    /// - Parameters:
+    ///   - username: IRC ログイン名（小文字）
+    ///   - displayName: 表示名
+    func recordUser(username: String, displayName: String) {
+        // 既存のエントリを削除して先頭に追加（最新発言順を維持）
+        orderedUsernames.removeAll { $0 == username }
+        orderedUsernames.insert(username, at: 0)
+        displayNames[username] = displayName
+    }
+
+    /// クエリに前方一致するユーザー候補を返す
+    ///
+    /// username または displayName の先頭がクエリに一致するユーザーを最新発言順で返す。
+    /// クエリが空の場合は全件を返す。大文字小文字は区別しない。
+    ///
+    /// - Parameter query: フィルタリング文字列
+    /// - Returns: マッチしたユーザー候補の配列（最新発言順）
+    func candidates(matching query: String) -> [UserCandidate] {
+        orderedUsernames
+            .compactMap { username -> UserCandidate? in
+                guard let displayName = displayNames[username] else { return nil }
+                return UserCandidate(username: username, displayName: displayName)
+            }
+            .filter { candidate in
+                guard !query.isEmpty else { return true }
+                return candidate.username.localizedCaseInsensitiveContains(query)
+                    || candidate.displayName.localizedCaseInsensitiveContains(query)
+            }
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -80,6 +80,9 @@ final class ChatViewModel {
     /// エモート定義ストア（エモートピッカーのデータソースに使用）
     let emoteStore: EmoteStore
 
+    /// @メンション補完用ユーザー名リスト（入力バーの補完候補として使用）
+    let mentionStore: MentionStore = MentionStore()
+
     /// グローバルバッジフェッチタスク（切断時にキャンセル）
     private var globalBadgeFetchTask: Task<Void, Never>?
 
@@ -275,6 +278,8 @@ final class ChatViewModel {
         if currentRoomId == nil {
             currentRoomId = message.roomId
         }
+        // @メンション補完の候補リストを更新する
+        mentionStore.recordUser(username: message.username, displayName: message.displayName)
         messages.append(message)
         if messages.count > Self.maxMessages {
             messages.removeFirst(messages.count - Self.maxMessages)

--- a/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
@@ -26,7 +26,7 @@ final class MentionCompletionViewModel {
     /// 選択中の候補インデックス
     private(set) var selectedIndex: Int = 0
 
-    /// テキスト内の @ から現在カーソルまでの NSRange（置換に使用）
+    /// テキスト内の @ から現在カーソルまでの NSRange（UTF-16 基準、置換に使用）
     private(set) var mentionRange: NSRange?
 
     // MARK: - プライベートプロパティ
@@ -47,8 +47,8 @@ final class MentionCompletionViewModel {
     /// `@` の直前が空白または文頭の場合のみトリガーとして認識する。
     ///
     /// - Parameters:
-    ///   - text: 入力テキスト全体
-    ///   - cursorPosition: カーソル位置（文字数）
+    ///   - text: 入力テキスト全体（plainText ベースの文字列）
+    ///   - cursorPosition: カーソル位置（plainText 上の文字数）
     func updateFromText(_ text: String, cursorPosition: Int) {
         let nsText = text as NSString
         let searchRange = NSRange(location: 0, length: min(cursorPosition, nsText.length))
@@ -59,10 +59,9 @@ final class MentionCompletionViewModel {
             return
         }
 
-        let query = tokenInfo.query
-        mentionRange = NSRange(location: tokenInfo.atLocation, length: tokenInfo.atLocation + tokenInfo.tokenLength - tokenInfo.atLocation)
+        mentionRange = NSRange(location: tokenInfo.atNSLocation, length: tokenInfo.tokenNSLength)
 
-        let newCandidates = mentionStore.candidates(matching: query)
+        let newCandidates = mentionStore.candidates(matching: tokenInfo.query)
         candidates = newCandidates
         selectedIndex = 0
         isActive = true
@@ -76,6 +75,16 @@ final class MentionCompletionViewModel {
     func moveSelection(by offset: Int) {
         guard !candidates.isEmpty else { return }
         selectedIndex = max(0, min(candidates.count - 1, selectedIndex + offset))
+    }
+
+    /// 選択インデックスを直接指定する
+    ///
+    /// 範囲外の値はクランプする。
+    ///
+    /// - Parameter index: 設定するインデックス
+    func setSelection(to index: Int) {
+        guard !candidates.isEmpty else { return }
+        selectedIndex = max(0, min(candidates.count - 1, index))
     }
 
     /// 選択中の候補を確定し、挿入文字列を返す
@@ -115,11 +124,11 @@ final class MentionCompletionViewModel {
             return nil
         }
 
-        let atIndex = textUpToCursor.distance(from: textUpToCursor.startIndex, to: atRange.lowerBound)
-        let atNSLocation = atIndex
+        // 文字数ベースのインデックス（isWhitespace チェック用）
+        let atCharIndex = textUpToCursor.distance(from: textUpToCursor.startIndex, to: atRange.lowerBound)
 
         // @ の直前が空白または文頭であることを確認（メールアドレス等の誤検出防止）
-        if atIndex > 0 {
+        if atCharIndex > 0 {
             let beforeAt = textUpToCursor[textUpToCursor.index(before: atRange.lowerBound)]
             guard beforeAt.isWhitespace else {
                 return nil
@@ -129,17 +138,23 @@ final class MentionCompletionViewModel {
         // @ 以降のクエリ文字列を取得
         let afterAt = String(textUpToCursor[atRange.upperBound...])
 
-        // クエリにスペースが含まれる場合はトークン終了（補完対象外）
-        guard !afterAt.contains(" ") else {
+        // クエリにホワイトスペースが含まれる場合はトークン終了（補完対象外）
+        guard !afterAt.contains(where: { $0.isWhitespace }) else {
             return nil
         }
 
-        let tokenLength = 1 + afterAt.count // @ + クエリ文字列
+        // UTF-16 オフセットを計算（NSRange / NSTextView との整合性のため）
+        let atNSLocation = textUpToCursor.utf16.distance(
+            from: textUpToCursor.utf16.startIndex,
+            to: atRange.lowerBound.samePosition(in: textUpToCursor.utf16)!
+        )
+        // "@" は BMP 文字で常に 1 UTF-16 code unit
+        let tokenNSLength = 1 + afterAt.utf16.count
 
         return MentionTokenInfo(
-            atLocation: atNSLocation,
+            atNSLocation: atNSLocation,
             query: afterAt,
-            tokenLength: tokenLength
+            tokenNSLength: tokenNSLength
         )
     }
 }
@@ -148,10 +163,10 @@ final class MentionCompletionViewModel {
 
 /// メンショントークンの検出結果
 private struct MentionTokenInfo {
-    /// テキスト内の @ の位置（文字インデックス）
-    let atLocation: Int
+    /// テキスト内の @ の UTF-16 オフセット（NSRange 用）
+    let atNSLocation: Int
     /// @ 以降のクエリ文字列
     let query: String
-    /// トークン全体の長さ（@ + クエリ）
-    let tokenLength: Int
+    /// トークン全体の UTF-16 長さ（@ + クエリ）
+    let tokenNSLength: Int
 }

--- a/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
@@ -48,11 +48,12 @@ final class MentionCompletionViewModel {
     ///
     /// - Parameters:
     ///   - text: 入力テキスト全体（plainText ベースの文字列）
-    ///   - cursorPosition: カーソル位置（plainText 上の文字数）
+    ///   - cursorPosition: カーソル位置（plainText 上の Character 数）
     func updateFromText(_ text: String, cursorPosition: Int) {
-        let nsText = text as NSString
-        let searchRange = NSRange(location: 0, length: min(cursorPosition, nsText.length))
-        let textUpToCursor = nsText.substring(with: searchRange)
+        // String.Index ベースで切り出すことで Character と UTF-16 の不整合を回避する
+        let clampedPosition = max(0, min(cursorPosition, text.count))
+        let cursorIndex = text.index(text.startIndex, offsetBy: clampedPosition)
+        let textUpToCursor = String(text[..<cursorIndex])
 
         guard let tokenInfo = findMentionToken(in: textUpToCursor) else {
             deactivate()

--- a/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
@@ -1,0 +1,157 @@
+// MentionCompletionViewModel.swift
+// @メンション補完の状態管理 ViewModel
+// @ トリガーの検出、候補フィルタリング、選択操作を担当する
+
+import Foundation
+import Observation
+
+/// @メンション補完の状態管理 ViewModel
+///
+/// 入力テキストを監視し、`@` トリガーを検出して候補リストを管理する。
+/// キーボード操作（上下移動・確定・キャンセル）のロジックも提供する。
+///
+/// - Note: `EmoteRichTextView` の `textDidChange` / `doCommandBy` から呼び出す
+@Observable
+@MainActor
+final class MentionCompletionViewModel {
+
+    // MARK: - パブリックプロパティ
+
+    /// 補完がアクティブ状態かどうか
+    private(set) var isActive: Bool = false
+
+    /// 現在の候補一覧
+    private(set) var candidates: [MentionStore.UserCandidate] = []
+
+    /// 選択中の候補インデックス
+    private(set) var selectedIndex: Int = 0
+
+    /// テキスト内の @ から現在カーソルまでの NSRange（置換に使用）
+    private(set) var mentionRange: NSRange?
+
+    // MARK: - プライベートプロパティ
+
+    private let mentionStore: MentionStore
+
+    // MARK: - 初期化
+
+    init(mentionStore: MentionStore) {
+        self.mentionStore = mentionStore
+    }
+
+    // MARK: - パブリックメソッド
+
+    /// テキストとカーソル位置から @ トークンを検出し候補を更新する
+    ///
+    /// カーソル直前の文字列を走査して `@` を探す。
+    /// `@` の直前が空白または文頭の場合のみトリガーとして認識する。
+    ///
+    /// - Parameters:
+    ///   - text: 入力テキスト全体
+    ///   - cursorPosition: カーソル位置（文字数）
+    func updateFromText(_ text: String, cursorPosition: Int) {
+        let nsText = text as NSString
+        let searchRange = NSRange(location: 0, length: min(cursorPosition, nsText.length))
+        let textUpToCursor = nsText.substring(with: searchRange)
+
+        guard let tokenInfo = findMentionToken(in: textUpToCursor) else {
+            deactivate()
+            return
+        }
+
+        let query = tokenInfo.query
+        mentionRange = NSRange(location: tokenInfo.atLocation, length: tokenInfo.atLocation + tokenInfo.tokenLength - tokenInfo.atLocation)
+
+        let newCandidates = mentionStore.candidates(matching: query)
+        candidates = newCandidates
+        selectedIndex = 0
+        isActive = true
+    }
+
+    /// 選択インデックスを移動する
+    ///
+    /// 候補リストの境界でクランプする（ラップしない）。
+    ///
+    /// - Parameter offset: 移動量（正: 下、負: 上）
+    func moveSelection(by offset: Int) {
+        guard !candidates.isEmpty else { return }
+        selectedIndex = max(0, min(candidates.count - 1, selectedIndex + offset))
+    }
+
+    /// 選択中の候補を確定し、挿入文字列を返す
+    ///
+    /// - Returns: `@username ` 形式の文字列。候補が空の場合は `nil`
+    func confirmSelection() -> String? {
+        guard isActive, !candidates.isEmpty, selectedIndex < candidates.count else {
+            return nil
+        }
+        let candidate = candidates[selectedIndex]
+        deactivate()
+        return "@\(candidate.username) "
+    }
+
+    /// 補完をキャンセルしてアクティブ状態を解除する
+    func cancel() {
+        deactivate()
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// アクティブ状態を解除してリセットする
+    private func deactivate() {
+        isActive = false
+        candidates = []
+        selectedIndex = 0
+        mentionRange = nil
+    }
+
+    /// カーソル前のテキストからメンショントークンを検出する
+    ///
+    /// - Parameter textUpToCursor: カーソルまでのテキスト
+    /// - Returns: トークン情報。メンションが見つからない場合は `nil`
+    private func findMentionToken(in textUpToCursor: String) -> MentionTokenInfo? {
+        // 末尾から @ を逆方向に検索
+        guard let atRange = textUpToCursor.range(of: "@", options: .backwards) else {
+            return nil
+        }
+
+        let atIndex = textUpToCursor.distance(from: textUpToCursor.startIndex, to: atRange.lowerBound)
+        let atNSLocation = atIndex
+
+        // @ の直前が空白または文頭であることを確認（メールアドレス等の誤検出防止）
+        if atIndex > 0 {
+            let beforeAt = textUpToCursor[textUpToCursor.index(before: atRange.lowerBound)]
+            guard beforeAt.isWhitespace else {
+                return nil
+            }
+        }
+
+        // @ 以降のクエリ文字列を取得
+        let afterAt = String(textUpToCursor[atRange.upperBound...])
+
+        // クエリにスペースが含まれる場合はトークン終了（補完対象外）
+        guard !afterAt.contains(" ") else {
+            return nil
+        }
+
+        let tokenLength = 1 + afterAt.count // @ + クエリ文字列
+
+        return MentionTokenInfo(
+            atLocation: atNSLocation,
+            query: afterAt,
+            tokenLength: tokenLength
+        )
+    }
+}
+
+// MARK: - 内部型
+
+/// メンショントークンの検出結果
+private struct MentionTokenInfo {
+    /// テキスト内の @ の位置（文字インデックス）
+    let atLocation: Int
+    /// @ 以降のクエリ文字列
+    let query: String
+    /// トークン全体の長さ（@ + クエリ）
+    let tokenLength: Int
+}

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -241,19 +241,13 @@ struct ChatInputBar: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .offset(y: -min(
                     CGFloat(mentionCompletionVM.candidates.count),
-                    CGFloat(Self.mentionDropdownMaxRows)
-                ) * Self.mentionDropdownRowHeight)
+                    CGFloat(MentionCompletionView.maxVisibleRows)
+                ) * MentionCompletionView.rowHeight)
             }
         }
     }
 
     // MARK: - ヘルパー
-
-    /// @メンション補完ドロップダウンの1行あたりの高さ（MentionCompletionView.rowHeight と連動）
-    private static let mentionDropdownRowHeight: CGFloat = 32
-
-    /// @メンション補完ドロップダウンの最大表示件数（MentionCompletionView.maxVisibleRows と連動）
-    private static let mentionDropdownMaxRows: Int = 6
 
     /// TextKit のデフォルト行高とインライン emote の高さを考慮した1行分の入力フィールド高さを計算する
     ///
@@ -331,30 +325,6 @@ struct ChatInputBar: View {
         }
     }
 
-    /// draft テキストから末尾の @メンショントークンの NSRange を探す
-    ///
-    /// - Parameter text: 対象のテキスト
-    /// - Returns: @トークンの NSRange（UTF-16 基準）。見つからない場合は nil
-    private func findMentionTokenRange(in text: String) -> NSRange? {
-        guard let atRange = text.range(of: "@", options: .backwards) else { return nil }
-        let atIndex = text.distance(from: text.startIndex, to: atRange.lowerBound)
-
-        // @ の直前がホワイトスペースまたは文頭であることを確認
-        if atIndex > 0 {
-            let beforeAt = text[text.index(before: atRange.lowerBound)]
-            guard beforeAt.isWhitespace else { return nil }
-        }
-
-        let afterAt = String(text[atRange.upperBound...])
-        // ホワイトスペースを含む場合はトークン終了（isWhitespace で統一）
-        guard !afterAt.contains(where: { $0.isWhitespace }) else { return nil }
-
-        let atNSLocation = text.utf16.distance(
-            from: text.utf16.startIndex,
-            to: atRange.lowerBound.samePosition(in: text.utf16)!
-        )
-        return NSRange(location: atNSLocation, length: 1 + afterAt.utf16.count)
-    }
 }
 
 // MARK: - CircularIconBackground

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -21,7 +21,18 @@ struct ChatInputBar: View {
     @State private var showEmotePicker = false
 
     /// @メンション補完の状態管理 ViewModel
-    @State private var mentionCompletionVM: MentionCompletionViewModel = MentionCompletionViewModel(mentionStore: MentionStore())
+    ///
+    /// `viewModel.mentionStore` を使って初期化する。
+    /// `@State` プロパティは init 引数で初期値を設定することで不要な再作成を防ぐ。
+    @State private var mentionCompletionVM: MentionCompletionViewModel
+
+    init(viewModel: ChatViewModel, authState: AuthState) {
+        self.viewModel = viewModel
+        self.authState = authState
+        self._mentionCompletionVM = State(
+            initialValue: MentionCompletionViewModel(mentionStore: viewModel.mentionStore)
+        )
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -39,10 +50,6 @@ struct ChatInputBar: View {
             }
         }
         .background(Color(.controlBackgroundColor))
-        .onAppear {
-            // viewModel の mentionStore を使用するよう初期化する
-            mentionCompletionVM = MentionCompletionViewModel(mentionStore: viewModel.mentionStore)
-        }
     }
 
     // MARK: - サブビュー
@@ -232,14 +239,21 @@ struct ChatInputBar: View {
                     confirmMentionCandidate(at: index)
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                .offset(y: -(mentionCompletionVM.candidates.isEmpty
-                    ? 0
-                    : min(CGFloat(mentionCompletionVM.candidates.count), 6) * 32))
+                .offset(y: -min(
+                    CGFloat(mentionCompletionVM.candidates.count),
+                    CGFloat(Self.mentionDropdownMaxRows)
+                ) * Self.mentionDropdownRowHeight)
             }
         }
     }
 
     // MARK: - ヘルパー
+
+    /// @メンション補完ドロップダウンの1行あたりの高さ（MentionCompletionView.rowHeight と連動）
+    private static let mentionDropdownRowHeight: CGFloat = 32
+
+    /// @メンション補完ドロップダウンの最大表示件数（MentionCompletionView.maxVisibleRows と連動）
+    private static let mentionDropdownMaxRows: Int = 6
 
     /// TextKit のデフォルト行高とインライン emote の高さを考慮した1行分の入力フィールド高さを計算する
     ///
@@ -302,12 +316,14 @@ struct ChatInputBar: View {
     ///
     /// - Parameter index: 選択した候補のインデックス
     private func confirmMentionCandidate(at index: Int) {
-        mentionCompletionVM.moveSelection(by: index - mentionCompletionVM.selectedIndex)
+        mentionCompletionVM.setSelection(to: index)
+        // mentionRange は confirmSelection() の前に取得する（確定後に nil になるため）
+        let range = mentionCompletionVM.mentionRange
         guard let insertion = mentionCompletionVM.confirmSelection() else { return }
 
         // draft の @ トークン部分を挿入文字列で置換する
-        // draft はプレーンテキストなので文字列操作で直接置換できる
-        if let range = findMentionTokenRange(in: draft) {
+        // draft はプレーンテキストなので NSString で直接置換できる
+        if let range {
             let nsString = draft as NSString
             draft = nsString.replacingCharacters(in: range, with: insertion)
         } else {
@@ -318,21 +334,26 @@ struct ChatInputBar: View {
     /// draft テキストから末尾の @メンショントークンの NSRange を探す
     ///
     /// - Parameter text: 対象のテキスト
-    /// - Returns: @トークンの NSRange。見つからない場合は nil
+    /// - Returns: @トークンの NSRange（UTF-16 基準）。見つからない場合は nil
     private func findMentionTokenRange(in text: String) -> NSRange? {
         guard let atRange = text.range(of: "@", options: .backwards) else { return nil }
         let atIndex = text.distance(from: text.startIndex, to: atRange.lowerBound)
 
-        // @ の直前が空白または文頭であることを確認
+        // @ の直前がホワイトスペースまたは文頭であることを確認
         if atIndex > 0 {
             let beforeAt = text[text.index(before: atRange.lowerBound)]
             guard beforeAt.isWhitespace else { return nil }
         }
 
         let afterAt = String(text[atRange.upperBound...])
-        guard !afterAt.contains(" ") else { return nil }
+        // ホワイトスペースを含む場合はトークン終了（isWhitespace で統一）
+        guard !afterAt.contains(where: { $0.isWhitespace }) else { return nil }
 
-        return NSRange(location: atIndex, length: 1 + afterAt.count)
+        let atNSLocation = text.utf16.distance(
+            from: text.utf16.startIndex,
+            to: atRange.lowerBound.samePosition(in: text.utf16)!
+        )
+        return NSRange(location: atNSLocation, length: 1 + afterAt.utf16.count)
     }
 }
 

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -20,6 +20,9 @@ struct ChatInputBar: View {
     /// エモートピッカーの表示状態
     @State private var showEmotePicker = false
 
+    /// @メンション補完の状態管理 ViewModel
+    @State private var mentionCompletionVM: MentionCompletionViewModel = MentionCompletionViewModel(mentionStore: MentionStore())
+
     var body: some View {
         VStack(spacing: 0) {
             // 認証エラーバナー（chat:edit スコープ不足またはログアウト）
@@ -36,6 +39,10 @@ struct ChatInputBar: View {
             }
         }
         .background(Color(.controlBackgroundColor))
+        .onAppear {
+            // viewModel の mentionStore を使用するよう初期化する
+            mentionCompletionVM = MentionCompletionViewModel(mentionStore: viewModel.mentionStore)
+        }
     }
 
     // MARK: - サブビュー
@@ -143,7 +150,8 @@ struct ChatInputBar: View {
                 draft: $draft,
                 emoteStore: viewModel.emoteStore,
                 onSubmit: submit,
-                isDisabled: !viewModel.canSendMessage
+                isDisabled: !viewModel.canSendMessage,
+                mentionCompletionViewModel: mentionCompletionVM
             )
             .frame(height: Self.inputFieldHeight)
             .padding(.leading, 14)
@@ -214,6 +222,21 @@ struct ChatInputBar: View {
                     .id(error)
             }
         }
+        // @メンション補完ドロップダウン（入力バーの上に表示）
+        .overlay(alignment: .top) {
+            if mentionCompletionVM.isActive && !mentionCompletionVM.candidates.isEmpty {
+                MentionCompletionView(
+                    candidates: mentionCompletionVM.candidates,
+                    selectedIndex: mentionCompletionVM.selectedIndex
+                ) { index in
+                    confirmMentionCandidate(at: index)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .offset(y: -(mentionCompletionVM.candidates.isEmpty
+                    ? 0
+                    : min(CGFloat(mentionCompletionVM.candidates.count), 6) * 32))
+            }
+        }
     }
 
     // MARK: - ヘルパー
@@ -273,6 +296,43 @@ struct ChatInputBar: View {
         Task {
             try? await viewModel.sendMessage(text)
         }
+    }
+
+    /// クリックで @メンション候補を選択確定する
+    ///
+    /// - Parameter index: 選択した候補のインデックス
+    private func confirmMentionCandidate(at index: Int) {
+        mentionCompletionVM.moveSelection(by: index - mentionCompletionVM.selectedIndex)
+        guard let insertion = mentionCompletionVM.confirmSelection() else { return }
+
+        // draft の @ トークン部分を挿入文字列で置換する
+        // draft はプレーンテキストなので文字列操作で直接置換できる
+        if let range = findMentionTokenRange(in: draft) {
+            let nsString = draft as NSString
+            draft = nsString.replacingCharacters(in: range, with: insertion)
+        } else {
+            draft += insertion
+        }
+    }
+
+    /// draft テキストから末尾の @メンショントークンの NSRange を探す
+    ///
+    /// - Parameter text: 対象のテキスト
+    /// - Returns: @トークンの NSRange。見つからない場合は nil
+    private func findMentionTokenRange(in text: String) -> NSRange? {
+        guard let atRange = text.range(of: "@", options: .backwards) else { return nil }
+        let atIndex = text.distance(from: text.startIndex, to: atRange.lowerBound)
+
+        // @ の直前が空白または文頭であることを確認
+        if atIndex > 0 {
+            let beforeAt = text[text.index(before: atRange.lowerBound)]
+            guard beforeAt.isWhitespace else { return nil }
+        }
+
+        let afterAt = String(text[atRange.upperBound...])
+        guard !afterAt.contains(" ") else { return nil }
+
+        return NSRange(location: atIndex, length: 1 + afterAt.count)
     }
 }
 

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -192,6 +192,71 @@ struct EmoteRichTextView: NSViewRepresentable {
         return plainOffset
     }
 
+    /// plainText 上の NSRange（Character 数基準）を NSTextView の NSRange（UTF-16 オフセット）に変換する
+    ///
+    /// `replaceMentionToken` で `NSTextView.insertText(_:replacementRange:)` に渡す範囲を
+    /// plainText 座標から NSTextView 座標に変換するために使用する。
+    ///
+    /// - Parameters:
+    ///   - plainRange: plainText 上の NSRange（Character 数基準）
+    ///   - attributedString: NSTextView の現在の attributedString
+    /// - Returns: NSTextView 座標の NSRange（UTF-16 オフセット）
+    static func nsViewRange(from plainRange: NSRange, in attributedString: NSAttributedString) -> NSRange {
+        let startNS = nsViewOffset(for: plainRange.location, in: attributedString)
+        let endNS = nsViewOffset(for: plainRange.location + plainRange.length, in: attributedString)
+        return NSRange(location: startNS, length: endNS - startNS)
+    }
+
+    /// plainText 上の Character インデックスを NSTextView の UTF-16 オフセットに変換する
+    ///
+    /// - Parameters:
+    ///   - plainCharIndex: plainText 上の Character 数インデックス
+    ///   - attributedString: NSTextView の現在の attributedString
+    /// - Returns: NSTextView の UTF-16 オフセット
+    private static func nsViewOffset(for plainCharIndex: Int, in attributedString: NSAttributedString) -> Int {
+        var nsOffset = 0
+        var plainOffset = 0
+
+        attributedString.enumerateAttributes(
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { attrs, range, stop in
+            guard plainOffset < plainCharIndex else {
+                stop.pointee = true
+                return
+            }
+
+            if let attachment = attrs[.attachment] as? EmoteTextAttachment {
+                let emoteLen = attachment.emoteName.count
+                if plainOffset + emoteLen <= plainCharIndex {
+                    plainOffset += emoteLen
+                    nsOffset += range.length
+                } else {
+                    // インデックスがアタッチメント内 → アタッチメント末尾にスナップ
+                    nsOffset += range.length
+                    plainOffset = plainCharIndex
+                    stop.pointee = true
+                }
+            } else {
+                let segmentStr = (attributedString.string as NSString).substring(with: range)
+                let segmentCharLen = segmentStr.count
+                let remaining = plainCharIndex - plainOffset
+                if remaining >= segmentCharLen {
+                    plainOffset += segmentCharLen
+                    nsOffset += range.length
+                } else {
+                    // インデックスがこのテキストセグメント内
+                    let partStr = String(segmentStr.prefix(remaining))
+                    plainOffset = plainCharIndex
+                    nsOffset += partStr.utf16.count
+                    stop.pointee = true
+                }
+            }
+        }
+
+        return nsOffset
+    }
+
     // MARK: - Coordinator
 
     /// NSTextViewDelegate を実装し、エモート検出・置換・draft 更新を担当する
@@ -356,14 +421,15 @@ struct EmoteRichTextView: NSViewRepresentable {
         ///   - range: テキスト内の置換対象範囲（@ から現在クエリ末尾まで）
         ///   - textView: 対象の NSTextView
         private func replaceMentionToken(with insertion: String, range: NSRange, in textView: NSTextView) {
-            // NSTextView 上の対応する範囲を置換する
-            // plainText の文字オフセットと NSTextView.string の UTF-16 オフセットを整合させる
+            // mentionRange は plainText 座標（Character 数）で保持されているため
+            // NSTextView.insertText の replacementRange に渡す前に UTF-16 座標に変換する
+            let nsRange = EmoteRichTextView.nsViewRange(from: range, in: textView.attributedString())
             let nsString = textView.string as NSString
-            guard range.location <= nsString.length,
-                  range.location + range.length <= nsString.length else { return }
+            guard nsRange.location <= nsString.length,
+                  nsRange.location + nsRange.length <= nsString.length else { return }
 
             isUpdatingFromBinding = true
-            textView.insertText(insertion, replacementRange: range)
+            textView.insertText(insertion, replacementRange: nsRange)
 
             // draft を更新
             let plain = EmoteRichTextView.plainText(from: textView.attributedString())

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -144,6 +144,54 @@ struct EmoteRichTextView: NSViewRepresentable {
         return result
     }
 
+    /// NSTextView の UTF-16 カーソル位置を plainText 上の文字数インデックスに変換する
+    ///
+    /// エモートアタッチメントが存在する場合、NSTextView 上では1文字（U+FFFC）だが
+    /// plainText ではエモート名の文字数分になるためオフセットのずれが生じる。
+    /// この変換を行うことで `MentionCompletionViewModel.updateFromText` に正確な
+    /// カーソル位置を渡せる。
+    ///
+    /// - Parameters:
+    ///   - nsViewOffset: NSTextView の selectedRange().location（UTF-16 オフセット）
+    ///   - attributedString: NSTextView の現在の attributedString
+    /// - Returns: plainText 上の文字数インデックス
+    static func plainTextCursorPosition(from nsViewOffset: Int, in attributedString: NSAttributedString) -> Int {
+        var plainOffset = 0
+        var nsOffset = 0
+
+        attributedString.enumerateAttributes(
+            in: NSRange(location: 0, length: attributedString.length),
+            options: []
+        ) { attrs, range, stop in
+            guard nsOffset < nsViewOffset else {
+                stop.pointee = true
+                return
+            }
+
+            if let attachment = attrs[.attachment] as? EmoteTextAttachment {
+                // アタッチメントは NSTextView 上では range.length (通常1) 、plainText ではエモート名の長さ
+                let remaining = nsViewOffset - nsOffset
+                plainOffset += attachment.emoteName.count
+                nsOffset += range.length
+                if remaining < range.length {
+                    stop.pointee = true
+                }
+            } else {
+                let segmentNSLen = range.length
+                let remaining = nsViewOffset - nsOffset
+                let partRange = NSRange(location: range.location, length: min(remaining, segmentNSLen))
+                let partStr = (attributedString.string as NSString).substring(with: partRange)
+                plainOffset += partStr.count
+                nsOffset += partRange.length
+                if remaining < segmentNSLen {
+                    stop.pointee = true
+                }
+            }
+        }
+
+        return plainOffset
+    }
+
     // MARK: - Coordinator
 
     /// NSTextViewDelegate を実装し、エモート検出・置換・draft 更新を担当する
@@ -244,8 +292,13 @@ struct EmoteRichTextView: NSViewRepresentable {
             }
 
             // @メンション補完の候補を更新する
-            let cursorPosition = textView.selectedRange().location
-            mentionCompletionViewModel.updateFromText(plain, cursorPosition: cursorPosition)
+            // NSTextView の UTF-16 カーソル位置を plainText の文字数インデックスに変換して渡す
+            let nsViewOffset = textView.selectedRange().location
+            let plainCursorPosition = EmoteRichTextView.plainTextCursorPosition(
+                from: nsViewOffset,
+                in: textView.attributedString()
+            )
+            mentionCompletionViewModel.updateFromText(plain, cursorPosition: plainCursorPosition)
         }
 
         /// Enter / Shift+Enter で送信、補完アクティブ時は上下キー・Esc も処理する
@@ -275,10 +328,12 @@ struct EmoteRichTextView: NSViewRepresentable {
                     // Enter / Tab: 候補確定
                     // confirmSelection() は内部で mentionRange を nil にリセットするため、先に取得しておく
                     let range = mentionCompletionViewModel.mentionRange
-                    if let insertion = mentionCompletionViewModel.confirmSelection(), let range {
+                    let insertion = mentionCompletionViewModel.confirmSelection()
+                    if let insertion, let range {
+                        // 候補が選択されていた場合: トークンを置換
                         replaceMentionToken(with: insertion, range: range, in: textView)
-                    } else if mentionCompletionViewModel.isActive {
-                        // 候補が空でもアクティブな場合は Enter を送信に通す
+                    } else {
+                        // 候補が空または選択なしの場合: 補完をキャンセルして通常送信へ
                         mentionCompletionViewModel.cancel()
                         onSubmit()
                     }

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -273,9 +273,9 @@ struct EmoteRichTextView: NSViewRepresentable {
                 if commandSelector == #selector(NSResponder.insertNewline(_:))
                     || commandSelector == #selector(NSResponder.insertTab(_:)) {
                     // Enter / Tab: 候補確定
-                    if let insertion = mentionCompletionViewModel.confirmSelection(),
-                       let range = mentionCompletionViewModel.mentionRange {
-                        // mentionRange は確定前に取得しておく（confirmSelection 後は nil になる）
+                    // confirmSelection() は内部で mentionRange を nil にリセットするため、先に取得しておく
+                    let range = mentionCompletionViewModel.mentionRange
+                    if let insertion = mentionCompletionViewModel.confirmSelection(), let range {
                         replaceMentionToken(with: insertion, range: range, in: textView)
                     } else if mentionCompletionViewModel.isActive {
                         // 候補が空でもアクティブな場合は Enter を送信に通す

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -27,6 +27,9 @@ struct EmoteRichTextView: NSViewRepresentable {
     /// 入力無効フラグ
     var isDisabled: Bool
 
+    /// @メンション補完の状態管理 ViewModel
+    var mentionCompletionViewModel: MentionCompletionViewModel
+
     // MARK: - NSViewRepresentable
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -78,7 +81,7 @@ struct EmoteRichTextView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(draft: $draft, emoteStore: emoteStore, onSubmit: onSubmit)
+        Coordinator(draft: $draft, emoteStore: emoteStore, onSubmit: onSubmit, mentionCompletionViewModel: mentionCompletionViewModel)
     }
 
     /// ビュー破棄前に呼ばれるクリーンアップ（@MainActor 上で実行される）
@@ -150,6 +153,7 @@ struct EmoteRichTextView: NSViewRepresentable {
         @Binding var draft: String
         let emoteStore: EmoteStore
         let onSubmit: () -> Void
+        let mentionCompletionViewModel: MentionCompletionViewModel
 
         /// binding 側からのリセット中フラグ（無限ループ防止）
         var isUpdatingFromBinding = false
@@ -160,10 +164,11 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// `nonisolated(unsafe)` は不要。プロパティは常に MainActor 上でアクセスされる。
         private var frameUpdateObserver: NSObjectProtocol?
 
-        init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void) {
+        init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void, mentionCompletionViewModel: MentionCompletionViewModel) {
             self._draft = draft
             self.emoteStore = emoteStore
             self.onSubmit = onSubmit
+            self.mentionCompletionViewModel = mentionCompletionViewModel
         }
 
         /// アニメーションフレーム更新通知を購読し、textView に再描画を要求する
@@ -237,19 +242,79 @@ struct EmoteRichTextView: NSViewRepresentable {
             if draft != plain {
                 draft = plain
             }
+
+            // @メンション補完の候補を更新する
+            let cursorPosition = textView.selectedRange().location
+            mentionCompletionViewModel.updateFromText(plain, cursorPosition: cursorPosition)
         }
 
-        /// Enter / Shift+Enter で送信
+        /// Enter / Shift+Enter で送信、補完アクティブ時は上下キー・Esc も処理する
         ///
         /// - Note: 入力欄は1行固定高さのため、Shift+Enter による改行挿入は無効化している。
         ///   改行を挿入しても表示領域外にクリップされるだけで混乱を招くため、両キーで送信する。
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+            // 補完アクティブ中のキーハンドリング
+            if mentionCompletionViewModel.isActive {
+                if commandSelector == #selector(NSResponder.moveUp(_:)) {
+                    // 上キー: 前の候補に移動
+                    mentionCompletionViewModel.moveSelection(by: -1)
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.moveDown(_:)) {
+                    // 下キー: 次の候補に移動
+                    mentionCompletionViewModel.moveSelection(by: 1)
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                    // Esc: 補完キャンセル
+                    mentionCompletionViewModel.cancel()
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.insertNewline(_:))
+                    || commandSelector == #selector(NSResponder.insertTab(_:)) {
+                    // Enter / Tab: 候補確定
+                    if let insertion = mentionCompletionViewModel.confirmSelection(),
+                       let range = mentionCompletionViewModel.mentionRange {
+                        // mentionRange は確定前に取得しておく（confirmSelection 後は nil になる）
+                        replaceMentionToken(with: insertion, range: range, in: textView)
+                    } else if mentionCompletionViewModel.isActive {
+                        // 候補が空でもアクティブな場合は Enter を送信に通す
+                        mentionCompletionViewModel.cancel()
+                        onSubmit()
+                    }
+                    return true
+                }
+            }
+
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 // Enter / Shift+Enter いずれも送信（1行固定のため改行を許可しない）
                 onSubmit()
                 return true
             }
             return false
+        }
+
+        /// @メンショントークンを補完候補で置換し draft を更新する
+        ///
+        /// - Parameters:
+        ///   - insertion: 挿入する文字列（`@username ` 形式）
+        ///   - range: テキスト内の置換対象範囲（@ から現在クエリ末尾まで）
+        ///   - textView: 対象の NSTextView
+        private func replaceMentionToken(with insertion: String, range: NSRange, in textView: NSTextView) {
+            // NSTextView 上の対応する範囲を置換する
+            // plainText の文字オフセットと NSTextView.string の UTF-16 オフセットを整合させる
+            let nsString = textView.string as NSString
+            guard range.location <= nsString.length,
+                  range.location + range.length <= nsString.length else { return }
+
+            isUpdatingFromBinding = true
+            textView.insertText(insertion, replacementRange: range)
+
+            // draft を更新
+            let plain = EmoteRichTextView.plainText(from: textView.attributedString())
+            if draft != plain {
+                draft = plain
+            }
         }
 
         // MARK: - エモート検出・置換

--- a/Sources/TwitchChat/Views/MentionCompletionView.swift
+++ b/Sources/TwitchChat/Views/MentionCompletionView.swift
@@ -1,0 +1,87 @@
+// MentionCompletionView.swift
+// @メンション補完のドロップダウン候補リスト表示ビュー
+// 入力バーの上に重ねて表示し、ユーザー名候補を一覧する
+
+import SwiftUI
+
+/// @メンション補完候補のドロップダウンビュー
+///
+/// `ChatInputBar` の `inputForm` に `.overlay` で重ね、入力バーの上方向に表示する。
+/// クリックで候補を選択確定できる。キーボード操作は `EmoteRichTextView` が担当する。
+struct MentionCompletionView: View {
+
+    /// 表示する候補一覧
+    var candidates: [MentionStore.UserCandidate]
+
+    /// 現在選択中の候補インデックス
+    var selectedIndex: Int
+
+    /// 候補を選択したときのコールバック（インデックスを渡す）
+    var onSelect: (Int) -> Void
+
+    /// 1行の高さ
+    private static let rowHeight: CGFloat = 32
+
+    /// 最大表示件数
+    private static let maxVisibleRows: Int = 6
+
+    var body: some View {
+        let visibleCount = min(candidates.count, Self.maxVisibleRows)
+        let listHeight = CGFloat(visibleCount) * Self.rowHeight
+
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                    candidateRow(candidate: candidate, index: index)
+                }
+            }
+        }
+        .frame(height: listHeight)
+        .background(Color(.windowBackgroundColor))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.separatorColor), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: -2)
+    }
+
+    // MARK: - サブビュー
+
+    /// 候補1件分の行ビュー
+    @ViewBuilder
+    private func candidateRow(candidate: MentionStore.UserCandidate, index: Int) -> some View {
+        Button {
+            onSelect(index)
+        } label: {
+            HStack(spacing: 8) {
+                // ユーザー名（displayName を優先表示）
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(candidate.displayName)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(index == selectedIndex ? Color.white : Color.primary)
+                        .lineLimit(1)
+
+                    // displayName と username が異なる場合のみ username をサブテキストで表示
+                    if candidate.displayName.lowercased() != candidate.username {
+                        Text("@\(candidate.username)")
+                            .font(.system(size: 11))
+                            .foregroundStyle(index == selectedIndex ? Color.white.opacity(0.8) : Color.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer()
+            }
+            .frame(height: Self.rowHeight)
+            .padding(.horizontal, 12)
+            .background(index == selectedIndex ? Color.accentColor : Color.clear)
+        }
+        .buttonStyle(.plain)
+
+        if index < candidates.count - 1 {
+            Divider()
+                .padding(.horizontal, 8)
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/MentionCompletionView.swift
+++ b/Sources/TwitchChat/Views/MentionCompletionView.swift
@@ -22,16 +22,21 @@ struct MentionCompletionView: View {
     /// 1行の高さ
     private static let rowHeight: CGFloat = 32
 
+    /// Divider の高さ（1pt）
+    private static let dividerHeight: CGFloat = 1
+
     /// 最大表示件数
     private static let maxVisibleRows: Int = 6
 
     var body: some View {
         let visibleCount = min(candidates.count, Self.maxVisibleRows)
+        // Divider を含めた正確な高さ計算（最後の行には Divider なし）
         let listHeight = CGFloat(visibleCount) * Self.rowHeight
+            + CGFloat(max(0, visibleCount - 1)) * Self.dividerHeight
 
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(Array(candidates.enumerated()), id: \.offset) { index, candidate in
+                ForEach(Array(candidates.enumerated()), id: \.element.id) { index, candidate in
                     candidateRow(candidate: candidate, index: index)
                 }
             }
@@ -51,6 +56,7 @@ struct MentionCompletionView: View {
     /// 候補1件分の行ビュー
     @ViewBuilder
     private func candidateRow(candidate: MentionStore.UserCandidate, index: Int) -> some View {
+        let isSelected = index == selectedIndex
         Button {
             onSelect(index)
         } label: {
@@ -59,14 +65,14 @@ struct MentionCompletionView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text(candidate.displayName)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(index == selectedIndex ? Color.white : Color.primary)
+                        .foregroundStyle(isSelected ? Color.white : Color.primary)
                         .lineLimit(1)
 
                     // displayName と username が異なる場合のみ username をサブテキストで表示
                     if candidate.displayName.lowercased() != candidate.username {
                         Text("@\(candidate.username)")
                             .font(.system(size: 11))
-                            .foregroundStyle(index == selectedIndex ? Color.white.opacity(0.8) : Color.secondary)
+                            .foregroundStyle(isSelected ? Color.white.opacity(0.8) : Color.secondary)
                             .lineLimit(1)
                     }
                 }
@@ -75,9 +81,11 @@ struct MentionCompletionView: View {
             }
             .frame(height: Self.rowHeight)
             .padding(.horizontal, 12)
-            .background(index == selectedIndex ? Color.accentColor : Color.clear)
+            .background(isSelected ? Color.accentColor : Color.clear)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(candidate.displayName)（@\(candidate.username)）")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
 
         if index < candidates.count - 1 {
             Divider()

--- a/Sources/TwitchChat/Views/MentionCompletionView.swift
+++ b/Sources/TwitchChat/Views/MentionCompletionView.swift
@@ -19,14 +19,14 @@ struct MentionCompletionView: View {
     /// 候補を選択したときのコールバック（インデックスを渡す）
     var onSelect: (Int) -> Void
 
-    /// 1行の高さ
-    private static let rowHeight: CGFloat = 32
+    /// 1行の高さ（ChatInputBar のオフセット計算と共有するため internal）
+    static let rowHeight: CGFloat = 32
 
     /// Divider の高さ（1pt）
     private static let dividerHeight: CGFloat = 1
 
-    /// 最大表示件数
-    private static let maxVisibleRows: Int = 6
+    /// 最大表示件数（ChatInputBar のオフセット計算と共有するため internal）
+    static let maxVisibleRows: Int = 6
 
     var body: some View {
         let visibleCount = min(candidates.count, Self.maxVisibleRows)

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -839,4 +839,46 @@ struct ChatViewModelTests {
         let replyToIds = await mockClient.sentReplyToIds
         #expect(replyToIds.last == .some(nil))
     }
+
+    // MARK: - mentionStore 連携
+
+    @Test("メッセージ受信後に mentionStore の候補にユーザーが追加される")
+    func メッセージ受信後にmentionStoreの候補にユーザーが追加される() async throws {
+        // 前提: チャンネルに接続する
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+        await viewModel.connect(to: "テストチャンネル")
+        await waitFor { viewModel.connectionState == .connected }
+
+        // 実行: チャットメッセージを受信する
+        let message = makeTestChatMessage(displayName: "配信者テスト", text: "こんにちは")
+        await mockClient.sendMessage(message)
+        await waitFor { viewModel.messages.count >= 1 }
+
+        // 検証: mentionStore に発言者が登録されている
+        let candidates = viewModel.mentionStore.candidates(matching: "")
+        #expect(candidates.isEmpty == false)
+        #expect(candidates.contains { $0.displayName == "配信者テスト" })
+    }
+
+    @Test("複数のメッセージを受信すると最新発言者が先頭になる")
+    func 複数のメッセージを受信すると最新発言者が先頭になる() async throws {
+        // 前提: チャンネルに接続する
+        let mockClient = MockTwitchIRCClient()
+        let viewModel = ChatViewModel(ircClient: mockClient)
+        await viewModel.connect(to: "テストチャンネル")
+        await waitFor { viewModel.connectionState == .connected }
+
+        // 実行: 異なるユーザーのメッセージを順番に受信する
+        let msg1 = makeTestChatMessage(displayName: "ユーザーA", text: "最初のメッセージ")
+        let msg2 = makeTestChatMessage(displayName: "ユーザーB", text: "2番目のメッセージ")
+        await mockClient.sendMessage(msg1)
+        await waitFor { viewModel.messages.count >= 1 }
+        await mockClient.sendMessage(msg2)
+        await waitFor { viewModel.messages.count >= 2 }
+
+        // 検証: 最後に発言した ユーザーB が先頭に来る
+        let candidates = viewModel.mentionStore.candidates(matching: "")
+        #expect(candidates.first?.displayName == "ユーザーB")
+    }
 }

--- a/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
@@ -11,6 +11,9 @@ struct MentionCompletionViewModelTests {
     // MARK: - テスト用ヘルパー
 
     /// ユーザーが3名登録済みの MentionStore を生成する
+    ///
+    /// 登録順: ninja → pokimane → nickmercs
+    /// candidates(matching: "") の返却順（最新発言順）: [nickmercs, pokimane, ninja]
     @MainActor
     private func makeStore() -> MentionStore {
         let store = MentionStore()
@@ -37,7 +40,8 @@ struct MentionCompletionViewModelTests {
     func testAtSignAfterSpaceActivates() {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
-        vm.updateFromText("こんにちは @", cursorPosition: 8)
+        // "こんにちは @" は7文字（カーソルは末尾）
+        vm.updateFromText("こんにちは @", cursorPosition: 7)
 
         #expect(vm.isActive == true)
     }
@@ -119,7 +123,8 @@ struct MentionCompletionViewModelTests {
     func testNoMatchCandidatesEmpty() {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
-        vm.updateFromText("@存在しないユーザー", cursorPosition: 9)
+        // "@存在しないユーザー" は10文字（カーソルは末尾）
+        vm.updateFromText("@存在しないユーザー", cursorPosition: 10)
 
         #expect(vm.candidates.isEmpty)
     }
@@ -176,28 +181,49 @@ struct MentionCompletionViewModelTests {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
         vm.updateFromText("@", cursorPosition: 1)
-        // 候補は3件（ninja, pokimane, nickmercs）。インデックスの最大は 2
+        // 候補は3件（nickmercs, pokimane, ninja）。インデックスの最大は 2
         vm.moveSelection(by: 10)
 
         #expect(vm.selectedIndex == 2)
     }
 
+    @Test("setSelection(to:) で直接インデックスを指定できる")
+    @MainActor
+    func testSetSelectionDirectly() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        vm.setSelection(to: 2)
+
+        #expect(vm.selectedIndex == 2)
+    }
+
+    @Test("setSelection(to:) は範囲外の値をクランプする")
+    @MainActor
+    func testSetSelectionClamped() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        vm.setSelection(to: 100)
+
+        #expect(vm.selectedIndex == 2) // 候補3件なので最大インデックスは2
+    }
+
     // MARK: - confirmSelection（確定）
 
-    @Test("confirmSelection() は選択中のユーザーの @username 形式の文字列を返す")
+    @Test("confirmSelection() は選択中の候補（先頭）の @username 形式の文字列を返す")
     @MainActor
     func testConfirmSelectionReturnsUsername() {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
-        // 前提: @ を入力すると最新発言順で nickmercs, pokimane, ninja の順になる
+        // 前提: makeStore は ninja → pokimane → nickmercs の順に記録するため、
+        // 最新発言順では nickmercs が先頭（インデックス0）になる
         vm.updateFromText("@", cursorPosition: 1)
 
         let result = vm.confirmSelection()
 
-        // 先頭（インデックス0）の候補の username が返る
-        #expect(result != nil)
-        #expect(result?.hasPrefix("@") == true)
-        #expect(result?.hasSuffix(" ") == true)
+        // 先頭の候補（nickmercs）が "@nickmercs " の形式で返る
+        #expect(result == "@nickmercs ")
     }
 
     @Test("confirmSelection() は選択確定後に非アクティブ状態になる")
@@ -227,13 +253,14 @@ struct MentionCompletionViewModelTests {
     func testConfirmSecondCandidate() {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
+        // "@ni" にマッチするのは nickmercs（0番目）と ninja（1番目）
         vm.updateFromText("@ni", cursorPosition: 3)
-        // ni にマッチするのは nickmercs と ninja の2件
-        vm.moveSelection(by: 1)  // インデックス 1 に移動
+        vm.moveSelection(by: 1)  // インデックス1（ninja）に移動
+
         let result = vm.confirmSelection()
 
-        #expect(result != nil)
-        #expect(result?.hasPrefix("@") == true)
+        // インデックス1の ninja が "@ninja " として返る
+        #expect(result == "@ninja ")
     }
 
     // MARK: - mentionRange（置換範囲）
@@ -258,7 +285,7 @@ struct MentionCompletionViewModelTests {
     func testMentionRangeAfterSpace() {
         let vm = MentionCompletionViewModel(mentionStore: makeStore())
 
-        // "こんにちは @ni" のような入力
+        // "hello @ni" のような入力
         let text = "hello @ni"
         vm.updateFromText(text, cursorPosition: text.count)
 

--- a/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
@@ -1,0 +1,271 @@
+// MentionCompletionViewModelTests.swift
+// MentionCompletionViewModel の @ トリガー検出・候補管理・選択操作のテスト
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+@Suite("MentionCompletionViewModelTests")
+struct MentionCompletionViewModelTests {
+
+    // MARK: - テスト用ヘルパー
+
+    /// ユーザーが3名登録済みの MentionStore を生成する
+    @MainActor
+    private func makeStore() -> MentionStore {
+        let store = MentionStore()
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+        store.recordUser(username: "nickmercs", displayName: "NICKMERCS")
+        return store
+    }
+
+    // MARK: - isActive（アクティブ化・非アクティブ化）
+
+    @Test("@ を単独入力するとアクティブ状態になる")
+    @MainActor
+    func testAtSignActivates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+
+        #expect(vm.isActive == true)
+    }
+
+    @Test("スペースの後の @ でアクティブ状態になる")
+    @MainActor
+    func testAtSignAfterSpaceActivates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("こんにちは @", cursorPosition: 8)
+
+        #expect(vm.isActive == true)
+    }
+
+    @Test("@ を含まないテキストではアクティブ状態にならない")
+    @MainActor
+    func testNoAtSignDoesNotActivate() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("普通のメッセージ", cursorPosition: 8)
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("単語の途中の @ はトリガーにならない（例: メールアドレス形式）")
+    @MainActor
+    func testAtSignInMiddleOfWordDoesNotActivate() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        // "user@example" の @ はメンションではない
+        vm.updateFromText("user@example", cursorPosition: 12)
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("@ を削除するとアクティブ状態が解除される")
+    @MainActor
+    func testDeletingAtSignDeactivates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@ni", cursorPosition: 3)
+        #expect(vm.isActive == true)
+
+        // @ を削除してテキストを更新
+        vm.updateFromText("ni", cursorPosition: 2)
+        #expect(vm.isActive == false)
+    }
+
+    @Test("cancel() を呼ぶとアクティブ状態が解除される")
+    @MainActor
+    func testCancelDeactivates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@ninja", cursorPosition: 6)
+        #expect(vm.isActive == true)
+
+        vm.cancel()
+        #expect(vm.isActive == false)
+    }
+
+    // MARK: - candidates（候補フィルタリング）
+
+    @Test("@ のみ入力した場合は全候補が表示される")
+    @MainActor
+    func testAtSignShowsAllCandidates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+
+        // 登録ユーザー3名全員が候補に上がる
+        #expect(vm.candidates.count == 3)
+    }
+
+    @Test("@ni と入力すると ninja と nickmercs が候補に表示される")
+    @MainActor
+    func testFilteredCandidates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@ni", cursorPosition: 3)
+
+        #expect(vm.candidates.count == 2)
+        let usernames = vm.candidates.map { $0.username }
+        #expect(usernames.contains("ninja"))
+        #expect(usernames.contains("nickmercs"))
+    }
+
+    @Test("マッチしないクエリでは候補が空になる")
+    @MainActor
+    func testNoMatchCandidatesEmpty() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@存在しないユーザー", cursorPosition: 9)
+
+        #expect(vm.candidates.isEmpty)
+    }
+
+    // MARK: - selectedIndex（選択操作）
+
+    @Test("初期状態の selectedIndex は 0 である")
+    @MainActor
+    func testInitialSelectedIndex() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("moveSelection(by: 1) で次の候補に移動する")
+    @MainActor
+    func testMoveSelectionDown() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        vm.moveSelection(by: 1)
+
+        #expect(vm.selectedIndex == 1)
+    }
+
+    @Test("moveSelection(by: -1) で前の候補に移動する")
+    @MainActor
+    func testMoveSelectionUp() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        vm.moveSelection(by: 1) // インデックス 1 に移動
+        vm.moveSelection(by: -1) // インデックス 0 に戻る
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("先頭でさらに上に移動しようとしてもクランプされる（0 以下にならない）")
+    @MainActor
+    func testSelectionClampedAtTop() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        vm.moveSelection(by: -1)
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("末尾でさらに下に移動しようとしてもクランプされる（候補数を超えない）")
+    @MainActor
+    func testSelectionClampedAtBottom() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        // 候補は3件（ninja, pokimane, nickmercs）。インデックスの最大は 2
+        vm.moveSelection(by: 10)
+
+        #expect(vm.selectedIndex == 2)
+    }
+
+    // MARK: - confirmSelection（確定）
+
+    @Test("confirmSelection() は選択中のユーザーの @username 形式の文字列を返す")
+    @MainActor
+    func testConfirmSelectionReturnsUsername() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        // 前提: @ を入力すると最新発言順で nickmercs, pokimane, ninja の順になる
+        vm.updateFromText("@", cursorPosition: 1)
+
+        let result = vm.confirmSelection()
+
+        // 先頭（インデックス0）の候補の username が返る
+        #expect(result != nil)
+        #expect(result?.hasPrefix("@") == true)
+        #expect(result?.hasSuffix(" ") == true)
+    }
+
+    @Test("confirmSelection() は選択確定後に非アクティブ状態になる")
+    @MainActor
+    func testConfirmSelectionDeactivates() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@", cursorPosition: 1)
+        _ = vm.confirmSelection()
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("候補が空の場合 confirmSelection() は nil を返す")
+    @MainActor
+    func testConfirmSelectionWithNoCandidatesReturnsNil() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@存在しない", cursorPosition: 6)
+        let result = vm.confirmSelection()
+
+        #expect(result == nil)
+    }
+
+    @Test("2番目の候補を選択して確定すると正しい username が返る")
+    @MainActor
+    func testConfirmSecondCandidate() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        vm.updateFromText("@ni", cursorPosition: 3)
+        // ni にマッチするのは nickmercs と ninja の2件
+        vm.moveSelection(by: 1)  // インデックス 1 に移動
+        let result = vm.confirmSelection()
+
+        #expect(result != nil)
+        #expect(result?.hasPrefix("@") == true)
+    }
+
+    // MARK: - mentionRange（置換範囲）
+
+    @Test("mentionRange は @ から現在のクエリ末尾までの範囲を返す")
+    @MainActor
+    func testMentionRangeForCurrentToken() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        // "@ninja" と入力中、カーソルが末尾の場合
+        vm.updateFromText("@ninja", cursorPosition: 6)
+
+        let range = vm.mentionRange
+        #expect(range != nil)
+        // "@ninja" の6文字分の範囲
+        #expect(range?.length == 6)
+        #expect(range?.location == 0)
+    }
+
+    @Test("スペース後の @ の mentionRange はスペース以降の正しい範囲を返す")
+    @MainActor
+    func testMentionRangeAfterSpace() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        // "こんにちは @ni" のような入力
+        let text = "hello @ni"
+        vm.updateFromText(text, cursorPosition: text.count)
+
+        let range = vm.mentionRange
+        #expect(range != nil)
+        // "@ni" の3文字分
+        #expect(range?.length == 3)
+        #expect(range?.location == 6)
+    }
+}

--- a/Tests/TwitchChatTests/MentionStoreTests.swift
+++ b/Tests/TwitchChatTests/MentionStoreTests.swift
@@ -17,10 +17,15 @@ struct MentionStoreTests {
 
         store.recordUser(username: "ninja", displayName: "Ninja")
 
+        // 安全なアクセス: 先に件数を確認してから first で取得する
         let result = store.candidates(matching: "")
+        guard let first = result.first else {
+            Issue.record("candidates に1件追加されているはずだが、空だった")
+            return
+        }
         #expect(result.count == 1)
-        #expect(result[0].username == "ninja")
-        #expect(result[0].displayName == "Ninja")
+        #expect(first.username == "ninja")
+        #expect(first.displayName == "Ninja")
     }
 
     @Test("同じユーザーを複数回記録しても重複しない")
@@ -59,12 +64,15 @@ struct MentionStoreTests {
         store.recordUser(username: "pokimane", displayName: "Pokimane")
 
         let result = store.candidates(matching: "")
+        // 配列アクセス前に件数を確認
+        #expect(result.count >= 2)
+        guard result.count >= 2 else { return }
         // 最後に記録した pokimane が先頭
         #expect(result[0].username == "pokimane")
         #expect(result[1].username == "ninja")
     }
 
-    @Test("既存ユーザーを再度記録すると先頭に移動する")
+    @Test("既存ユーザーを再度記録すると先頭に移動し、順序全体が正しい")
     @MainActor
     func testRerecordedUserMovesToFront() {
         let store = MentionStore()
@@ -78,8 +86,13 @@ struct MentionStoreTests {
         store.recordUser(username: "ninja", displayName: "Ninja")
 
         let result = store.candidates(matching: "")
-        // ninja が先頭に移動している
+        // 配列アクセス前に件数を確認
+        #expect(result.count == 3)
+        guard result.count == 3 else { return }
+        // ninja が先頭に移動し、残りは記録順が維持される
         #expect(result[0].username == "ninja")
+        #expect(result[1].username == "shroud")
+        #expect(result[2].username == "pokimane")
     }
 
     // MARK: - candidates(matching:)
@@ -96,7 +109,7 @@ struct MentionStoreTests {
         #expect(result.count == 2)
     }
 
-    @Test("前方一致でフィルタリングできる")
+    @Test("前方一致でフィルタリングできる（非マッチユーザーは除外される）")
     @MainActor
     func testPrefixMatchFilter() {
         let store = MentionStore()
@@ -105,12 +118,14 @@ struct MentionStoreTests {
         store.recordUser(username: "pokimane", displayName: "Pokimane")
         store.recordUser(username: "nickmercs", displayName: "NICKMERCS")
 
-        // "ni" で ninja と nickmercs がヒット
+        // "ni" で ninja と nickmercs がヒット。pokimane はヒットしない
         let result = store.candidates(matching: "ni")
         #expect(result.count == 2)
         let usernames = result.map { $0.username }
         #expect(usernames.contains("ninja"))
         #expect(usernames.contains("nickmercs"))
+        // 否定チェック: pokimane は除外される
+        #expect(!usernames.contains("pokimane"))
     }
 
     @Test("フィルタは大文字小文字を区別しない")
@@ -122,8 +137,12 @@ struct MentionStoreTests {
 
         // 大文字でも検索できる
         let result = store.candidates(matching: "NIN")
+        guard let first = result.first else {
+            Issue.record("'NIN' で ninja がヒットするはずだが、結果が空だった")
+            return
+        }
         #expect(result.count == 1)
-        #expect(result[0].username == "ninja")
+        #expect(first.username == "ninja")
     }
 
     @Test("displayName でもフィルタリングできる")
@@ -135,10 +154,14 @@ struct MentionStoreTests {
         store.recordUser(username: "vtuber_jp", displayName: "日本語VTuber")
         store.recordUser(username: "englishstreamer", displayName: "EnglishStreamer")
 
-        // displayName で検索
+        // displayName の先頭で検索
         let result = store.candidates(matching: "日本語")
+        guard let first = result.first else {
+            Issue.record("'日本語' で vtuber_jp がヒットするはずだが、結果が空だった")
+            return
+        }
         #expect(result.count == 1)
-        #expect(result[0].username == "vtuber_jp")
+        #expect(first.username == "vtuber_jp")
     }
 
     @Test("該当なしの場合は空配列が返る")
@@ -159,5 +182,45 @@ struct MentionStoreTests {
 
         let result = store.candidates(matching: "")
         #expect(result.isEmpty)
+    }
+
+    // MARK: - メモリ上限
+
+    @Test("maxMentionsCount を超えると古いユーザーが削除される")
+    @MainActor
+    func testMaxMentionsCountTrimsOldUsers() {
+        let store = MentionStore()
+        let max = MentionStore.maxMentionsCount
+
+        // max 件を超えるユーザーを記録する
+        for i in 0..<(max + 10) {
+            store.recordUser(username: "user\(i)", displayName: "ユーザー\(i)")
+        }
+
+        // 検証: max 件以下に収まっている
+        let result = store.candidates(matching: "")
+        #expect(result.count == max)
+    }
+
+    @Test("上限超過時に最も古いユーザーが削除される")
+    @MainActor
+    func testOldestUserRemovedWhenExceedingLimit() {
+        let store = MentionStore()
+        let max = MentionStore.maxMentionsCount
+
+        // "最古ユーザー" を最初に記録する
+        store.recordUser(username: "最古ユーザー", displayName: "最古ユーザー表示名")
+
+        // max 件分を追加して上限を超えさせる
+        for i in 1..<max {
+            store.recordUser(username: "user\(i)", displayName: "ユーザー\(i)")
+        }
+
+        // 検証: 最古ユーザーは削除されている（上限に達した後の追加で押し出される）
+        // ここで1件追加すると max+1 件になるため最古が削除される
+        store.recordUser(username: "追加ユーザー", displayName: "追加ユーザー表示名")
+
+        let result = store.candidates(matching: "最古ユーザー")
+        #expect(result.isEmpty, "上限超過により最古ユーザーは削除されているはずだが、まだ存在している")
     }
 }

--- a/Tests/TwitchChatTests/MentionStoreTests.swift
+++ b/Tests/TwitchChatTests/MentionStoreTests.swift
@@ -1,0 +1,163 @@
+// MentionStoreTests.swift
+// MentionStore のユーザー記録・候補フィルタリングのテスト
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+@Suite("MentionStoreTests")
+struct MentionStoreTests {
+
+    // MARK: - recordUser
+
+    @Test("ユーザーを記録すると candidates に追加される")
+    @MainActor
+    func testRecordUserAddsCandidate() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+
+        let result = store.candidates(matching: "")
+        #expect(result.count == 1)
+        #expect(result[0].username == "ninja")
+        #expect(result[0].displayName == "Ninja")
+    }
+
+    @Test("同じユーザーを複数回記録しても重複しない")
+    @MainActor
+    func testRecordUserDeduplicated() {
+        let store = MentionStore()
+
+        store.recordUser(username: "shroud", displayName: "shroud")
+        store.recordUser(username: "shroud", displayName: "shroud")
+        store.recordUser(username: "shroud", displayName: "shroud")
+
+        let result = store.candidates(matching: "")
+        #expect(result.count == 1)
+    }
+
+    @Test("複数のユーザーを記録できる")
+    @MainActor
+    func testRecordMultipleUsers() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+        store.recordUser(username: "shroud", displayName: "shroud")
+
+        let result = store.candidates(matching: "")
+        #expect(result.count == 3)
+    }
+
+    @Test("最新発言者が先頭に来る順序になる")
+    @MainActor
+    func testRecentUserComesFirst() {
+        let store = MentionStore()
+
+        // 前提: 先に ninja を記録してから pokimane を記録する
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+
+        let result = store.candidates(matching: "")
+        // 最後に記録した pokimane が先頭
+        #expect(result[0].username == "pokimane")
+        #expect(result[1].username == "ninja")
+    }
+
+    @Test("既存ユーザーを再度記録すると先頭に移動する")
+    @MainActor
+    func testRerecordedUserMovesToFront() {
+        let store = MentionStore()
+
+        // 前提: ninja → pokimane → shroud の順に記録
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+        store.recordUser(username: "shroud", displayName: "shroud")
+
+        // ninja が再発言
+        store.recordUser(username: "ninja", displayName: "Ninja")
+
+        let result = store.candidates(matching: "")
+        // ninja が先頭に移動している
+        #expect(result[0].username == "ninja")
+    }
+
+    // MARK: - candidates(matching:)
+
+    @Test("空クエリで全件が返る")
+    @MainActor
+    func testEmptyQueryReturnsAll() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+
+        let result = store.candidates(matching: "")
+        #expect(result.count == 2)
+    }
+
+    @Test("前方一致でフィルタリングできる")
+    @MainActor
+    func testPrefixMatchFilter() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+        store.recordUser(username: "pokimane", displayName: "Pokimane")
+        store.recordUser(username: "nickmercs", displayName: "NICKMERCS")
+
+        // "ni" で ninja と nickmercs がヒット
+        let result = store.candidates(matching: "ni")
+        #expect(result.count == 2)
+        let usernames = result.map { $0.username }
+        #expect(usernames.contains("ninja"))
+        #expect(usernames.contains("nickmercs"))
+    }
+
+    @Test("フィルタは大文字小文字を区別しない")
+    @MainActor
+    func testCaseInsensitiveFilter() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+
+        // 大文字でも検索できる
+        let result = store.candidates(matching: "NIN")
+        #expect(result.count == 1)
+        #expect(result[0].username == "ninja")
+    }
+
+    @Test("displayName でもフィルタリングできる")
+    @MainActor
+    func testFilterByDisplayName() {
+        let store = MentionStore()
+
+        // username: vtuber_jp, displayName: 日本語VTuber
+        store.recordUser(username: "vtuber_jp", displayName: "日本語VTuber")
+        store.recordUser(username: "englishstreamer", displayName: "EnglishStreamer")
+
+        // displayName で検索
+        let result = store.candidates(matching: "日本語")
+        #expect(result.count == 1)
+        #expect(result[0].username == "vtuber_jp")
+    }
+
+    @Test("該当なしの場合は空配列が返る")
+    @MainActor
+    func testNoMatchReturnsEmpty() {
+        let store = MentionStore()
+
+        store.recordUser(username: "ninja", displayName: "Ninja")
+
+        let result = store.candidates(matching: "存在しないユーザー")
+        #expect(result.isEmpty)
+    }
+
+    @Test("ユーザーが0件の状態でも空配列が返る")
+    @MainActor
+    func testEmptyStoreReturnsEmpty() {
+        let store = MentionStore()
+
+        let result = store.candidates(matching: "")
+        #expect(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- チャット入力中に `@` を入力すると直近のチャット参加者がドロップダウンで表示される
- 上下キーで選択移動、Enter/Tab で確定、Esc でキャンセル
- 候補リストのクリックでも確定可能
- 単語途中の `@`（メールアドレス等）は無視

## 実装詳細

| ファイル | 内容 |
|---|---|
| `MentionStore` | チャット参加者を最新発言順(最大200件)で管理、前方一致フィルタ |
| `MentionCompletionViewModel` | `@` トリガー検出・候補管理・選択操作（UTF-16 オフセット対応） |
| `MentionCompletionView` | 入力バー上のドロップダウンUI（アクセシビリティ対応） |
| `ChatViewModel` | `mentionStore` 追加、`appendMessage` でユーザー記録 |
| `EmoteRichTextView` | `@` 検出・キーハンドリング・カーソル位置変換 |
| `ChatInputBar` | ViewModel 保持・オーバーレイ配置 |

新規テスト: 33件（MentionStoreTests 13件、MentionCompletionViewModelTests 22件、ChatViewModelTests 2件）

## Test plan

- [ ] `swift build` でビルド成功を確認
- [ ] `swift test` でテスト全パスを確認
- [ ] アプリ起動 → チャンネル接続 → チャットが流れた後に `@` 入力 → 候補表示確認
- [ ] 文字入力でフィルタリング（前方一致）確認
- [ ] 上下キーで選択移動、Enter で確定確認
- [ ] Esc でキャンセル確認
- [ ] クリックによる候補確定確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)