### PR TITLE
feat: スラッシュコマンド(/)補完機能を実装する

### DIFF
--- a/Sources/TwitchChat/Models/SlashCommandDefinition.swift
+++ b/Sources/TwitchChat/Models/SlashCommandDefinition.swift
@@ -113,6 +113,6 @@ struct SlashCommandDefinition: Identifiable {
             name: "delete",
             description: "特定のメッセージを削除する",
             usage: "/delete <メッセージID>"
-        ),
+        )
     ]
 }

--- a/Sources/TwitchChat/Models/SlashCommandDefinition.swift
+++ b/Sources/TwitchChat/Models/SlashCommandDefinition.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `name` フィールドで紐づける。
 ///
 /// - Note: `allCommands` は静的リストとして定義する。
-struct SlashCommandDefinition: Identifiable {
+struct SlashCommandDefinition: Identifiable, Hashable {
 
     /// コマンド名（先頭スラッシュなし。例: "ban", "timeout"）
     let name: String
@@ -113,6 +113,91 @@ struct SlashCommandDefinition: Identifiable {
             name: "delete",
             description: "特定のメッセージを削除する",
             usage: "/delete <メッセージID>"
+        ),
+        SlashCommandDefinition(
+            name: "mod",
+            description: "ユーザーをモデレーターに任命する",
+            usage: "/mod <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "unmod",
+            description: "ユーザーのモデレーター権限を解除する",
+            usage: "/unmod <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "vip",
+            description: "ユーザーにVIP権限を付与する",
+            usage: "/vip <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "unvip",
+            description: "ユーザーのVIP権限を解除する",
+            usage: "/unvip <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "raid",
+            description: "別のチャンネルにレイドする",
+            usage: "/raid <チャンネル名>"
+        ),
+        SlashCommandDefinition(
+            name: "unraid",
+            description: "レイドをキャンセルする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "host",
+            description: "別のチャンネルをホストする",
+            usage: "/host <チャンネル名>"
+        ),
+        SlashCommandDefinition(
+            name: "unhost",
+            description: "ホストを終了する",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "w",
+            description: "ウィスパー（非公開メッセージ）を送信する",
+            usage: "/w <ユーザー名> <メッセージ>"
+        ),
+        SlashCommandDefinition(
+            name: "mods",
+            description: "モデレーター一覧を表示する",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "vips",
+            description: "VIP一覧を表示する",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "announcement",
+            description: "アナウンスメッセージを送信する",
+            usage: "/announcement <メッセージ>"
+        ),
+        SlashCommandDefinition(
+            name: "warn",
+            description: "ユーザーに警告を送る",
+            usage: "/warn <ユーザー名> <理由>"
+        ),
+        SlashCommandDefinition(
+            name: "commercial",
+            description: "広告を再生する",
+            usage: "/commercial <秒数>"
+        ),
+        SlashCommandDefinition(
+            name: "color",
+            description: "チャット名前の色を変更する",
+            usage: "/color <色名またはHEX>"
+        ),
+        SlashCommandDefinition(
+            name: "shield",
+            description: "シールドモードを有効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "shieldoff",
+            description: "シールドモードを無効にする",
+            usage: nil
         )
     ]
 }

--- a/Sources/TwitchChat/Models/SlashCommandDefinition.swift
+++ b/Sources/TwitchChat/Models/SlashCommandDefinition.swift
@@ -1,0 +1,118 @@
+// SlashCommandDefinition.swift
+// スラッシュコマンドの静的定義モデル
+// 補完候補として表示するコマンド名・説明文・使用例を保持する
+
+import Foundation
+
+/// スラッシュコマンドの補完候補定義
+///
+/// 入力欄で `/` を入力した際に表示される補完候補の表示情報を保持する。
+/// コマンドのパース・実行ロジックは別途 `ChatCommandParser`（issue25 で実装予定）が担当し、
+/// `name` フィールドで紐づける。
+///
+/// - Note: `allCommands` は静的リストとして定義する。
+struct SlashCommandDefinition: Identifiable {
+
+    /// コマンド名（先頭スラッシュなし。例: "ban", "timeout"）
+    let name: String
+
+    /// コマンドの説明文（日本語）
+    let description: String
+
+    /// 使用例（例: "/ban <ユーザー名> [理由]"）。省略可能なコマンドは nil
+    let usage: String?
+
+    /// Identifiable 準拠。name をそのまま ID とする
+    var id: String { name }
+
+    // MARK: - 全コマンド定義
+
+    /// 利用可能なすべてのスラッシュコマンドの静的リスト
+    static let allCommands: [SlashCommandDefinition] = [
+        SlashCommandDefinition(
+            name: "me",
+            description: "アクション形式でメッセージを送信する",
+            usage: "/me <メッセージ>"
+        ),
+        SlashCommandDefinition(
+            name: "ban",
+            description: "ユーザーをBANする",
+            usage: "/ban <ユーザー名> [理由]"
+        ),
+        SlashCommandDefinition(
+            name: "unban",
+            description: "ユーザーのBANを解除する",
+            usage: "/unban <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "timeout",
+            description: "ユーザーを一時的にBANする",
+            usage: "/timeout <ユーザー名> <秒数> [理由]"
+        ),
+        SlashCommandDefinition(
+            name: "untimeout",
+            description: "ユーザーのタイムアウトを解除する",
+            usage: "/untimeout <ユーザー名>"
+        ),
+        SlashCommandDefinition(
+            name: "slow",
+            description: "スローモードを有効にする",
+            usage: "/slow [秒数]"
+        ),
+        SlashCommandDefinition(
+            name: "slowoff",
+            description: "スローモードを無効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "followers",
+            description: "フォロワー限定モードを有効にする",
+            usage: "/followers [日数]"
+        ),
+        SlashCommandDefinition(
+            name: "followersoff",
+            description: "フォロワー限定モードを無効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "subscribers",
+            description: "サブスクライバー限定モードを有効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "subscribersoff",
+            description: "サブスクライバー限定モードを無効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "emoteonly",
+            description: "エモート限定モードを有効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "emoteonlyoff",
+            description: "エモート限定モードを無効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "clear",
+            description: "チャットを全消去する",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "uniquechat",
+            description: "ユニークチャットモードを有効にする（重複メッセージを禁止）",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "uniquechatoff",
+            description: "ユニークチャットモードを無効にする",
+            usage: nil
+        ),
+        SlashCommandDefinition(
+            name: "delete",
+            description: "特定のメッセージを削除する",
+            usage: "/delete <メッセージID>"
+        ),
+    ]
+}

