### PR TITLE
fix: メンション・スラッシュコマンド補完の NSRange 座標系を Character 数基準に統一する

### DIFF
--- a/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
@@ -125,7 +125,7 @@ final class MentionCompletionViewModel {
             return nil
         }
 
-        // 文字数ベースのインデックス（isWhitespace チェック用）
+        // Character 数インデックス（isWhitespace チェックおよび NSRange の location として使用）
         let atCharIndex = textUpToCursor.distance(from: textUpToCursor.startIndex, to: atRange.lowerBound)
 
         // @ の直前が空白または文頭であることを確認（メールアドレス等の誤検出防止）
@@ -144,16 +144,11 @@ final class MentionCompletionViewModel {
             return nil
         }
 
-        // Character 数オフセットを計算（nsViewRange が Character 数基準を期待するため）
-        let atCharLocation = textUpToCursor.distance(
-            from: textUpToCursor.startIndex,
-            to: atRange.lowerBound
-        )
-        // "@" は 1 Character、afterAt も Character 数で計算する
+        // "@" は 1 Character、afterAt も Character 数で計算する（atCharIndex を再利用）
         let tokenCharLength = 1 + afterAt.count
 
         return MentionTokenInfo(
-            atCharLocation: atCharLocation,
+            atCharLocation: atCharIndex,
             query: afterAt,
             tokenCharLength: tokenCharLength
         )

--- a/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/MentionCompletionViewModel.swift
@@ -26,7 +26,7 @@ final class MentionCompletionViewModel {
     /// 選択中の候補インデックス
     private(set) var selectedIndex: Int = 0
 
-    /// テキスト内の @ から現在カーソルまでの NSRange（UTF-16 基準、置換に使用）
+    /// テキスト内の @ から現在カーソルまでの NSRange（Character 数基準、置換に使用）
     private(set) var mentionRange: NSRange?
 
     // MARK: - プライベートプロパティ
@@ -60,7 +60,7 @@ final class MentionCompletionViewModel {
             return
         }
 
-        mentionRange = NSRange(location: tokenInfo.atNSLocation, length: tokenInfo.tokenNSLength)
+        mentionRange = NSRange(location: tokenInfo.atCharLocation, length: tokenInfo.tokenCharLength)
 
         let newCandidates = mentionStore.candidates(matching: tokenInfo.query)
         candidates = newCandidates
@@ -144,18 +144,18 @@ final class MentionCompletionViewModel {
             return nil
         }
 
-        // UTF-16 オフセットを計算（NSRange / NSTextView との整合性のため）
-        let atNSLocation = textUpToCursor.utf16.distance(
-            from: textUpToCursor.utf16.startIndex,
-            to: atRange.lowerBound.samePosition(in: textUpToCursor.utf16)!
+        // Character 数オフセットを計算（nsViewRange が Character 数基準を期待するため）
+        let atCharLocation = textUpToCursor.distance(
+            from: textUpToCursor.startIndex,
+            to: atRange.lowerBound
         )
-        // "@" は BMP 文字で常に 1 UTF-16 code unit
-        let tokenNSLength = 1 + afterAt.utf16.count
+        // "@" は 1 Character、afterAt も Character 数で計算する
+        let tokenCharLength = 1 + afterAt.count
 
         return MentionTokenInfo(
-            atNSLocation: atNSLocation,
+            atCharLocation: atCharLocation,
             query: afterAt,
-            tokenNSLength: tokenNSLength
+            tokenCharLength: tokenCharLength
         )
     }
 }
