### PR TITLE
feat: slow/followers コマンドにパーサー層での値域バリデーションを追加する

### DIFF
--- a/Sources/TwitchChat/Models/HelixModerationModels.swift
+++ b/Sources/TwitchChat/Models/HelixModerationModels.swift
@@ -75,7 +75,9 @@ struct HelixChatSettingsRequest: Encodable, Sendable {
     /// slow_mode のみ設定するイニシャライザ
     ///
     /// - Parameter waitTime: スローモード待機秒数。Helix API の有効範囲は 3〜120 秒。
-    ///   指定がない場合はデフォルトの 30 秒を使用する。範囲外の値は自動的にクランプする
+    ///   指定がない場合はデフォルトの 30 秒を使用する。
+    ///   ChatCommandParser でバリデーション済みのため通常は範囲内の値が渡される。
+    ///   ここのクランプは防御的フォールバックとして残す
     static func slow(enabled: Bool, waitTime: Int?) -> Self {
         // Helix API の slow_mode_wait_time は 3〜120 秒に制限されている
         let clampedWaitTime = enabled ? max(3, min(120, waitTime ?? 30)) : nil

--- a/Sources/TwitchChat/Services/ChatCommandParser.swift
+++ b/Sources/TwitchChat/Services/ChatCommandParser.swift
@@ -58,11 +58,11 @@ enum ChatCommandParser {
         switch commandName {
         case "emoteonly":   return .emoteOnly(enabled: true)
         case "emoteonlyoff": return .emoteOnly(enabled: false)
-        case "slow":        return parseOptionalIntCommand(args: args, commandName: commandName) { .slow(seconds: $0) }
+        case "slow":        return parseOptionalIntCommand(args: args, commandName: commandName, validRange: 3...120) { .slow(seconds: $0) }
         case "slowoff":     return .slowOff
         case "subscribers": return .subscribers(enabled: true)
         case "subscribersoff": return .subscribers(enabled: false)
-        case "followers":   return parseOptionalIntCommand(args: args, commandName: commandName) { .followers(duration: $0) }
+        case "followers":   return parseOptionalIntCommand(args: args, commandName: commandName, validRange: 0...129_600) { .followers(duration: $0) }
         case "followersoff": return .followersOff
         case "uniquechat":  return .uniqueChat(enabled: true)
         case "uniquechatoff": return .uniqueChat(enabled: false)
@@ -142,13 +142,18 @@ enum ChatCommandParser {
     private static func parseOptionalIntCommand(
         args: String,
         commandName: String,
+        validRange: ClosedRange<Int>? = nil,
         makeCommand: (Int?) -> ChatCommand
     ) -> ChatCommand {
         let trimmedArgs = args.trimmingCharacters(in: .whitespaces)
-        // 引数なしの場合はデフォルト値で有効化
+        // 引数なしの場合はデフォルト値で有効化（範囲チェック不要）
         if trimmedArgs.isEmpty { return makeCommand(nil) }
         // 先頭トークンを整数としてパース。非数値の場合は .unknown を返す
         guard let value = trimmedArgs.split(separator: " ").first.flatMap({ Int($0) }) else {
+            return .unknown(command: commandName, args: args)
+        }
+        // 範囲が指定されている場合、範囲外の値は .unknown を返す
+        if let validRange, !validRange.contains(value) {
             return .unknown(command: commandName, args: args)
         }
         return makeCommand(value)

--- a/Sources/TwitchChat/Services/ChatCommandParser.swift
+++ b/Sources/TwitchChat/Services/ChatCommandParser.swift
@@ -138,6 +138,7 @@ enum ChatCommandParser {
     /// - Parameters:
     ///   - args: コマンド名を除いた引数文字列
     ///   - commandName: エラー表示に使用するコマンド名
+    ///   - validRange: 許容する整数値の範囲。指定した場合、範囲外の値は `.unknown` を返す。`nil` の場合は範囲チェックを行わない
     ///   - makeCommand: 整数値（または nil）を受け取って ChatCommand を生成するクロージャ
     private static func parseOptionalIntCommand(
         args: String,

--- a/Tests/TwitchChatTests/ChatCommandParserTests.swift
+++ b/Tests/TwitchChatTests/ChatCommandParserTests.swift
@@ -242,6 +242,66 @@ struct ChatCommandParserTests {
         #expect(ChatCommandParser.parse("/followers 10days") == .unknown(command: "followers", args: "10days"))
     }
 
+    // MARK: - /slow 範囲チェック
+
+    @Test("/slow で秒数が下限（3秒）未満の場合は unknown になること")
+    func testSlowCommandWithBelowMinDuration() {
+        // Helix API の slow_mode_wait_time は最低3秒
+        #expect(ChatCommandParser.parse("/slow 2") == .unknown(command: "slow", args: "2"))
+    }
+
+    @Test("/slow で秒数が0の場合は unknown になること")
+    func testSlowCommandWithZeroDuration() {
+        // 0秒はHelix APIの下限（3秒）を下回るため不正
+        #expect(ChatCommandParser.parse("/slow 0") == .unknown(command: "slow", args: "0"))
+    }
+
+    @Test("/slow で秒数が上限（120秒）を超える場合は unknown になること")
+    func testSlowCommandWithExceedingDuration() {
+        // Helix API の slow_mode_wait_time は最大120秒
+        #expect(ChatCommandParser.parse("/slow 121") == .unknown(command: "slow", args: "121"))
+    }
+
+    @Test("/slow で負の値は unknown になること")
+    func testSlowCommandWithNegativeDuration() {
+        // 負の秒数は無効
+        #expect(ChatCommandParser.parse("/slow -1") == .unknown(command: "slow", args: "-1"))
+    }
+
+    @Test("/slow で秒数が下限ちょうど（3秒）は正常にパースされること")
+    func testSlowCommandWithMinDuration() {
+        #expect(ChatCommandParser.parse("/slow 3") == .slow(seconds: 3))
+    }
+
+    @Test("/slow で秒数が上限ちょうど（120秒）は正常にパースされること")
+    func testSlowCommandWithMaxDuration() {
+        #expect(ChatCommandParser.parse("/slow 120") == .slow(seconds: 120))
+    }
+
+    // MARK: - /followers 範囲チェック
+
+    @Test("/followers で分数が0未満の場合は unknown になること")
+    func testFollowersCommandWithNegativeDuration() {
+        // フォロワー期間は0分以上
+        #expect(ChatCommandParser.parse("/followers -1") == .unknown(command: "followers", args: "-1"))
+    }
+
+    @Test("/followers で分数が上限（129,600分=90日）を超える場合は unknown になること")
+    func testFollowersCommandWithExceedingDuration() {
+        // Helix API の follower_mode_duration は最大129,600分
+        #expect(ChatCommandParser.parse("/followers 129601") == .unknown(command: "followers", args: "129601"))
+    }
+
+    @Test("/followers で分数が下限ちょうど（0分）は正常にパースされること")
+    func testFollowersCommandWithMinDuration() {
+        #expect(ChatCommandParser.parse("/followers 0") == .followers(duration: 0))
+    }
+
+    @Test("/followers で分数が上限ちょうど（129,600分）は正常にパースされること")
+    func testFollowersCommandWithMaxDuration() {
+        #expect(ChatCommandParser.parse("/followers 129600") == .followers(duration: 129_600))
+    }
+
     // MARK: - 連続する空白の正規化
 
     @Test("/ban で連続する空白が含まれても正しくパースされること")


### PR DESCRIPTION
## Summary

- `parseOptionalIntCommand` に `validRange: ClosedRange<Int>?` パラメータを追加し、`/slow`（3〜120秒）と `/followers`（0〜129,600分）に値域チェックを実装
- 範囲外の値は `/timeout` と同じパターンで `.unknown` を返すよう統一
- `HelixChatSettingsRequest.slow()` のサイレントクランプは防御的フォールバックとして残存

## Test plan

- [x] `/slow` 範囲チェック: 下限未満・0・上限超過・負値 → `.unknown`、下限ちょうど(3)・上限ちょうど(120) → 正常パース
- [x] `/followers` 範囲チェック: 負値・上限超過 → `.unknown`、0・上限ちょうど(129600) → 正常パース
- [x] `swift test --filter ChatCommandParserTests`: 51件全パス
- [x] `swiftlint`: 0 violations
- [x] `swift build`: Build complete
- [x] CodeRabbit: No findings

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)