--- a/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
@@ -51,9 +51,10 @@ final class SlashCommandCompletionViewModel {
 
         commandRange = NSRange(location: 0, length: tokenInfo.tokenNSLength)
 
+        let lowercasedQuery = tokenInfo.query.lowercased()
         let newCandidates = SlashCommandDefinition.allCommands.filter { command in
-            if tokenInfo.query.isEmpty { return true }
-            return command.name.lowercased().hasPrefix(tokenInfo.query.lowercased())
+            if lowercasedQuery.isEmpty { return true }
+            return command.name.lowercased().hasPrefix(lowercasedQuery)
         }
         candidates = newCandidates
         selectedIndex = 0

--- a/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
@@ -1,0 +1,148 @@
+// SlashCommandCompletionViewModel.swift
+// / スラッシュコマンド補完の状態管理 ViewModel
+// / トリガーの検出、候補フィルタリング、選択操作を担当する
+
+import Foundation
+import Observation
+
+/// スラッシュコマンド補完の状態管理 ViewModel
+///
+/// 入力テキストを監視し、先頭の `/` トリガーを検出してコマンド候補リストを管理する。
+/// キーボード操作（上下移動・確定・キャンセル）のロジックも提供する。
+///
+/// - Note: `EmoteRichTextView` の `textDidChange` / `doCommandBy` から呼び出す
+/// - Note: `@` メンション補完と排他的に動作する（テキスト先頭が `/` の場合のみアクティブ化）
+@Observable
+@MainActor
+final class SlashCommandCompletionViewModel {
+
+    // MARK: - パブリックプロパティ
+
+    /// 補完がアクティブ状態かどうか
+    private(set) var isActive: Bool = false
+
+    /// 現在の候補一覧（allCommands をフィルタリングした結果）
+    private(set) var candidates: [SlashCommandDefinition] = []
+
+    /// 選択中の候補インデックス
+    private(set) var selectedIndex: Int = 0
+
+    /// テキスト内の / から現在クエリ末尾までの NSRange（UTF-16 基準、置換に使用）
+    private(set) var commandRange: NSRange?
+
+    // MARK: - パブリックメソッド
+
+    /// テキストとカーソル位置から / トークンを検出し候補を更新する
+    ///
+    /// テキストの先頭が `/` で始まり、かつ `/` の後にスペースが含まれない場合のみアクティブ化する。
+    ///
+    /// - Parameters:
+    ///   - text: 入力テキスト全体（plainText ベースの文字列）
+    ///   - cursorPosition: カーソル位置（plainText 上の Character 数）
+    func updateFromText(_ text: String, cursorPosition: Int) {
+        let clampedPosition = max(0, min(cursorPosition, text.count))
+        let cursorIndex = text.index(text.startIndex, offsetBy: clampedPosition)
+        let textUpToCursor = String(text[..<cursorIndex])
+
+        guard let tokenInfo = findSlashToken(in: textUpToCursor) else {
+            deactivate()
+            return
+        }
+
+        commandRange = NSRange(location: 0, length: tokenInfo.tokenNSLength)
+
+        let newCandidates = SlashCommandDefinition.allCommands.filter { command in
+            if tokenInfo.query.isEmpty { return true }
+            return command.name.lowercased().hasPrefix(tokenInfo.query.lowercased())
+        }
+        candidates = newCandidates
+        selectedIndex = 0
+        isActive = true
+    }
+
+    /// 選択インデックスを移動する
+    ///
+    /// 候補リストの境界でクランプする（ラップしない）。
+    ///
+    /// - Parameter offset: 移動量（正: 下、負: 上）
+    func moveSelection(by offset: Int) {
+        guard !candidates.isEmpty else { return }
+        selectedIndex = max(0, min(candidates.count - 1, selectedIndex + offset))
+    }
+
+    /// 選択インデックスを直接指定する
+    ///
+    /// 範囲外の値はクランプする。
+    ///
+    /// - Parameter index: 設定するインデックス
+    func setSelection(to index: Int) {
+        guard !candidates.isEmpty else { return }
+        selectedIndex = max(0, min(candidates.count - 1, index))
+    }
+
+    /// 選択中の候補を確定し、挿入文字列を返す
+    ///
+    /// - Returns: `/command ` 形式の文字列。候補が空の場合は `nil`
+    func confirmSelection() -> String? {
+        guard isActive, !candidates.isEmpty, selectedIndex < candidates.count else {
+            return nil
+        }
+        let candidate = candidates[selectedIndex]
+        deactivate()
+        return "/\(candidate.name) "
+    }
+
+    /// 補完をキャンセルしてアクティブ状態を解除する
+    func cancel() {
+        deactivate()
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// アクティブ状態を解除してリセットする
+    private func deactivate() {
+        isActive = false
+        candidates = []
+        selectedIndex = 0
+        commandRange = nil
+    }
+
+    /// カーソル前のテキストからスラッシュトークンを検出する
+    ///
+    /// テキストの先頭が `/` で始まり、`/` の後にスペースが含まれない場合のみトークンとして認識する。
+    ///
+    /// - Parameter textUpToCursor: カーソルまでのテキスト
+    /// - Returns: トークン情報。スラッシュコマンドが見つからない場合は `nil`
+    private func findSlashToken(in textUpToCursor: String) -> SlashTokenInfo? {
+        // テキスト先頭が / で始まる場合のみトリガー
+        guard textUpToCursor.hasPrefix("/") else {
+            return nil
+        }
+
+        // / 以降のクエリ文字列を取得（先頭の / を除く）
+        let afterSlash = String(textUpToCursor.dropFirst())
+
+        // クエリにホワイトスペースが含まれる場合はトークン終了（引数入力フェーズ）
+        guard !afterSlash.contains(where: { $0.isWhitespace }) else {
+            return nil
+        }
+
+        // "/" は BMP 文字で常に 1 UTF-16 code unit
+        let tokenNSLength = 1 + afterSlash.utf16.count
+
+        return SlashTokenInfo(
+            query: afterSlash,
+            tokenNSLength: tokenNSLength
+        )
+    }
+}
+
+// MARK: - 内部型
+
+/// スラッシュトークンの検出結果
+private struct SlashTokenInfo {
+    /// / 以降のクエリ文字列（例: "ban", ""）
+    let query: String
+    /// トークン全体の UTF-16 長さ（/ + クエリ）
+    let tokenNSLength: Int
+}

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -26,11 +26,17 @@ struct ChatInputBar: View {
     /// `@State` プロパティは init 引数で初期値を設定することで不要な再作成を防ぐ。
     @State private var mentionCompletionVM: MentionCompletionViewModel
 
+    /// / スラッシュコマンド補完の状態管理 ViewModel
+    @State private var slashCommandCompletionVM: SlashCommandCompletionViewModel
+
     init(viewModel: ChatViewModel, authState: AuthState) {
         self.viewModel = viewModel
         self.authState = authState
         self._mentionCompletionVM = State(
             initialValue: MentionCompletionViewModel(mentionStore: viewModel.mentionStore)
+        )
+        self._slashCommandCompletionVM = State(
+            initialValue: SlashCommandCompletionViewModel()
         )
     }
 
@@ -158,7 +164,8 @@ struct ChatInputBar: View {
                 emoteStore: viewModel.emoteStore,
                 onSubmit: submit,
                 isDisabled: !viewModel.canSendMessage,
-                mentionCompletionViewModel: mentionCompletionVM
+                mentionCompletionViewModel: mentionCompletionVM,
+                slashCommandCompletionViewModel: slashCommandCompletionVM
             )
             .frame(height: Self.inputFieldHeight)
             .padding(.leading, 14)
@@ -227,6 +234,22 @@ struct ChatInputBar: View {
                         viewModel.clearSendError()
                     }
                     .id(error)
+            }
+        }
+        // / スラッシュコマンド補完ドロップダウン（入力バーの上に表示、@メンション補完と排他的）
+        .overlay(alignment: .top) {
+            if slashCommandCompletionVM.isActive && !slashCommandCompletionVM.candidates.isEmpty {
+                SlashCommandCompletionView(
+                    candidates: slashCommandCompletionVM.candidates,
+                    selectedIndex: slashCommandCompletionVM.selectedIndex
+                ) { index in
+                    confirmSlashCommandCandidate(at: index)
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .offset(y: -min(
+                    CGFloat(slashCommandCompletionVM.candidates.count),
+                    CGFloat(SlashCommandCompletionView.maxVisibleRows)
+                ) * SlashCommandCompletionView.rowHeight)
             }
         }
         // @メンション補完ドロップダウン（入力バーの上に表示）
@@ -303,6 +326,24 @@ struct ChatInputBar: View {
         draft = ""
         Task {
             try? await viewModel.sendMessage(text)
+        }
+    }
+
+    /// クリックで / スラッシュコマンド候補を選択確定する
+    ///
+    /// - Parameter index: 選択した候補のインデックス
+    private func confirmSlashCommandCandidate(at index: Int) {
+        slashCommandCompletionVM.setSelection(to: index)
+        // commandRange は confirmSelection() の前に取得する（確定後に nil になるため）
+        let range = slashCommandCompletionVM.commandRange
+        guard let insertion = slashCommandCompletionVM.confirmSelection() else { return }
+
+        // draft の / トークン部分を挿入文字列で置換する
+        if let range {
+            let nsString = draft as NSString
+            draft = nsString.replacingCharacters(in: range, with: insertion)
+        } else {
+            draft += insertion
         }
     }
 

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -237,8 +237,11 @@ struct ChatInputBar: View {
             }
         }
         // / スラッシュコマンド補完ドロップダウン（入力バーの上に表示、@メンション補完と排他的）
+        // slashCommandCompletionVM.isActive が true の場合 mentionCompletionVM は必ず非アクティブだが、
+        // ビュー層でも明示的に排他制御して安全性を高める
         .overlay(alignment: .top) {
-            if slashCommandCompletionVM.isActive && !slashCommandCompletionVM.candidates.isEmpty {
+            if slashCommandCompletionVM.isActive && !slashCommandCompletionVM.candidates.isEmpty
+                && !mentionCompletionVM.isActive {
                 SlashCommandCompletionView(
                     candidates: slashCommandCompletionVM.candidates,
                     selectedIndex: slashCommandCompletionVM.selectedIndex
@@ -252,9 +255,10 @@ struct ChatInputBar: View {
                 ) * SlashCommandCompletionView.rowHeight)
             }
         }
-        // @メンション補完ドロップダウン（入力バーの上に表示）
+        // @メンション補完ドロップダウン（入力バーの上に表示、スラッシュ補完と排他的）
         .overlay(alignment: .top) {
-            if mentionCompletionVM.isActive && !mentionCompletionVM.candidates.isEmpty {
+            if mentionCompletionVM.isActive && !mentionCompletionVM.candidates.isEmpty
+                && !slashCommandCompletionVM.isActive {
                 MentionCompletionView(
                     candidates: mentionCompletionVM.candidates,
                     selectedIndex: mentionCompletionVM.selectedIndex

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -249,10 +249,8 @@ struct ChatInputBar: View {
                     confirmSlashCommandCandidate(at: index)
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                .offset(y: -min(
-                    CGFloat(slashCommandCompletionVM.candidates.count),
-                    CGFloat(SlashCommandCompletionView.maxVisibleRows)
-                ) * SlashCommandCompletionView.rowHeight)
+                // listHeight(for:) を使って Divider 高さも含んだ正確なオフセットを計算する
+                .offset(y: -SlashCommandCompletionView.listHeight(for: slashCommandCompletionVM.candidates.count))
             }
         }
         // @メンション補完ドロップダウン（入力バーの上に表示、スラッシュ補完と排他的）
@@ -266,10 +264,8 @@ struct ChatInputBar: View {
                     confirmMentionCandidate(at: index)
                 }
                 .fixedSize(horizontal: false, vertical: true)
-                .offset(y: -min(
-                    CGFloat(mentionCompletionVM.candidates.count),
-                    CGFloat(MentionCompletionView.maxVisibleRows)
-                ) * MentionCompletionView.rowHeight)
+                // listHeight(for:) を使って Divider 高さも含んだ正確なオフセットを計算する
+                .offset(y: -MentionCompletionView.listHeight(for: mentionCompletionVM.candidates.count))
             }
         }
     }

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -475,35 +475,25 @@ struct EmoteRichTextView: NSViewRepresentable {
         }
 
         /// / スラッシュコマンドトークンを補完候補で置換し draft を更新する
-        ///
-        /// - Parameters:
-        ///   - insertion: 挿入する文字列（`/command ` 形式）
-        ///   - range: テキスト内の置換対象範囲（/ から現在クエリ末尾まで）
-        ///   - textView: 対象の NSTextView
         private func replaceSlashCommandToken(with insertion: String, range: NSRange, in textView: NSTextView) {
-            let nsRange = EmoteRichTextView.nsViewRange(from: range, in: textView.attributedString())
-            let nsString = textView.string as NSString
-            guard nsRange.location <= nsString.length,
-                  nsRange.location + nsRange.length <= nsString.length else { return }
-
-            isUpdatingFromBinding = true
-            textView.insertText(insertion, replacementRange: nsRange)
-
-            let plain = EmoteRichTextView.plainText(from: textView.attributedString())
-            if draft != plain {
-                draft = plain
-            }
+            replaceCompletionToken(with: insertion, range: range, in: textView)
         }
 
         /// @メンショントークンを補完候補で置換し draft を更新する
+        private func replaceMentionToken(with insertion: String, range: NSRange, in textView: NSTextView) {
+            replaceCompletionToken(with: insertion, range: range, in: textView)
+        }
+
+        /// 補完トークンを挿入文字列で置換し draft を更新する共通ヘルパー
+        ///
+        /// plainText 座標の NSRange を UTF-16 座標に変換し NSTextView に挿入する。
+        /// `isUpdatingFromBinding` を設定して `textDidChange` の無限ループを防ぐ。
         ///
         /// - Parameters:
-        ///   - insertion: 挿入する文字列（`@username ` 形式）
-        ///   - range: テキスト内の置換対象範囲（@ から現在クエリ末尾まで）
+        ///   - insertion: 挿入する文字列（例: `@username ` / `/command `）
+        ///   - range: テキスト内の置換対象範囲（plainText 座標）
         ///   - textView: 対象の NSTextView
-        private func replaceMentionToken(with insertion: String, range: NSRange, in textView: NSTextView) {
-            // mentionRange は plainText 座標（Character 数）で保持されているため
-            // NSTextView.insertText の replacementRange に渡す前に UTF-16 座標に変換する
+        private func replaceCompletionToken(with insertion: String, range: NSRange, in textView: NSTextView) {
             let nsRange = EmoteRichTextView.nsViewRange(from: range, in: textView.attributedString())
             let nsString = textView.string as NSString
             guard nsRange.location <= nsString.length,
@@ -512,7 +502,6 @@ struct EmoteRichTextView: NSViewRepresentable {
             isUpdatingFromBinding = true
             textView.insertText(insertion, replacementRange: nsRange)
 
-            // draft を更新
             let plain = EmoteRichTextView.plainText(from: textView.attributedString())
             if draft != plain {
                 draft = plain

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -287,7 +287,13 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// `nonisolated(unsafe)` は不要。プロパティは常に MainActor 上でアクセスされる。
         private var frameUpdateObserver: NSObjectProtocol?
 
-        init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void, mentionCompletionViewModel: MentionCompletionViewModel, slashCommandCompletionViewModel: SlashCommandCompletionViewModel) {
+        init(
+            draft: Binding<String>,
+            emoteStore: EmoteStore,
+            onSubmit: @escaping () -> Void,
+            mentionCompletionViewModel: MentionCompletionViewModel,
+            slashCommandCompletionViewModel: SlashCommandCompletionViewModel
+        ) {
             self._draft = draft
             self.emoteStore = emoteStore
             self.onSubmit = onSubmit
@@ -390,70 +396,35 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// - Note: 入力欄は1行固定高さのため、Shift+Enter による改行挿入は無効化している。
         ///   改行を挿入しても表示領域外にクリップされるだけで混乱を招くため、両キーで送信する。
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-            // スラッシュコマンド補完アクティブ中のキーハンドリング（優先度: メンション補完より高い）
-            if slashCommandCompletionViewModel.isActive {
-                if commandSelector == #selector(NSResponder.moveUp(_:)) {
-                    slashCommandCompletionViewModel.moveSelection(by: -1)
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.moveDown(_:)) {
-                    slashCommandCompletionViewModel.moveSelection(by: 1)
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-                    slashCommandCompletionViewModel.cancel()
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.insertNewline(_:))
-                    || commandSelector == #selector(NSResponder.insertTab(_:)) {
-                    // Enter / Tab: 候補確定
-                    // confirmSelection() は内部で commandRange を nil にリセットするため、先に取得しておく
-                    let range = slashCommandCompletionViewModel.commandRange
-                    let insertion = slashCommandCompletionViewModel.confirmSelection()
-                    if let insertion, let range {
-                        replaceSlashCommandToken(with: insertion, range: range, in: textView)
-                    } else {
-                        slashCommandCompletionViewModel.cancel()
-                        onSubmit()
-                    }
-                    return true
-                }
-            }
+            // スラッシュコマンド補完が優先（テキスト先頭 / のケース）
+            if slashCommandCompletionViewModel.isActive,
+               let handled = handleCompletionCommand(
+                commandSelector,
+                confirm: {
+                    guard let range = slashCommandCompletionViewModel.commandRange,
+                          let insertion = slashCommandCompletionViewModel.confirmSelection()
+                    else { return nil }
+                    return (insertion, range)
+                },
+                cancel: { slashCommandCompletionViewModel.cancel() },
+                move: { slashCommandCompletionViewModel.moveSelection(by: $0) },
+                replace: { replaceSlashCommandToken(with: $0, range: $1, in: textView) }
+               ) { return handled }
 
-            // @メンション補完アクティブ中のキーハンドリング
-            if mentionCompletionViewModel.isActive {
-                if commandSelector == #selector(NSResponder.moveUp(_:)) {
-                    // 上キー: 前の候補に移動
-                    mentionCompletionViewModel.moveSelection(by: -1)
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.moveDown(_:)) {
-                    // 下キー: 次の候補に移動
-                    mentionCompletionViewModel.moveSelection(by: 1)
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
-                    // Esc: 補完キャンセル
-                    mentionCompletionViewModel.cancel()
-                    return true
-                }
-                if commandSelector == #selector(NSResponder.insertNewline(_:))
-                    || commandSelector == #selector(NSResponder.insertTab(_:)) {
-                    // Enter / Tab: 候補確定
-                    // confirmSelection() は内部で mentionRange を nil にリセットするため、先に取得しておく
-                    let range = mentionCompletionViewModel.mentionRange
-                    let insertion = mentionCompletionViewModel.confirmSelection()
-                    if let insertion, let range {
-                        // 候補が選択されていた場合: トークンを置換
-                        replaceMentionToken(with: insertion, range: range, in: textView)
-                    } else {
-                        // 候補が空または選択なしの場合: 補完をキャンセルして通常送信へ
-                        mentionCompletionViewModel.cancel()
-                        onSubmit()
-                    }
-                    return true
-                }
-            }
+            // @メンション補完
+            if mentionCompletionViewModel.isActive,
+               let handled = handleCompletionCommand(
+                commandSelector,
+                confirm: {
+                    guard let range = mentionCompletionViewModel.mentionRange,
+                          let insertion = mentionCompletionViewModel.confirmSelection()
+                    else { return nil }
+                    return (insertion, range)
+                },
+                cancel: { mentionCompletionViewModel.cancel() },
+                move: { mentionCompletionViewModel.moveSelection(by: $0) },
+                replace: { replaceMentionToken(with: $0, range: $1, in: textView) }
+               ) { return handled }
 
             if commandSelector == #selector(NSResponder.insertNewline(_:)) {
                 // Enter / Shift+Enter いずれも送信（1行固定のため改行を許可しない）
@@ -461,6 +432,46 @@ struct EmoteRichTextView: NSViewRepresentable {
                 return true
             }
             return false
+        }
+
+        /// 補完共通のキーボードコマンドを処理する
+        ///
+        /// 上下移動・Esc・Enter/Tab を処理して `Bool?` を返す。
+        /// 処理した場合は `true`/`false`、処理対象外のセレクタは `nil` を返す。
+        ///
+        /// - Parameters:
+        ///   - commandSelector: NSTextView から渡されるセレクタ
+        ///   - confirm: 候補を確定する処理（確定文字列と置換範囲のタプル、または nil を返す）
+        ///   - cancel: 補完をキャンセルする処理
+        ///   - move: 選択インデックスを移動する処理（引数は offset）
+        ///   - replace: テキストを置換する処理
+        private func handleCompletionCommand(
+            _ commandSelector: Selector,
+            confirm: () -> (String, NSRange)?,
+            cancel: () -> Void,
+            move: (Int) -> Void,
+            replace: (String, NSRange) -> Void
+        ) -> Bool? {
+            if commandSelector == #selector(NSResponder.moveUp(_:)) {
+                move(-1); return true
+            }
+            if commandSelector == #selector(NSResponder.moveDown(_:)) {
+                move(1); return true
+            }
+            if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                cancel(); return true
+            }
+            if commandSelector == #selector(NSResponder.insertNewline(_:))
+                || commandSelector == #selector(NSResponder.insertTab(_:)) {
+                if let (insertion, range) = confirm() {
+                    replace(insertion, range)
+                } else {
+                    cancel()
+                    onSubmit()
+                }
+                return true
+            }
+            return nil
         }
 
         /// / スラッシュコマンドトークンを補完候補で置換し draft を更新する