@@ -164,10 +164,10 @@ final class MentionCompletionViewModel {
 
 /// メンショントークンの検出結果
 private struct MentionTokenInfo {
-    /// テキスト内の @ の UTF-16 オフセット（NSRange 用）
-    let atNSLocation: Int
+    /// テキスト内の @ の Character 数オフセット（nsViewRange 用）
+    let atCharLocation: Int
     /// @ 以降のクエリ文字列
     let query: String
-    /// トークン全体の UTF-16 長さ（@ + クエリ）
-    let tokenNSLength: Int
+    /// トークン全体の Character 数長さ（@ + クエリ）
+    let tokenCharLength: Int
 }

--- a/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/SlashCommandCompletionViewModel.swift
@@ -27,7 +27,7 @@ final class SlashCommandCompletionViewModel {
     /// 選択中の候補インデックス
     private(set) var selectedIndex: Int = 0
 
-    /// テキスト内の / から現在クエリ末尾までの NSRange（UTF-16 基準、置換に使用）
+    /// テキスト内の / から現在クエリ末尾までの NSRange（Character 数基準、置換に使用）
     private(set) var commandRange: NSRange?
 
     // MARK: - パブリックメソッド
@@ -49,7 +49,7 @@ final class SlashCommandCompletionViewModel {
             return
         }
 
-        commandRange = NSRange(location: 0, length: tokenInfo.tokenNSLength)
+        commandRange = NSRange(location: 0, length: tokenInfo.tokenCharLength)
 
         let lowercasedQuery = tokenInfo.query.lowercased()
         let newCandidates = SlashCommandDefinition.allCommands.filter { command in
@@ -128,12 +128,12 @@ final class SlashCommandCompletionViewModel {
             return nil
         }
 
-        // "/" は BMP 文字で常に 1 UTF-16 code unit
-        let tokenNSLength = 1 + afterSlash.utf16.count
+        // "/" は 1 Character、afterSlash も Character 数で計算する
+        let tokenCharLength = 1 + afterSlash.count
 
         return SlashTokenInfo(
             query: afterSlash,
-            tokenNSLength: tokenNSLength
+            tokenCharLength: tokenCharLength
         )
     }
 }
@@ -144,6 +144,6 @@ final class SlashCommandCompletionViewModel {
 private struct SlashTokenInfo {
     /// / 以降のクエリ文字列（例: "ban", ""）
     let query: String
-    /// トークン全体の UTF-16 長さ（/ + クエリ）
-    let tokenNSLength: Int
+    /// トークン全体の Character 数長さ（/ + クエリ）
+    let tokenCharLength: Int
 }

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -339,9 +339,11 @@ struct ChatInputBar: View {
         guard let insertion = slashCommandCompletionVM.confirmSelection() else { return }
 
         // draft の / トークン部分を挿入文字列で置換する
+        // range は Character 数基準のため Swift String API で処理する（NSString は UTF-16 基準で不正）
         if let range {
-            let nsString = draft as NSString
-            draft = nsString.replacingCharacters(in: range, with: insertion)
+            let startIndex = draft.index(draft.startIndex, offsetBy: range.location)
+            let endIndex = draft.index(startIndex, offsetBy: range.length)
+            draft = draft.replacingCharacters(in: startIndex..<endIndex, with: insertion)
         } else {
             draft += insertion
         }
@@ -357,10 +359,11 @@ struct ChatInputBar: View {
         guard let insertion = mentionCompletionVM.confirmSelection() else { return }
 
         // draft の @ トークン部分を挿入文字列で置換する
-        // draft はプレーンテキストなので NSString で直接置換できる
+        // range は Character 数基準のため Swift String API で処理する（NSString は UTF-16 基準で不正）
         if let range {
-            let nsString = draft as NSString
-            draft = nsString.replacingCharacters(in: range, with: insertion)
+            let startIndex = draft.index(draft.startIndex, offsetBy: range.location)
+            let endIndex = draft.index(startIndex, offsetBy: range.length)
+            draft = draft.replacingCharacters(in: startIndex..<endIndex, with: insertion)
         } else {
             draft += insertion
         }

--- a/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/MentionCompletionViewModelTests.swift
@@ -295,4 +295,22 @@ struct MentionCompletionViewModelTests {
         #expect(range?.length == 3)
         #expect(range?.location == 6)
     }
+
+    @Test("絵文字を含むテキストの後の @ の mentionRange は Character 数基準で正しい範囲を返す")
+    @MainActor
+    func testMentionRangeWithEmojiPrefix() {
+        let vm = MentionCompletionViewModel(mentionStore: makeStore())
+
+        // "🎮配信中 @ni" — "🎮" は UTF-16 で2 code unit だが Character では1文字
+        // "🎮配信中 " は 5 Character、UTF-16 では 6 code unit
+        let text = "🎮配信中 @ni"
+        vm.updateFromText(text, cursorPosition: text.count) // 8 Character
+
+        let range = vm.mentionRange
+        #expect(range != nil)
+        // "@ni" は 3 Character
+        #expect(range?.length == 3)
+        // "🎮配信中 " は 5 Character → location は 5（UTF-16 では 6 になるがそれは誤り）
+        #expect(range?.location == 5)
+    }
 }

--- a/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
+++ b/Tests/TwitchChatTests/SlashCommandCompletionViewModelTests.swift
@@ -302,4 +302,21 @@ struct SlashCommandCompletionViewModelTests {
         #expect(range?.length == 1)
         #expect(range?.location == 0)
     }
+
+    @Test("絵文字を含むクエリの commandRange は Character 数基準の length を返す")
+    @MainActor
+    func testCommandRangeWithEmojiQuery() {
+        let vm = SlashCommandCompletionViewModel()
+
+        // "/🎮test" — "/" は 1 Character, "🎮" は 1 Character（UTF-16 では 2 code unit）, "test" は 4 Character
+        // 合計 6 Character、UTF-16 では 7 code unit
+        let text = "/🎮test"
+        vm.updateFromText(text, cursorPosition: text.count) // 6 Character
+
+        let range = vm.commandRange
+        #expect(range != nil)
+        // "/🎮test" は 6 Character（UTF-16 では 7 になるがそれは誤り）
+        #expect(range?.length == 6)
+        #expect(range?.location == 0)
+    }
 }


### PR DESCRIPTION
## Summary

- `findMentionToken` / `findSlashToken` が UTF-16 オフセットで `mentionRange` / `commandRange` を計算していたが、消費者の `nsViewRange(from:in:)` は Character 数基準を期待しているため座標系の不整合が発生していた
- ViewModel 側の range 計算を Character 数基準に統一し、絵文字等の非 BMP 文字が先行するテキストで補完の置換範囲がずれるバグを修正
- `atCharLocation` の重複 distance 計算を排除し `atCharIndex` を再利用（CodeRabbit nitpick 対応）

## Test plan

- [ ] `MentionCompletionViewModelTests/testMentionRangeWithEmojiPrefix`: `"🎮配信中 @ni"` で `mentionRange.location == 5` を検証（旧実装では 6 が返る）
- [ ] `SlashCommandCompletionViewModelTests/testCommandRangeWithEmojiQuery`: `"/🎮test"` で `commandRange.length == 6` を検証（旧実装では 7 が返る）
- [ ] 既存の全補完テスト（48件）が引き続きパスすること

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)