### PR TITLE
feat: ModerationService のユーザーID解決結果にTTL付きキャッシュを追加する (#42)

### DIFF
--- a/Sources/TwitchChat/Services/ModerationService.swift
+++ b/Sources/TwitchChat/Services/ModerationService.swift
@@ -129,7 +129,13 @@ actor ModerationService: ModerationServiceProtocol {
         let now = currentDate()
 
         // 期限切れエントリを opportunistic pruning する（メモリ増大防止）
-        userIdCache = userIdCache.filter { now.timeIntervalSince($0.value.fetchedAt) < Self.cacheTimeToLive }
+        // filter による Dictionary 再生成を避け、removeValue でインプレース削除する
+        let keysToRemove = userIdCache.compactMap { key, value in
+            now.timeIntervalSince(value.fetchedAt) >= Self.cacheTimeToLive ? key : nil
+        }
+        for key in keysToRemove {
+            userIdCache.removeValue(forKey: key)
+        }
 
         // TTL 内のキャッシュエントリがあれば API を呼ばずに返す
         if let cached = userIdCache[normalizedLogin] {
@@ -144,8 +150,8 @@ actor ModerationService: ModerationServiceProtocol {
             throw HelixAPIError.notFound
         }
 
-        // 取得したユーザーIDをキャッシュに格納する
-        userIdCache[normalizedLogin] = (userId: user.id, fetchedAt: now)
+        // API 成功後のタイムスタンプを fetchedAt に使い、TTL の起点を正確にする
+        userIdCache[normalizedLogin] = (userId: user.id, fetchedAt: currentDate())
         return user.id
     }
 

--- a/Sources/TwitchChat/Services/ModerationService.swift
+++ b/Sources/TwitchChat/Services/ModerationService.swift
@@ -48,8 +48,8 @@ actor ModerationService: ModerationServiceProtocol {
     /// 現在日時を返すクロージャ（テスト時に差し替え可能）
     private let currentDate: @Sendable () -> Date
 
-    /// キャッシュの有効期間（秒）
-    private static let cacheTimeToLive: TimeInterval = 300
+    /// キャッシュの有効期間（秒）。テストから参照できるよう internal アクセスにする
+    static let cacheTimeToLive: TimeInterval = 300
 
     // MARK: - 初期化
 
@@ -126,9 +126,13 @@ actor ModerationService: ModerationServiceProtocol {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
 
+        let now = currentDate()
+
+        // 期限切れエントリを opportunistic pruning する（メモリ増大防止）
+        userIdCache = userIdCache.filter { now.timeIntervalSince($0.value.fetchedAt) < Self.cacheTimeToLive }
+
         // TTL 内のキャッシュエントリがあれば API を呼ばずに返す
-        if let cached = userIdCache[normalizedLogin],
-           currentDate().timeIntervalSince(cached.fetchedAt) < Self.cacheTimeToLive {
+        if let cached = userIdCache[normalizedLogin] {
             return cached.userId
         }
 
@@ -141,7 +145,7 @@ actor ModerationService: ModerationServiceProtocol {
         }
 
         // 取得したユーザーIDをキャッシュに格納する
-        userIdCache[normalizedLogin] = (userId: user.id, fetchedAt: currentDate())
+        userIdCache[normalizedLogin] = (userId: user.id, fetchedAt: now)
         return user.id
     }
 

--- a/Sources/TwitchChat/Services/ModerationService.swift
+++ b/Sources/TwitchChat/Services/ModerationService.swift
@@ -42,13 +42,25 @@ actor ModerationService: ModerationServiceProtocol {
 
     private let apiClient: any HelixAPIClientProtocol
 
+    /// ユーザー ID のインメモリキャッシュ（正規化済みログイン名 → ユーザーID + 取得日時）
+    private var userIdCache: [String: (userId: String, fetchedAt: Date)] = [:]
+
+    /// 現在日時を返すクロージャ（テスト時に差し替え可能）
+    private let currentDate: @Sendable () -> Date
+
+    /// キャッシュの有効期間（秒）
+    private static let cacheTimeToLive: TimeInterval = 300
+
     // MARK: - 初期化
 
     /// ModerationService を初期化する
     ///
-    /// - Parameter apiClient: Helix API クライアント
-    init(apiClient: any HelixAPIClientProtocol) {
+    /// - Parameters:
+    ///   - apiClient: Helix API クライアント
+    ///   - currentDate: 現在日時を返すクロージャ（テスト時に時刻を注入するために使用）
+    init(apiClient: any HelixAPIClientProtocol, currentDate: @Sendable @escaping () -> Date = { Date() }) {
         self.apiClient = apiClient
+        self.currentDate = currentDate
     }
 
     // MARK: - ModerationServiceProtocol
@@ -113,6 +125,13 @@ actor ModerationService: ModerationServiceProtocol {
         let normalizedLogin = login
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
+
+        // TTL 内のキャッシュエントリがあれば API を呼ばずに返す
+        if let cached = userIdCache[normalizedLogin],
+           currentDate().timeIntervalSince(cached.fetchedAt) < Self.cacheTimeToLive {
+            return cached.userId
+        }
+
         let response: HelixUsersResponse = try await apiClient.get(
             url: Self.usersURL,
             queryItems: [URLQueryItem(name: "login", value: normalizedLogin)]
@@ -120,6 +139,9 @@ actor ModerationService: ModerationServiceProtocol {
         guard let user = response.data.first else {
             throw HelixAPIError.notFound
         }
+
+        // 取得したユーザーIDをキャッシュに格納する
+        userIdCache[normalizedLogin] = (userId: user.id, fetchedAt: currentDate())
         return user.id
     }
 

--- a/Tests/TwitchChatTests/ModerationServiceTests.swift
+++ b/Tests/TwitchChatTests/ModerationServiceTests.swift
@@ -51,11 +51,15 @@ actor MockModerationAPIClient: HelixAPIClientProtocol {
     /// 最後に delete に渡されたクエリパラメータ
     private(set) var lastDeleteQueryItems: [URLQueryItem]?
 
+    /// get が呼ばれた回数
+    private(set) var getCallCount = 0
+
     // MARK: - HelixAPIClientProtocol 実装
 
     func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
         if shouldThrowUnauthorized { throw HelixAPIError.unauthorized }
         if shouldThrowForbidden { throw HelixAPIError.forbidden("テスト用権限エラー") }
+        getCallCount += 1
 
         // GET /users のシミュレート
         if T.self == HelixUsersResponse.self {
@@ -116,6 +120,17 @@ actor MockModerationAPIClient: HelixAPIClientProtocol {
     func setUnauthorized(_ value: Bool) {
         shouldThrowUnauthorized = value
     }
+}
+
+// MARK: - テスト用ヘルパー
+
+/// テスト内で currentDate クロージャに渡す可変な日時コンテナ
+///
+/// `@Sendable` クロージャは `var` を直接キャプチャできないため、
+/// 参照型のラッパーを使って時刻を可変に管理する
+final class DateBox: @unchecked Sendable {
+    var date: Date
+    init(_ date: Date = Date()) { self.date = date }
 }
 
 // MARK: - テスト本体
@@ -321,6 +336,161 @@ struct ModerationServiceTests {
 
         let queryItems = await mock.lastDeleteQueryItems
         #expect(queryItems?.contains(URLQueryItem(name: "message_id", value: "メッセージID_abc123")) == true)
+    }
+
+    // MARK: - ユーザーIDキャッシュ
+
+    @Test("同一ユーザーへの2回目呼び出しでAPIが1回だけ呼ばれること")
+    func testSameUserCallsAPIOnlyOnce() async throws {
+        let mock = MockModerationAPIClient()
+        await mock.addUser(id: "ユーザーID_001", login: "あらし太郎")
+        let service = ModerationService(apiClient: mock)
+
+        // 1回目: API を呼んでキャッシュに格納する
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+        // 2回目: キャッシュからユーザーIDを取得する（API は呼ばれない）
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "2回目の荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        // GET /users の呼び出しは1回のみであること
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 1)
+    }
+
+    @Test("TTL期限切れ後はAPIが再度呼ばれること")
+    func testCacheExpiredAfterTTL() async throws {
+        let mock = MockModerationAPIClient()
+        await mock.addUser(id: "ユーザーID_001", login: "あらし太郎")
+        // 現在時刻を制御できるクロージャを使って初期化する
+        let dateBox = DateBox()
+        let service = ModerationService(apiClient: mock, currentDate: { dateBox.date })
+
+        // 1回目: キャッシュに格納する
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        // TTL（300秒）を超える時間を経過させる
+        dateBox.date = dateBox.date.addingTimeInterval(301)
+
+        // 2回目: TTL 切れのため API が再度呼ばれる
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "再度の荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        // GET /users が2回呼ばれていること
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 2)
+    }
+
+    @Test("大文字小文字が異なるログイン名でキャッシュがヒットすること")
+    func testCacheHitWithDifferentCase() async throws {
+        let mock = MockModerationAPIClient()
+        // Twitch ユーザー名は ASCII 英数字小文字。モックには正規化後の小文字で登録する
+        await mock.addUser(id: "ユーザーID_001", login: "trolluser")
+        let service = ModerationService(apiClient: mock)
+
+        // 大文字混在で1回目（正規化されて "trolluser" としてキャッシュに格納される）
+        try await service.execute(
+            command: .ban(username: "TrollUser", reason: "荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+        // 小文字で2回目（キャッシュヒット）
+        try await service.execute(
+            command: .ban(username: "trolluser", reason: "再度の荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 1)
+    }
+
+    @Test("前後空白付きのログイン名でキャッシュがヒットすること")
+    func testCacheHitWithWhitespacePadding() async throws {
+        let mock = MockModerationAPIClient()
+        await mock.addUser(id: "ユーザーID_001", login: "あらし太郎")
+        let service = ModerationService(apiClient: mock)
+
+        // 前後空白付きで1回目（正規化されてキャッシュに格納）
+        try await service.execute(
+            command: .ban(username: "  あらし太郎  ", reason: "荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+        // 空白なしで2回目（キャッシュヒット）
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "再度の荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 1)
+    }
+
+    @Test("異なるユーザーはそれぞれAPIが呼ばれること")
+    func testDifferentUsersEachCallAPI() async throws {
+        let mock = MockModerationAPIClient()
+        await mock.addUser(id: "ユーザーID_001", login: "あらし太郎")
+        await mock.addUser(id: "ユーザーID_002", login: "スパマー花子")
+        let service = ModerationService(apiClient: mock)
+
+        // 別々のユーザーにコマンドを実行する
+        try await service.execute(
+            command: .ban(username: "あらし太郎", reason: "荒らし行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+        try await service.execute(
+            command: .ban(username: "スパマー花子", reason: "スパム行為"),
+            broadcasterId: broadcasterID,
+            moderatorId: moderatorID
+        )
+
+        // それぞれのユーザーで1回ずつ、合計2回 API が呼ばれること
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 2)
+    }
+
+    @Test("存在しないユーザーはキャッシュされないこと")
+    func testNotFoundUserIsNotCached() async throws {
+        let mock = MockModerationAPIClient()
+        // ユーザーを登録しない（存在しないユーザーをシミュレート）
+        let service = ModerationService(apiClient: mock)
+
+        // 1回目: notFound エラーが throw される
+        await #expect(throws: HelixAPIError.notFound) {
+            try await service.execute(
+                command: .ban(username: "存在しないユーザー", reason: nil),
+                broadcasterId: broadcasterID,
+                moderatorId: moderatorID
+            )
+        }
+        // 2回目: キャッシュされていないため再度 API が呼ばれる
+        await #expect(throws: HelixAPIError.notFound) {
+            try await service.execute(
+                command: .ban(username: "存在しないユーザー", reason: nil),
+                broadcasterId: broadcasterID,
+                moderatorId: moderatorID
+            )
+        }
+
+        // notFound はキャッシュしないため2回 API が呼ばれていること
+        let getCallCount = await mock.getCallCount
+        #expect(getCallCount == 2)
     }
 
     // MARK: - エラー伝播

--- a/Tests/TwitchChatTests/ModerationServiceTests.swift
+++ b/Tests/TwitchChatTests/ModerationServiceTests.swift
@@ -3,6 +3,7 @@
 // MockHelixAPIClient を使ってネットワーク通信なしでモデレーション API 呼び出しを検証する
 
 import Foundation
+import os
 import Testing
 @testable import TwitchChat
 
@@ -127,10 +128,24 @@ actor MockModerationAPIClient: HelixAPIClientProtocol {
 /// テスト内で currentDate クロージャに渡す可変な日時コンテナ
 ///
 /// `@Sendable` クロージャは `var` を直接キャプチャできないため、
-/// 参照型のラッパーを使って時刻を可変に管理する
+/// 参照型のラッパーを使って時刻を可変に管理する。
+/// `OSAllocatedUnfairLock` で排他制御し、`@unchecked Sendable` の安全性を担保する
 final class DateBox: @unchecked Sendable {
-    var date: Date
-    init(_ date: Date = Date()) { self.date = date }
+    private let lock: OSAllocatedUnfairLock<Date>
+
+    var date: Date {
+        get { lock.withLock { $0 } }
+        set { lock.withLock { $0 = newValue } }
+    }
+
+    init(_ date: Date = Date()) {
+        lock = OSAllocatedUnfairLock(initialState: date)
+    }
+
+    /// 指定秒数だけ日時を進める
+    func advance(by seconds: TimeInterval) {
+        lock.withLock { $0 = $0.addingTimeInterval(seconds) }
+    }
 }
 
 // MARK: - テスト本体
@@ -379,8 +394,8 @@ struct ModerationServiceTests {
             moderatorId: moderatorID
         )
 
-        // TTL（300秒）を超える時間を経過させる
-        dateBox.date = dateBox.date.addingTimeInterval(301)
+        // TTL を超える時間を経過させる（実装定数 cacheTimeToLive + 1 秒）
+        dateBox.advance(by: ModerationService.cacheTimeToLive + 1)
 
         // 2回目: TTL 切れのため API が再度呼ばれる
         try await service.execute(


### PR DESCRIPTION
## Summary

- `resolveUserId` が毎回 `GET /helix/users` を呼んでいた問題を解消するため、TTL 5分のインメモリキャッシュを追加
- `userIdCache: [String: (userId: String, fetchedAt: Date)]` を actor プロパティとして保持し、actor isolation でスレッドセーフを担保
- `currentDate: @Sendable () -> Date` クロージャを `init` に追加してテスト時の時刻制御を可能にする
- `resolveUserId` 呼び出しごとに期限切れエントリを opportunistic pruning してメモリ増大を防止
- テスト 6 件追加（キャッシュヒット、TTL期限切れ、大小文字・空白正規化、異なるユーザー、非キャッシュ確認）

## Test plan

- [ ] `swift test --filter ModerationServiceTests` で 17 件すべてパスすること
- [ ] `swift build` でビルドエラーがないこと
- [ ] `swiftlint lint --quiet` で警告がないこと
- [ ] CI (GitHub Actions) の build / test / lint ジョブが全てグリーンになること

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)