--- a/Sources/TwitchChat/Views/EmoteRichTextView.swift
+++ b/Sources/TwitchChat/Views/EmoteRichTextView.swift
@@ -30,6 +30,9 @@ struct EmoteRichTextView: NSViewRepresentable {
     /// @メンション補完の状態管理 ViewModel
     var mentionCompletionViewModel: MentionCompletionViewModel
 
+    /// / スラッシュコマンド補完の状態管理 ViewModel
+    var slashCommandCompletionViewModel: SlashCommandCompletionViewModel
+
     // MARK: - NSViewRepresentable
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -81,7 +84,13 @@ struct EmoteRichTextView: NSViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(draft: $draft, emoteStore: emoteStore, onSubmit: onSubmit, mentionCompletionViewModel: mentionCompletionViewModel)
+        Coordinator(
+            draft: $draft,
+            emoteStore: emoteStore,
+            onSubmit: onSubmit,
+            mentionCompletionViewModel: mentionCompletionViewModel,
+            slashCommandCompletionViewModel: slashCommandCompletionViewModel
+        )
     }
 
     /// ビュー破棄前に呼ばれるクリーンアップ（@MainActor 上で実行される）
@@ -267,6 +276,7 @@ struct EmoteRichTextView: NSViewRepresentable {
         let emoteStore: EmoteStore
         let onSubmit: () -> Void
         let mentionCompletionViewModel: MentionCompletionViewModel
+        let slashCommandCompletionViewModel: SlashCommandCompletionViewModel
 
         /// binding 側からのリセット中フラグ（無限ループ防止）
         var isUpdatingFromBinding = false
@@ -277,11 +287,12 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// `nonisolated(unsafe)` は不要。プロパティは常に MainActor 上でアクセスされる。
         private var frameUpdateObserver: NSObjectProtocol?
 
-        init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void, mentionCompletionViewModel: MentionCompletionViewModel) {
+        init(draft: Binding<String>, emoteStore: EmoteStore, onSubmit: @escaping () -> Void, mentionCompletionViewModel: MentionCompletionViewModel, slashCommandCompletionViewModel: SlashCommandCompletionViewModel) {
             self._draft = draft
             self.emoteStore = emoteStore
             self.onSubmit = onSubmit
             self.mentionCompletionViewModel = mentionCompletionViewModel
+            self.slashCommandCompletionViewModel = slashCommandCompletionViewModel
         }
 
         /// アニメーションフレーム更新通知を購読し、textView に再描画を要求する
@@ -356,14 +367,22 @@ struct EmoteRichTextView: NSViewRepresentable {
                 draft = plain
             }
 
-            // @メンション補完の候補を更新する
             // NSTextView の UTF-16 カーソル位置を plainText の文字数インデックスに変換して渡す
             let nsViewOffset = textView.selectedRange().location
             let plainCursorPosition = EmoteRichTextView.plainTextCursorPosition(
                 from: nsViewOffset,
                 in: textView.attributedString()
             )
-            mentionCompletionViewModel.updateFromText(plain, cursorPosition: plainCursorPosition)
+
+            // スラッシュコマンド補完を先に更新する（テキスト先頭 / の場合のみアクティブ化）
+            slashCommandCompletionViewModel.updateFromText(plain, cursorPosition: plainCursorPosition)
+
+            // スラッシュ補完がアクティブな場合はメンション補完をスキップする（排他制御）
+            if !slashCommandCompletionViewModel.isActive {
+                mentionCompletionViewModel.updateFromText(plain, cursorPosition: plainCursorPosition)
+            } else {
+                mentionCompletionViewModel.cancel()
+            }
         }
 
         /// Enter / Shift+Enter で送信、補完アクティブ時は上下キー・Esc も処理する
@@ -371,7 +390,37 @@ struct EmoteRichTextView: NSViewRepresentable {
         /// - Note: 入力欄は1行固定高さのため、Shift+Enter による改行挿入は無効化している。
         ///   改行を挿入しても表示領域外にクリップされるだけで混乱を招くため、両キーで送信する。
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
-            // 補完アクティブ中のキーハンドリング
+            // スラッシュコマンド補完アクティブ中のキーハンドリング（優先度: メンション補完より高い）
+            if slashCommandCompletionViewModel.isActive {
+                if commandSelector == #selector(NSResponder.moveUp(_:)) {
+                    slashCommandCompletionViewModel.moveSelection(by: -1)
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.moveDown(_:)) {
+                    slashCommandCompletionViewModel.moveSelection(by: 1)
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+                    slashCommandCompletionViewModel.cancel()
+                    return true
+                }
+                if commandSelector == #selector(NSResponder.insertNewline(_:))
+                    || commandSelector == #selector(NSResponder.insertTab(_:)) {
+                    // Enter / Tab: 候補確定
+                    // confirmSelection() は内部で commandRange を nil にリセットするため、先に取得しておく
+                    let range = slashCommandCompletionViewModel.commandRange
+                    let insertion = slashCommandCompletionViewModel.confirmSelection()
+                    if let insertion, let range {
+                        replaceSlashCommandToken(with: insertion, range: range, in: textView)
+                    } else {
+                        slashCommandCompletionViewModel.cancel()
+                        onSubmit()
+                    }
+                    return true
+                }
+            }
+
+            // @メンション補完アクティブ中のキーハンドリング
             if mentionCompletionViewModel.isActive {
                 if commandSelector == #selector(NSResponder.moveUp(_:)) {
                     // 上キー: 前の候補に移動
@@ -412,6 +461,27 @@ struct EmoteRichTextView: NSViewRepresentable {
                 return true
             }
             return false
+        }
+
+        /// / スラッシュコマンドトークンを補完候補で置換し draft を更新する
+        ///
+        /// - Parameters:
+        ///   - insertion: 挿入する文字列（`/command ` 形式）
+        ///   - range: テキスト内の置換対象範囲（/ から現在クエリ末尾まで）
+        ///   - textView: 対象の NSTextView
+        private func replaceSlashCommandToken(with insertion: String, range: NSRange, in textView: NSTextView) {
+            let nsRange = EmoteRichTextView.nsViewRange(from: range, in: textView.attributedString())
+            let nsString = textView.string as NSString
+            guard nsRange.location <= nsString.length,
+                  nsRange.location + nsRange.length <= nsString.length else { return }
+
+            isUpdatingFromBinding = true
+            textView.insertText(insertion, replacementRange: nsRange)
+
+            let plain = EmoteRichTextView.plainText(from: textView.attributedString())
+            if draft != plain {
+                draft = plain
+            }
         }
 
         /// @メンショントークンを補完候補で置換し draft を更新する

--- a/Sources/TwitchChat/Views/MentionCompletionView.swift
+++ b/Sources/TwitchChat/Views/MentionCompletionView.swift
@@ -23,16 +23,26 @@ struct MentionCompletionView: View {
     static let rowHeight: CGFloat = 32
 
     /// Divider の高さ（1pt）
-    private static let dividerHeight: CGFloat = 1
+    static let dividerHeight: CGFloat = 1
 
     /// 最大表示件数（ChatInputBar のオフセット計算と共有するため internal）
     static let maxVisibleRows: Int = 6
 
+    /// 候補数からドロップダウンの正確な表示高さを計算する
+    ///
+    /// Divider 高さを含む正確な高さを返す。`ChatInputBar` の `.offset` 計算と同一の式を使うことで
+    /// ビューの frame とオフセットのズレを防ぐ。
+    ///
+    /// - Parameter candidateCount: 表示する候補の件数
+    /// - Returns: ドロップダウンの高さ（pt）
+    static func listHeight(for candidateCount: Int) -> CGFloat {
+        let visibleCount = min(candidateCount, maxVisibleRows)
+        return CGFloat(visibleCount) * rowHeight
+            + CGFloat(max(0, visibleCount - 1)) * dividerHeight
+    }
+
     var body: some View {
-        let visibleCount = min(candidates.count, Self.maxVisibleRows)
-        // Divider を含めた正確な高さ計算（最後の行には Divider なし）
-        let listHeight = CGFloat(visibleCount) * Self.rowHeight
-            + CGFloat(max(0, visibleCount - 1)) * Self.dividerHeight
+        let listHeight = Self.listHeight(for: candidates.count)
 
         ScrollView {
             LazyVStack(spacing: 0) {

--- a/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
+++ b/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
@@ -1,0 +1,94 @@
+// SlashCommandCompletionView.swift
+// スラッシュコマンド補完のドロップダウン候補リスト表示ビュー
+// 入力バーの上に重ねて表示し、利用可能なコマンド一覧を表示する
+
+import SwiftUI
+
+/// スラッシュコマンド補完候補のドロップダウンビュー
+///
+/// `ChatInputBar` の `inputForm` に `.overlay` で重ね、入力バーの上方向に表示する。
+/// クリックで候補を選択確定できる。キーボード操作は `EmoteRichTextView` が担当する。
+struct SlashCommandCompletionView: View {
+
+    /// 表示する候補一覧
+    var candidates: [SlashCommandDefinition]
+
+    /// 現在選択中の候補インデックス
+    var selectedIndex: Int
+
+    /// 候補を選択したときのコールバック（インデックスを渡す）
+    var onSelect: (Int) -> Void
+
+    /// 1行の高さ（ChatInputBar のオフセット計算と共有するため internal）
+    static let rowHeight: CGFloat = 32
+
+    /// Divider の高さ（1pt）
+    private static let dividerHeight: CGFloat = 1
+
+    /// 最大表示件数（ChatInputBar のオフセット計算と共有するため internal）
+    static let maxVisibleRows: Int = 6
+
+    var body: some View {
+        let visibleCount = min(candidates.count, Self.maxVisibleRows)
+        // Divider を含めた正確な高さ計算（最後の行には Divider なし）
+        let listHeight = CGFloat(visibleCount) * Self.rowHeight
+            + CGFloat(max(0, visibleCount - 1)) * Self.dividerHeight
+
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(candidates.enumerated()), id: \.element.id) { index, candidate in
+                    candidateRow(candidate: candidate, index: index)
+                }
+            }
+        }
+        .frame(height: listHeight)
+        .background(Color(.windowBackgroundColor))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.separatorColor), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: -2)
+    }
+
+    // MARK: - サブビュー
+
+    /// 候補1件分の行ビュー
+    @ViewBuilder
+    private func candidateRow(candidate: SlashCommandDefinition, index: Int) -> some View {
+        let isSelected = index == selectedIndex
+        Button {
+            onSelect(index)
+        } label: {
+            HStack(spacing: 8) {
+                // コマンド名と説明文
+                VStack(alignment: .leading, spacing: 1) {
+                    // コマンド名: monospace 太字で表示
+                    Text("/\(candidate.name)")
+                        .font(.system(size: 13, weight: .bold, design: .monospaced))
+                        .foregroundStyle(isSelected ? Color.white : Color.primary)
+                        .lineLimit(1)
+
+                    // 説明文: secondary カラーで表示
+                    Text(candidate.description)
+                        .font(.system(size: 11))
+                        .foregroundStyle(isSelected ? Color.white.opacity(0.8) : Color.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+            }
+            .frame(height: Self.rowHeight)
+            .padding(.horizontal, 12)
+            .background(isSelected ? Color.accentColor : Color.clear)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("/\(candidate.name): \(candidate.description)")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+        if index < candidates.count - 1 {
+            Divider()
+                .padding(.horizontal, 8)
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
+++ b/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
@@ -34,10 +34,19 @@ struct SlashCommandCompletionView: View {
         let listHeight = CGFloat(visibleCount) * Self.rowHeight
             + CGFloat(max(0, visibleCount - 1)) * Self.dividerHeight
 
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                ForEach(Array(candidates.enumerated()), id: \.element.id) { index, candidate in
-                    candidateRow(candidate: candidate, index: index)
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(Array(candidates.enumerated()), id: \.element.id) { index, candidate in
+                        candidateRow(candidate: candidate, index: index)
+                            .id(candidate.id)
+                    }
+                }
+            }
+            .onChange(of: selectedIndex) { _, newIndex in
+                guard newIndex < candidates.count else { return }
+                withAnimation(.easeInOut(duration: 0.1)) {
+                    proxy.scrollTo(candidates[newIndex].id, anchor: .center)
                 }
             }
         }

--- a/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
+++ b/Sources/TwitchChat/Views/SlashCommandCompletionView.swift
@@ -23,16 +23,26 @@ struct SlashCommandCompletionView: View {
     static let rowHeight: CGFloat = 32
 
     /// Divider の高さ（1pt）
-    private static let dividerHeight: CGFloat = 1
+    static let dividerHeight: CGFloat = 1
 
     /// 最大表示件数（ChatInputBar のオフセット計算と共有するため internal）
     static let maxVisibleRows: Int = 6
 
+    /// 候補数からドロップダウンの正確な表示高さを計算する
+    ///
+    /// Divider 高さを含む正確な高さを返す。`ChatInputBar` の `.offset` 計算と同一の式を使うことで
+    /// ビューの frame とオフセットのズレを防ぐ。
+    ///
+    /// - Parameter candidateCount: 表示する候補の件数
+    /// - Returns: ドロップダウンの高さ（pt）
+    static func listHeight(for candidateCount: Int) -> CGFloat {
+        let visibleCount = min(candidateCount, maxVisibleRows)
+        return CGFloat(visibleCount) * rowHeight
+            + CGFloat(max(0, visibleCount - 1)) * dividerHeight
+    }
+
     var body: some View {
-        let visibleCount = min(candidates.count, Self.maxVisibleRows)
-        // Divider を含めた正確な高さ計算（最後の行には Divider なし）
-        let listHeight = CGFloat(visibleCount) * Self.rowHeight
-            + CGFloat(max(0, visibleCount - 1)) * Self.dividerHeight
+        let listHeight = Self.listHeight(for: candidates.count)
 
         ScrollViewReader { proxy in
             ScrollView {

--- a/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
@@ -1,0 +1,296 @@
+// SlashCommandCompletionViewModelTests.swift
+// SlashCommandCompletionViewModel の / トリガー検出・候補管理・選択操作のテスト
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+@Suite("SlashCommandCompletionViewModelTests")
+struct SlashCommandCompletionViewModelTests {
+
+    // MARK: - isActive（アクティブ化・非アクティブ化）
+
+    @Test("/ を単独入力するとアクティブ状態になる")
+    @MainActor
+    func testSlashAloneActivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+
+        #expect(vm.isActive == true)
+    }
+
+    @Test("/ban と入力するとアクティブ状態になる")
+    @MainActor
+    func testSlashCommandActivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/ban", cursorPosition: 4)
+
+        #expect(vm.isActive == true)
+    }
+
+    @Test("テキスト途中の / はトリガーにならない（例: hello /ban）")
+    @MainActor
+    func testSlashInMiddleDoesNotActivate() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // テキストの先頭でない / はコマンドとして認識しない
+        vm.updateFromText("hello /ban", cursorPosition: 10)
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("スラッシュのないテキストではアクティブ状態にならない")
+    @MainActor
+    func testNoSlashDoesNotActivate() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("普通のメッセージ", cursorPosition: 8)
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("/ の後にスペースが入ると補完が終了する")
+    @MainActor
+    func testSlashFollowedBySpaceDeactivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // "/ban " のようにスペースが入った場合は補完終了
+        vm.updateFromText("/ban ", cursorPosition: 5)
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("/ を削除するとアクティブ状態が解除される")
+    @MainActor
+    func testDeletingSlashDeactivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/ba", cursorPosition: 3)
+        #expect(vm.isActive == true)
+
+        // / を削除してテキストを更新
+        vm.updateFromText("ba", cursorPosition: 2)
+        #expect(vm.isActive == false)
+    }
+
+    @Test("cancel() を呼ぶとアクティブ状態が解除される")
+    @MainActor
+    func testCancelDeactivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/ban", cursorPosition: 4)
+        #expect(vm.isActive == true)
+
+        vm.cancel()
+        #expect(vm.isActive == false)
+    }
+
+    // MARK: - candidates（候補フィルタリング）
+
+    @Test("/ のみ入力した場合は全コマンドが候補に表示される")
+    @MainActor
+    func testSlashAloneShowsAllCandidates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+
+        #expect(vm.candidates.count == SlashCommandDefinition.allCommands.count)
+    }
+
+    @Test("/ba と入力すると ban が候補に表示される")
+    @MainActor
+    func testFilteredCandidatesBan() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/ba", cursorPosition: 3)
+
+        let names = vm.candidates.map { $0.name }
+        #expect(names.contains("ban"))
+    }
+
+    @Test("/em と入力すると emoteonly と emoteonlyoff が候補に表示される")
+    @MainActor
+    func testFilteredCandidatesEmote() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/em", cursorPosition: 3)
+
+        let names = vm.candidates.map { $0.name }
+        #expect(names.contains("emoteonly"))
+        #expect(names.contains("emoteonlyoff"))
+    }
+
+    @Test("マッチしないクエリでは候補が空になる")
+    @MainActor
+    func testNoMatchCandidatesEmpty() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/存在しないコマンド", cursorPosition: 9)
+
+        #expect(vm.candidates.isEmpty)
+    }
+
+    // MARK: - selectedIndex（選択操作）
+
+    @Test("初期状態の selectedIndex は 0 である")
+    @MainActor
+    func testInitialSelectedIndex() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("moveSelection(by: 1) で次の候補に移動する")
+    @MainActor
+    func testMoveSelectionDown() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.moveSelection(by: 1)
+
+        #expect(vm.selectedIndex == 1)
+    }
+
+    @Test("moveSelection(by: -1) で前の候補に移動する")
+    @MainActor
+    func testMoveSelectionUp() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.moveSelection(by: 1) // インデックス 1 に移動
+        vm.moveSelection(by: -1) // インデックス 0 に戻る
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("先頭でさらに上に移動しようとしてもクランプされる（0 以下にならない）")
+    @MainActor
+    func testSelectionClampedAtTop() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.moveSelection(by: -1)
+
+        #expect(vm.selectedIndex == 0)
+    }
+
+    @Test("末尾でさらに下に移動しようとしてもクランプされる（候補数を超えない）")
+    @MainActor
+    func testSelectionClampedAtBottom() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.moveSelection(by: 1000)
+
+        #expect(vm.selectedIndex == SlashCommandDefinition.allCommands.count - 1)
+    }
+
+    @Test("setSelection(to:) で直接インデックスを指定できる")
+    @MainActor
+    func testSetSelectionDirectly() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.setSelection(to: 2)
+
+        #expect(vm.selectedIndex == 2)
+    }
+
+    @Test("setSelection(to:) は範囲外の値をクランプする")
+    @MainActor
+    func testSetSelectionClamped() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        vm.setSelection(to: 1000)
+
+        #expect(vm.selectedIndex == SlashCommandDefinition.allCommands.count - 1)
+    }
+
+    // MARK: - confirmSelection（確定）
+
+    @Test("confirmSelection() は選択中の候補の /command 形式の文字列を返す")
+    @MainActor
+    func testConfirmSelectionReturnsCommand() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // "/me" でフィルタリングしてme コマンドを先頭に
+        vm.updateFromText("/me", cursorPosition: 3)
+        // me コマンドが先頭（インデックス0）に来るはず
+        vm.setSelection(to: 0)
+
+        let result = vm.confirmSelection()
+
+        // 先頭の候補（me）が "/me " の形式で返る
+        #expect(result == "/me ")
+    }
+
+    @Test("confirmSelection() は選択確定後に非アクティブ状態になる")
+    @MainActor
+    func testConfirmSelectionDeactivates() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+        _ = vm.confirmSelection()
+
+        #expect(vm.isActive == false)
+    }
+
+    @Test("候補が空の場合 confirmSelection() は nil を返す")
+    @MainActor
+    func testConfirmSelectionWithNoCandidatesReturnsNil() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/存在しないコマンド", cursorPosition: 9)
+        let result = vm.confirmSelection()
+
+        #expect(result == nil)
+    }
+
+    @Test("2番目の候補を選択して確定すると正しいコマンドが返る")
+    @MainActor
+    func testConfirmSecondCandidate() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // "/ban" にマッチするコマンドは ban のみ
+        vm.updateFromText("/ban", cursorPosition: 4)
+
+        let result = vm.confirmSelection()
+
+        #expect(result == "/ban ")
+    }
+
+    // MARK: - commandRange（置換範囲）
+
+    @Test("commandRange は / から現在のクエリ末尾までの範囲を返す")
+    @MainActor
+    func testCommandRangeForCurrentToken() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // "/ban" と入力中、カーソルが末尾の場合
+        vm.updateFromText("/ban", cursorPosition: 4)
+
+        let range = vm.commandRange
+        #expect(range != nil)
+        // "/ban" の4文字分の範囲
+        #expect(range?.length == 4)
+        #expect(range?.location == 0)
+    }
+
+    @Test("/ のみ入力時の commandRange は length が 1 である")
+    @MainActor
+    func testCommandRangeForSlashOnly() {
+        let vm = SlashCommandCompletionViewModel()
+
+        vm.updateFromText("/", cursorPosition: 1)
+
+        let range = vm.commandRange
+        #expect(range != nil)
+        #expect(range?.length == 1)
+        #expect(range?.location == 0)
+    }
+}

--- a/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
@@ -127,7 +127,8 @@ struct SlashCommandCompletionViewModelTests {
     func testNoMatchCandidatesEmpty() {
         let vm = SlashCommandCompletionViewModel()
 
-        vm.updateFromText("/存在しないコマンド", cursorPosition: 9)
+        // "/存在しないコマンド" は "/" + 9文字 = 10文字
+        vm.updateFromText("/存在しないコマンド", cursorPosition: 10)
 
         #expect(vm.candidates.isEmpty)
     }
@@ -245,23 +246,31 @@ struct SlashCommandCompletionViewModelTests {
     func testConfirmSelectionWithNoCandidatesReturnsNil() {
         let vm = SlashCommandCompletionViewModel()
 
-        vm.updateFromText("/存在しないコマンド", cursorPosition: 9)
+        // "/存在しないコマンド" は "/" + 9文字 = 10文字
+        vm.updateFromText("/存在しないコマンド", cursorPosition: 10)
         let result = vm.confirmSelection()
 
         #expect(result == nil)
     }
 
-    @Test("2番目の候補を選択して確定すると正しいコマンドが返る")
+    @Test("/em で絞り込んだ後、2番目の候補（emoteonlyoff）を選択して確定すると正しいコマンドが返る")
     @MainActor
     func testConfirmSecondCandidate() {
         let vm = SlashCommandCompletionViewModel()
 
-        // "/ban" にマッチするコマンドは ban のみ
-        vm.updateFromText("/ban", cursorPosition: 4)
+        // "/em" にマッチするコマンドは emoteonly と emoteonlyoff の2件
+        vm.updateFromText("/em", cursorPosition: 3)
+        // インデックス1（2番目の候補）を選択
+        vm.setSelection(to: 1)
 
         let result = vm.confirmSelection()
 
-        #expect(result == "/ban ")
+        // 選択した2番目の候補が "/候補名 " の形式で返る
+        #expect(result != nil)
+        if let result {
+            #expect(result.hasPrefix("/"))
+            #expect(result.hasSuffix(" "))
+        }
     }
 
     // MARK: - commandRange（置換範囲）

--- a/Tests/TwitchChatTests/SlashCommandDefinitionTests.swift
+++ b/Tests/TwitchChatTests/SlashCommandDefinitionTests.swift
@@ -18,7 +18,13 @@ struct SlashCommandDefinitionTests {
     func testAllCommandNamesAreUnique() {
         let names = SlashCommandDefinition.allCommands.map { $0.name }
         let uniqueNames = Set(names)
-        #expect(names.count == uniqueNames.count)
+        // 重複しているコマンド名を特定してメッセージに含める
+        let duplicates = names.filter { name in names.filter { $0 == name }.count > 1 }
+        let uniqueDuplicates = Array(Set(duplicates)).sorted()
+        #expect(
+            names.count == uniqueNames.count,
+            "重複しているコマンド名: \(uniqueDuplicates.joined(separator: ", "))"
+        )
     }
 
     @Test("allCommands の各コマンドの name に先頭スラッシュが含まれないこと")
@@ -40,33 +46,20 @@ struct SlashCommandDefinitionTests {
     @Test("id は name と一致すること")
     func testIdEqualsName() {
         for command in SlashCommandDefinition.allCommands {
-            #expect(command.id == command.name)
+            #expect(
+                command.id == command.name,
+                "コマンド '\(command.name)' の id '\(command.id)' が name と一致しません"
+            )
         }
     }
 
     // MARK: - 必須コマンドの存在確認
 
-    @Test("ban コマンドが定義されていること")
-    func testBanCommandExists() {
+    @Test("主要コマンドが allCommands に定義されていること", arguments: [
+        "me", "ban", "timeout", "clear"
+    ])
+    func testEssentialCommandExists(expectedName: String) {
         let names = SlashCommandDefinition.allCommands.map { $0.name }
-        #expect(names.contains("ban"))
-    }
-
-    @Test("timeout コマンドが定義されていること")
-    func testTimeoutCommandExists() {
-        let names = SlashCommandDefinition.allCommands.map { $0.name }
-        #expect(names.contains("timeout"))
-    }
-
-    @Test("me コマンドが定義されていること")
-    func testMeCommandExists() {
-        let names = SlashCommandDefinition.allCommands.map { $0.name }
-        #expect(names.contains("me"))
-    }
-
-    @Test("clear コマンドが定義されていること")
-    func testClearCommandExists() {
-        let names = SlashCommandDefinition.allCommands.map { $0.name }
-        #expect(names.contains("clear"))
+        #expect(names.contains(expectedName), "/\(expectedName) コマンドが allCommands に定義されていません")
     }
 }

--- a/Tests/TwitchChatTests/SlashCommandDefinitionTests.swift
+++ b/Tests/TwitchChatTests/SlashCommandDefinitionTests.swift
@@ -1,0 +1,72 @@
+// SlashCommandDefinitionTests.swift
+// SlashCommandDefinition の静的コマンドリスト・構造のテスト
+
+import Testing
+@testable import TwitchChat
+
+@Suite("SlashCommandDefinitionTests")
+struct SlashCommandDefinitionTests {
+
+    // MARK: - allCommands
+
+    @Test("allCommands が空でないこと")
+    func testAllCommandsNotEmpty() {
+        #expect(!SlashCommandDefinition.allCommands.isEmpty)
+    }
+
+    @Test("allCommands の各コマンドの name が一意であること")
+    func testAllCommandNamesAreUnique() {
+        let names = SlashCommandDefinition.allCommands.map { $0.name }
+        let uniqueNames = Set(names)
+        #expect(names.count == uniqueNames.count)
+    }
+
+    @Test("allCommands の各コマンドの name に先頭スラッシュが含まれないこと")
+    func testCommandNamesDoNotContainLeadingSlash() {
+        for command in SlashCommandDefinition.allCommands {
+            #expect(!command.name.hasPrefix("/"), "コマンド '\(command.name)' に先頭スラッシュが含まれています")
+        }
+    }
+
+    @Test("allCommands の各コマンドの description が空でないこと")
+    func testAllCommandDescriptionsNotEmpty() {
+        for command in SlashCommandDefinition.allCommands {
+            #expect(!command.description.isEmpty, "コマンド '\(command.name)' の description が空です")
+        }
+    }
+
+    // MARK: - Identifiable
+
+    @Test("id は name と一致すること")
+    func testIdEqualsName() {
+        for command in SlashCommandDefinition.allCommands {
+            #expect(command.id == command.name)
+        }
+    }
+
+    // MARK: - 必須コマンドの存在確認
+
+    @Test("ban コマンドが定義されていること")
+    func testBanCommandExists() {
+        let names = SlashCommandDefinition.allCommands.map { $0.name }
+        #expect(names.contains("ban"))
+    }
+
+    @Test("timeout コマンドが定義されていること")
+    func testTimeoutCommandExists() {
+        let names = SlashCommandDefinition.allCommands.map { $0.name }
+        #expect(names.contains("timeout"))
+    }
+
+    @Test("me コマンドが定義されていること")
+    func testMeCommandExists() {
+        let names = SlashCommandDefinition.allCommands.map { $0.name }
+        #expect(names.contains("me"))
+    }
+
+    @Test("clear コマンドが定義されていること")
+    func testClearCommandExists() {
+        let names = SlashCommandDefinition.allCommands.map { $0.name }
+        #expect(names.contains("clear"))
+    }
+}


### PR DESCRIPTION
## Summary

- 入力欄で `/` を入力すると利用可能なコマンド一覧がドロップダウン表示される
- 上下キー・Tab・Enter で候補を選択・挿入、Esc でキャンセル、クリックでも選択可能
- `@` メンション補完と排他制御（テキスト先頭 `/` の場合はスラッシュ補完が優先）

## 変更内容

**新規ファイル**
- `SlashCommandDefinition` — 33コマンドの静的定義モデル（Identifiable, Hashable準拠）
- `SlashCommandCompletionViewModel` — `/` トリガー検出・候補フィルタリング・選択操作
- `SlashCommandCompletionView` — コマンド名＋説明文のドロップダウンUI（ScrollViewReader対応）

**変更ファイル**
- `EmoteRichTextView` — `textDidChange`/`doCommandBy` にスラッシュ補完分岐を追加、`replaceCompletionToken` に共通化
- `ChatInputBar` — `@State`・overlay・`confirmSlashCommandCandidate` を追加

**テスト**
- `SlashCommandDefinitionTests` — 6テスト（@Test(arguments:)でパラメータ化）
- `SlashCommandCompletionViewModelTests` — 24テスト

## Test plan

- [ ] `swift build` でビルドエラーがないこと
- [ ] `swift test` で全テストがパスすること
- [ ] SwiftLint 警告・エラーがゼロであること
- [ ] 入力欄で `/` を入力するとコマンド候補が表示されること
- [ ] `/ba` と入力すると `ban` にフィルタリングされること
- [ ] 上下キーで選択移動し Tab/Enter で `/ban ` が挿入されること
- [ ] Esc でキャンセルされること
- [ ] `@` メンション補完が引き続き正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)