### PR TITLE
feat: EventSub WebSocket で楽観的メッセージの ID を確定し返信を有効化する

### DIFF
--- a/Sources/TwitchChat/Auth/AuthConfig.swift
+++ b/Sources/TwitchChat/Auth/AuthConfig.swift
@@ -33,6 +33,7 @@ enum AuthConfig {
     /// - `chat:read`: IRC チャット読み取り（認証接続に使用）
     /// - `chat:edit`: IRC チャット書き込み（コメント投稿に使用）
     /// - `user:read:follows`: フォロー中の配信中ストリーム一覧取得に使用
+    /// - `user:read:chat`: EventSub `channel.chat.message` 購読（楽観的 UI の ID 確定に使用）
     /// - `moderator:manage:banned_users`: バン・タイムアウト操作（Helix API /moderation/bans）
     /// - `moderator:manage:chat_settings`: エモートオンリー・スロー・サブスクライバーモード等
     /// - `moderator:manage:chat_messages`: チャットクリア・メッセージ削除
@@ -40,6 +41,7 @@ enum AuthConfig {
         "chat:read",
         "chat:edit",
         "user:read:follows",
+        "user:read:chat",
         "moderator:manage:banned_users",
         "moderator:manage:chat_settings",
         "moderator:manage:chat_messages"

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -311,6 +311,18 @@ public final class AuthState {
     }
 }
 
+// MARK: - テスト用メソッド
+
+extension AuthState {
+    /// テスト用: ユーザー ID を直接設定する
+    ///
+    /// ログインフローをバイパスして userId だけを設定するテスト専用メソッド。
+    /// 実際のログインとトークンは設定しないため、本番コードでは使用しないこと。
+    func setUserIdForTesting(_ id: String) {
+        userId = id
+    }
+}
+
 // MARK: - HelixAPITokenProvider 準拠
 
 extension AuthState: HelixAPITokenProvider {

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -133,11 +133,9 @@ public final class AuthState {
             print("[AuthState] restoreSession: validateToken 成功 — login=\(validateResponse.login)")
             #endif
 
-            // 必須スコープが不足している場合は自動ログアウトして再ログインを促す。
-            // chat:edit: コメント投稿に必要。user:read:chat: EventSub 購読（楽観的メッセージ ID 確定）に必要。
+            // 必須スコープが不足している場合は自動ログアウトして再ログインを促す
             let scopes = validateResponse.scopes
-            let requiredScopes = ["chat:edit", "user:read:chat"]
-            let missingScopes = requiredScopes.filter { !scopes.contains($0) }
+            let missingScopes = missingRequiredChatScopes(in: scopes)
             if !missingScopes.isEmpty {
                 #if DEBUG
                 print("[AuthState] restoreSession: 必須スコープ不足 \(missingScopes) — 自動ログアウトして再ログインを要求")
@@ -206,6 +204,18 @@ public final class AuthState {
                 expiresIn: deviceResponse.expiresIn
             )
             let validateResponse = try await authClient.validateToken(accessToken: tokenResponse.accessToken)
+
+            // 必須スコープ不足の場合はロールバックしてログアウト状態に戻す
+            let missingScopes = missingRequiredChatScopes(in: validateResponse.scopes)
+            guard missingScopes.isEmpty else {
+                #if DEBUG
+                print("[AuthState] login: 必須スコープ不足 \(missingScopes) — ログインを中断")
+                #endif
+                deviceFlowInfo = nil
+                loginError = "必要なスコープ（\(missingScopes.joined(separator: ", "))）が付与されていません。再ログインしてください。"
+                status = .loggedOut
+                return
+            }
 
             // Keychain にトークンを保存
             try await keychainStore.save(key: "access_token", value: tokenResponse.accessToken)
@@ -281,6 +291,17 @@ public final class AuthState {
 
     // MARK: - プライベートメソッド
 
+    /// EventSub 購読・チャット投稿に必要な必須スコープ一覧
+    private static let requiredChatScopes = ["chat:edit", "user:read:chat"]
+
+    /// 不足している必須スコープを返す
+    ///
+    /// - Parameter scopes: トークンに付与されているスコープ一覧
+    /// - Returns: 不足スコープの配列。すべて揃っている場合は空配列
+    private func missingRequiredChatScopes(in scopes: [String]) -> [String] {
+        Self.requiredChatScopes.filter { !scopes.contains($0) }
+    }
+
     /// リフレッシュトークンで新しいアクセストークンを取得する
 
     private func tryRefreshToken() async {
@@ -296,12 +317,28 @@ public final class AuthState {
             let tokenResponse = try await authClient.refreshToken(refreshToken: refreshTokenValue)
             let validateResponse = try await authClient.validateToken(accessToken: tokenResponse.accessToken)
 
+            // 必須スコープ不足の場合は認証情報を廃棄してログアウト
+            let missingScopes = missingRequiredChatScopes(in: validateResponse.scopes)
+            guard missingScopes.isEmpty else {
+                #if DEBUG
+                print("[AuthState] tryRefreshToken: 必須スコープ不足 \(missingScopes) — ログアウト")
+                #endif
+                await keychainStore.deleteAll()
+                accessToken = nil
+                userId = nil
+                grantedScopes = []
+                status = .loggedOut
+                return
+            }
+
             try await keychainStore.save(key: "access_token", value: tokenResponse.accessToken)
             try await keychainStore.save(key: "refresh_token", value: tokenResponse.refreshToken)
+            // validateResponse.userId を優先して使用し、Keychain にも上書き保存する
+            try await keychainStore.save(key: "user_id", value: validateResponse.userId)
 
             grantedScopes = validateResponse.scopes
             accessToken = tokenResponse.accessToken
-            userId = await keychainStore.load(key: "user_id")
+            userId = validateResponse.userId
             status = .loggedIn(userLogin: validateResponse.login)
         } catch {
             await keychainStore.deleteAll()

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -133,12 +133,14 @@ public final class AuthState {
             print("[AuthState] restoreSession: validateToken 成功 — login=\(validateResponse.login)")
             #endif
 
-            // chat:edit スコープ不足の場合、既存セッションを自動ログアウトして再ログインを促す
-            // （コメント投稿機能追加に伴い、古いスコープのトークンを無効扱いにする）
+            // 必須スコープが不足している場合は自動ログアウトして再ログインを促す。
+            // chat:edit: コメント投稿に必要。user:read:chat: EventSub 購読（楽観的メッセージ ID 確定）に必要。
             let scopes = validateResponse.scopes
-            if !scopes.contains("chat:edit") {
+            let requiredScopes = ["chat:edit", "user:read:chat"]
+            let missingScopes = requiredScopes.filter { !scopes.contains($0) }
+            if !missingScopes.isEmpty {
                 #if DEBUG
-                print("[AuthState] restoreSession: chat:edit スコープなし — 自動ログアウトして再ログインを要求")
+                print("[AuthState] restoreSession: 必須スコープ不足 \(missingScopes) — 自動ログアウトして再ログインを要求")
                 #endif
                 await logout()
                 return
@@ -313,15 +315,17 @@ public final class AuthState {
 
 // MARK: - テスト用メソッド
 
+#if DEBUG
 extension AuthState {
     /// テスト用: ユーザー ID を直接設定する
     ///
     /// ログインフローをバイパスして userId だけを設定するテスト専用メソッド。
-    /// 実際のログインとトークンは設定しないため、本番コードでは使用しないこと。
+    /// `#if DEBUG` でガードされており、リリースビルドでは使用不可。
     func setUserIdForTesting(_ id: String) {
         userId = id
     }
 }
+#endif
 
 // MARK: - HelixAPITokenProvider 準拠
 

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -191,6 +191,35 @@ struct ChatMessage: Sendable, Identifiable {
         self.isSystemNotice = false
     }
 
+    /// 楽観的 UI メッセージの ID を EventSub で受信した本物の message ID で差し替えた新しいインスタンスを生成する
+    ///
+    /// Twitch IRC は自分のメッセージをエコーバックしないため、送信直後は楽観的 UI メッセージとして
+    /// ローカル UUID が割り当てられる。EventSub `channel.chat.message` で本物の ID を受信した際に
+    /// このイニシャライザで差し替えることで、返信機能が有効化される。
+    ///
+    /// - Parameters:
+    ///   - original: 差し替え元の楽観的 UI メッセージ
+    ///   - realId: EventSub から受信した本物の message ID
+    init(confirming original: ChatMessage, withRealId realId: String) {
+        self.id = realId
+        self.username = original.username
+        self.displayName = original.displayName
+        self.text = original.text
+        self.isAction = original.isAction
+        self.colorHex = original.colorHex
+        self.badges = original.badges
+        self.emotes = original.emotes
+        self.segments = original.segments
+        self.roomId = original.roomId
+        self.receivedAt = original.receivedAt
+        self.replyParentMsgId = original.replyParentMsgId
+        self.replyParentUserLogin = original.replyParentUserLogin
+        self.replyParentDisplayName = original.replyParentDisplayName
+        self.replyParentMsgBody = original.replyParentMsgBody
+        self.isOptimistic = false
+        self.isSystemNotice = original.isSystemNotice
+    }
+
     /// システム通知メッセージを生成する
     ///
     /// モデレーションコマンドの成功・失敗等、アプリが生成する情報メッセージに使用する。

--- a/Sources/TwitchChat/Models/EventSubModels.swift
+++ b/Sources/TwitchChat/Models/EventSubModels.swift
@@ -1,0 +1,153 @@
+// EventSubModels.swift
+// Twitch EventSub WebSocket で受信するメッセージの Codable モデル定義
+//
+// EventSub WebSocket は JSON ベースのプロトコル。
+// 全メッセージはトップレベルの EventSubMessage として受信し、
+// metadata.messageType でメッセージ種別を判別する。
+//
+// 参考: https://dev.twitch.tv/docs/eventsub/handling-websocket-events/
+
+import Foundation
+
+// MARK: - トップレベルメッセージ
+
+/// EventSub WebSocket で受信するメッセージのトップレベルモデル
+///
+/// すべてのメッセージが共通の envelope 構造を持ち、
+/// `metadata.messageType` でメッセージ種別を判別する。
+struct EventSubMessage: Decodable {
+    let metadata: EventSubMetadata
+    let payload: EventSubPayload
+}
+
+// MARK: - メタデータ
+
+/// EventSub メッセージのメタデータ
+///
+/// 全メッセージ共通のヘッダー情報を保持する。
+struct EventSubMetadata: Decodable {
+    /// メッセージの一意な識別子
+    let messageId: String
+
+    /// メッセージ種別
+    let messageType: EventSubMessageType
+
+    /// メッセージのタイムスタンプ（ISO8601）
+    let messageTimestamp: String
+
+    /// サブスクリプション種別（notification/revocation のみ存在）
+    let subscriptionType: String?
+
+    /// サブスクリプションバージョン（notification/revocation のみ存在）
+    let subscriptionVersion: String?
+}
+
+/// EventSub メッセージ種別
+enum EventSubMessageType: String, Decodable {
+    /// 接続確立（session_id を含む）
+    case sessionWelcome = "session_welcome"
+    /// keepalive（ペイロードなし）
+    case sessionKeepalive = "session_keepalive"
+    /// 再接続要求（新しい WebSocket URL を含む）
+    case sessionReconnect = "session_reconnect"
+    /// イベント通知（購読イベントのデータを含む）
+    case notification = "notification"
+    /// サブスクリプション失効
+    case revocation = "revocation"
+    /// 将来追加される可能性のある未知の種別
+    case unknown
+
+    /// 未知の raw value は .unknown に fallback する
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = EventSubMessageType(rawValue: raw) ?? .unknown
+    }
+}
+
+// MARK: - ペイロード
+
+/// EventSub メッセージのペイロード
+///
+/// メッセージ種別によって含まれるフィールドが異なる。
+/// session_welcome / session_reconnect: `session` が存在
+/// notification: `subscription` + `event` が存在
+/// revocation: `subscription` が存在
+/// session_keepalive: 全フィールド nil
+struct EventSubPayload: Decodable {
+    /// セッション情報（session_welcome / session_reconnect）
+    let session: EventSubSession?
+
+    /// サブスクリプション情報（notification / revocation）
+    let subscription: EventSubSubscriptionInfo?
+
+    /// イベントデータ（notification のみ）
+    let event: EventSubChatEvent?
+}
+
+/// EventSub セッション情報
+///
+/// session_welcome / session_reconnect メッセージのペイロードに含まれる。
+struct EventSubSession: Decodable {
+    /// セッションの一意な識別子
+    ///
+    /// Helix API でサブスクリプション登録する際に transport.session_id として使用する。
+    let id: String
+
+    /// セッションの状態（"connected", "reconnecting" 等）
+    let status: String
+
+    /// keepalive タイムアウト秒数
+    ///
+    /// この時間内に keepalive または notification が届かない場合は再接続が必要。
+    /// session_reconnect では null。
+    let keepaliveTimeoutSeconds: Int?
+
+    /// 再接続先 WebSocket URL（session_reconnect のみ）
+    let reconnectUrl: String?
+}
+
+/// サブスクリプション情報（notification / revocation 用）
+///
+/// notification メッセージのペイロードに含まれるが、
+/// 現在は event フィールドのみ使用するため最小限の定義にとどめる。
+struct EventSubSubscriptionInfo: Decodable {
+    let id: String
+    let status: String
+    let type: String
+}
+
+// MARK: - チャットメッセージイベント
+
+/// channel.chat.message EventSub イベント
+///
+/// notification メッセージの payload.event として受信する。
+/// 自分が送信したメッセージも含む全チャットメッセージを配信する。
+struct EventSubChatEvent: Decodable {
+    /// チャンネルオーナーのユーザー ID
+    let broadcasterUserId: String
+
+    /// チャンネルオーナーのログイン名（小文字）
+    let broadcasterUserLogin: String
+
+    /// 発言者のユーザー ID
+    let chatterUserId: String
+
+    /// 発言者のログイン名（小文字）
+    let chatterUserLogin: String
+
+    /// メッセージの本物の一意な識別子
+    ///
+    /// Twitch サーバーが割り当てる ID。
+    /// 楽観的 UI メッセージのローカル UUID をこの ID で差し替えることで返信機能を有効化する。
+    let messageId: String
+
+    /// メッセージ本文
+    let message: EventSubChatMessageContent
+}
+
+/// EventSub チャットメッセージの本文
+struct EventSubChatMessageContent: Decodable {
+    /// メッセージテキスト（プレーンテキスト形式）
+    let text: String
+}

--- a/Sources/TwitchChat/Models/EventSubModels.swift
+++ b/Sources/TwitchChat/Models/EventSubModels.swift
@@ -123,7 +123,7 @@ struct EventSubSubscriptionInfo: Decodable {
 ///
 /// notification メッセージの payload.event として受信する。
 /// 自分が送信したメッセージも含む全チャットメッセージを配信する。
-struct EventSubChatEvent: Decodable {
+struct EventSubChatEvent: Decodable, Sendable {
     /// チャンネルオーナーのユーザー ID
     let broadcasterUserId: String
 
@@ -147,7 +147,7 @@ struct EventSubChatEvent: Decodable {
 }
 
 /// EventSub チャットメッセージの本文
-struct EventSubChatMessageContent: Decodable {
+struct EventSubChatMessageContent: Decodable, Sendable {
     /// メッセージテキスト（プレーンテキスト形式）
     let text: String
 }

--- a/Sources/TwitchChat/Models/EventSubSubscriptionModels.swift
+++ b/Sources/TwitchChat/Models/EventSubSubscriptionModels.swift
@@ -1,0 +1,81 @@
+// EventSubSubscriptionModels.swift
+// Twitch Helix API を使った EventSub サブスクリプション登録・削除のリクエスト/レスポンスモデル
+//
+// EventSub WebSocket の subscription 登録には、Welcome メッセージで取得した session_id が必要。
+// POST https://api.twitch.tv/helix/eventsub/subscriptions
+// DELETE https://api.twitch.tv/helix/eventsub/subscriptions?id={subscription_id}
+
+import Foundation
+
+// MARK: - サブスクリプション登録リクエスト
+
+/// EventSub サブスクリプション登録リクエストボディ
+///
+/// Helix API `POST /eventsub/subscriptions` に送信する。
+struct EventSubSubscriptionRequest: Encodable, Sendable {
+    /// 購読するイベントの種別（例: "channel.chat.message"）
+    let type: String
+
+    /// イベントのバージョン（例: "1"）
+    let version: String
+
+    /// イベントの配信条件
+    let condition: EventSubCondition
+
+    /// イベントの配信トランスポート（WebSocket セッション）
+    let transport: EventSubTransport
+}
+
+/// EventSub サブスクリプション条件
+///
+/// `channel.chat.message` の場合:
+/// - `broadcasterUserId`: メッセージを受信するチャンネルのオーナー ID
+/// - `userId`: 認証済みユーザー ID（自分のユーザー ID）
+struct EventSubCondition: Encodable, Sendable {
+    /// チャンネルオーナーのユーザー ID
+    let broadcasterUserId: String
+
+    /// 認証済みユーザー ID（自分の ID）
+    let userId: String
+
+    enum CodingKeys: String, CodingKey {
+        case broadcasterUserId = "broadcaster_user_id"
+        case userId = "user_id"
+    }
+}
+
+/// EventSub WebSocket トランスポート設定
+struct EventSubTransport: Encodable, Sendable {
+    /// トランスポート方式（"websocket" 固定）
+    let method: String
+
+    /// EventSub WebSocket の Welcome メッセージで受信したセッション ID
+    let sessionId: String
+
+    enum CodingKeys: String, CodingKey {
+        case method
+        case sessionId = "session_id"
+    }
+}
+
+// MARK: - サブスクリプション登録レスポンス
+
+/// EventSub サブスクリプション登録レスポンス
+struct EventSubSubscriptionResponse: Decodable, Sendable {
+    /// 登録されたサブスクリプション一覧（通常は 1 件）
+    let data: [EventSubSubscriptionData]
+}
+
+/// 登録済みサブスクリプションの詳細
+struct EventSubSubscriptionData: Decodable, Sendable {
+    /// サブスクリプションの一意な識別子
+    ///
+    /// `DELETE /eventsub/subscriptions?id=` で削除する際に使用する。
+    let id: String
+
+    /// サブスクリプションの状態（"enabled", "webhook_callback_verification_pending" 等）
+    let status: String
+
+    /// サブスクリプション種別（例: "channel.chat.message"）
+    let type: String
+}

--- a/Sources/TwitchChat/Services/TwitchEventSubClient.swift
+++ b/Sources/TwitchChat/Services/TwitchEventSubClient.swift
@@ -26,25 +26,6 @@ enum EventSubConnectionState: Sendable, Equatable {
     case disconnected
 }
 
-// MARK: - keepalive 設定
-
-/// EventSub keepalive タイムアウト監視の設定
-///
-/// Twitch 側から keepalive が送られてくるため、クライアントは受信タイムアウトを監視する。
-struct EventSubKeepaliveConfiguration: Sendable {
-    /// Welcome メッセージで指定された keepalive_timeout_seconds への加算余裕（秒）
-    ///
-    /// Twitch の仕様: keepalive_timeout_seconds が過ぎるまでに keepalive が届かない場合は再接続。
-    /// ここでは若干の余裕を持たせて誤タイムアウトを防ぐ。
-    let toleranceSeconds: TimeInterval
-
-    /// 本番環境向けデフォルト（5 秒の余裕）
-    static let `default` = EventSubKeepaliveConfiguration(toleranceSeconds: 5.0)
-
-    /// テスト用の極小設定（余裕なし）
-    static let fastTest = EventSubKeepaliveConfiguration(toleranceSeconds: 0.0)
-}
-
 // MARK: - プロトコル
 
 /// Twitch EventSub WebSocket クライアントの抽象化プロトコル
@@ -321,9 +302,9 @@ actor TwitchEventSubClient: TwitchEventSubClientProtocol {
                 try await webSocketClient.connect(to: currentWebSocketURL)
                 if isIntentionallyDisconnected { await webSocketClient.disconnect(); return }
 
-                // 再接続成功 → 受信ループを再起動
+                // 再接続成功 → 受信ループを再起動する
+                // .connected は Welcome メッセージ受信時に yield するため、ここでは yield しない
                 reconnectAttempt = 0
-                connectionStateContinuation?.yield(.connected)
                 receiveLoopTask = Task { await receiveLoop() }
                 return
             } catch {

--- a/Sources/TwitchChat/Services/TwitchEventSubClient.swift
+++ b/Sources/TwitchChat/Services/TwitchEventSubClient.swift
@@ -1,0 +1,357 @@
+// TwitchEventSubClient.swift
+// Twitch EventSub WebSocket 接続を管理するクライアント
+//
+// EventSub WebSocket は JSON ベースのプロトコル。IRC クライアントとは異なり、
+// Twitch 側からの keepalive メッセージを受信して生存確認する（クライアントから PING しない）。
+//
+// 主な役割:
+// - wss://eventsub.wss.twitch.tv/ws に接続し、Welcome メッセージで session_id を取得する
+// - Helix API 経由でサブスクリプションを登録・削除する
+// - channel.chat.message イベントを chatMessageEventStream で配信する
+// - Reconnect メッセージへの対応および予期せぬ切断時の指数バックオフ再接続
+//
+// 参考: https://dev.twitch.tv/docs/eventsub/handling-websocket-events/
+
+import Foundation
+
+// MARK: - EventSub 接続状態
+
+/// EventSub クライアントの接続状態
+enum EventSubConnectionState: Sendable, Equatable {
+    /// 接続済み（session_id 確定済み）
+    case connected
+    /// 再接続中（指数バックオフでリトライ中）
+    case reconnecting(attempt: Int)
+    /// 切断済み（意図的な disconnect() 後）
+    case disconnected
+}
+
+// MARK: - keepalive 設定
+
+/// EventSub keepalive タイムアウト監視の設定
+///
+/// Twitch 側から keepalive が送られてくるため、クライアントは受信タイムアウトを監視する。
+struct EventSubKeepaliveConfiguration: Sendable {
+    /// Welcome メッセージで指定された keepalive_timeout_seconds への加算余裕（秒）
+    ///
+    /// Twitch の仕様: keepalive_timeout_seconds が過ぎるまでに keepalive が届かない場合は再接続。
+    /// ここでは若干の余裕を持たせて誤タイムアウトを防ぐ。
+    let toleranceSeconds: TimeInterval
+
+    /// 本番環境向けデフォルト（5 秒の余裕）
+    static let `default` = EventSubKeepaliveConfiguration(toleranceSeconds: 5.0)
+
+    /// テスト用の極小設定（余裕なし）
+    static let fastTest = EventSubKeepaliveConfiguration(toleranceSeconds: 0.0)
+}
+
+// MARK: - プロトコル
+
+/// Twitch EventSub WebSocket クライアントの抽象化プロトコル
+///
+/// ChannelManager がこのプロトコルに依存することで、テスト時にモックへの差し替えが可能になる
+protocol TwitchEventSubClientProtocol: Actor {
+    /// channel.chat.message EventSub イベントを配信する AsyncStream
+    var chatMessageEventStream: AsyncStream<EventSubChatEvent> { get }
+
+    /// 接続状態の変化を配信する AsyncStream
+    var connectionStateStream: AsyncStream<EventSubConnectionState> { get }
+
+    /// 現在の session_id（テスト検証用）
+    var sessionId: String? { get }
+
+    /// EventSub WebSocket に接続する
+    func connect() async throws
+
+    /// 接続を切断する
+    func disconnect() async
+
+    /// 指定チャンネルの channel.chat.message サブスクリプションを登録する
+    ///
+    /// - Parameters:
+    ///   - broadcasterId: チャンネルオーナーのユーザー ID
+    ///   - userId: 認証済みユーザー ID（自分の ID）
+    func subscribeChatMessage(broadcasterId: String, userId: String) async throws
+
+    /// 指定チャンネルのサブスクリプションを解除する
+    ///
+    /// - Parameters:
+    ///   - broadcasterId: チャンネルオーナーのユーザー ID（サブスクリプション ID の検索に使用）
+    func unsubscribeChatMessage(broadcasterId: String) async throws
+}
+
+// MARK: - TwitchEventSubClient
+
+/// Twitch EventSub WebSocket クライアント
+///
+/// EventSub WebSocket に接続し、channel.chat.message イベントを AsyncStream で配信する。
+/// 予期せぬ切断時は指数バックオフで自動再接続する。
+actor TwitchEventSubClient: TwitchEventSubClientProtocol {
+
+    // MARK: - 定数
+
+    private static let defaultWebSocketURL = URL(string: "wss://eventsub.wss.twitch.tv/ws")!
+    private static let subscriptionsURL = URL(string: "https://api.twitch.tv/helix/eventsub/subscriptions")!
+
+    // MARK: - ストリームプロパティ
+
+    /// channel.chat.message EventSub イベントを配信する AsyncStream
+    let chatMessageEventStream: AsyncStream<EventSubChatEvent>
+
+    /// 接続状態の変化を配信する AsyncStream
+    let connectionStateStream: AsyncStream<EventSubConnectionState>
+
+    // MARK: - プライベートプロパティ
+
+    private let webSocketClient: any WebSocketClientProtocol
+    private let apiClient: any HelixAPIClientProtocol
+
+    private var chatMessageContinuation: AsyncStream<EventSubChatEvent>.Continuation?
+    private var connectionStateContinuation: AsyncStream<EventSubConnectionState>.Continuation?
+
+    /// 受信ループタスク
+    private var receiveLoopTask: Task<Void, Never>?
+
+    /// 現在の EventSub セッション ID（Helix API でサブスクリプション登録に使用する）
+    private(set) var sessionId: String?
+
+    /// 接続先 WebSocket URL（Reconnect メッセージで更新される）
+    private var currentWebSocketURL: URL
+
+    /// 意図的切断フラグ
+    private var isIntentionallyDisconnected: Bool = false
+
+    /// 現在の再接続試行回数
+    private var reconnectAttempt: Int = 0
+
+    /// バックオフ設定
+    private let backoffConfig: BackoffConfiguration
+
+    /// JSON デコーダー（snake_case → camelCase 変換）
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    /// 登録済みサブスクリプション（broadcasterId → subscription_id）
+    private var subscriptions: [String: String] = [:]
+
+    // MARK: - 初期化
+
+    /// TwitchEventSubClient を初期化する
+    ///
+    /// - Parameters:
+    ///   - webSocketClient: WebSocket クライアント実装（テスト時はモックを注入）
+    ///   - apiClient: Helix API クライアント（サブスクリプション登録に使用）
+    ///   - backoffConfig: 指数バックオフ設定（テスト時は `.fastTest` を指定）
+    init(
+        webSocketClient: any WebSocketClientProtocol = URLSessionWebSocketClient(),
+        apiClient: any HelixAPIClientProtocol,
+        backoffConfig: BackoffConfiguration = .default
+    ) {
+        var chatContinuation: AsyncStream<EventSubChatEvent>.Continuation?
+        self.chatMessageEventStream = AsyncStream { chatContinuation = $0 }
+        self.chatMessageContinuation = chatContinuation
+
+        var stateContinuation: AsyncStream<EventSubConnectionState>.Continuation?
+        self.connectionStateStream = AsyncStream { stateContinuation = $0 }
+        self.connectionStateContinuation = stateContinuation
+
+        self.webSocketClient = webSocketClient
+        self.apiClient = apiClient
+        self.backoffConfig = backoffConfig
+        self.currentWebSocketURL = Self.defaultWebSocketURL
+    }
+
+    // MARK: - 接続・切断
+
+    /// EventSub WebSocket に接続する
+    func connect() async throws {
+        isIntentionallyDisconnected = false
+        reconnectAttempt = 0
+        currentWebSocketURL = Self.defaultWebSocketURL
+
+        try await webSocketClient.connect(to: currentWebSocketURL)
+
+        // 受信ループを別タスクで起動
+        receiveLoopTask = Task { await receiveLoop() }
+    }
+
+    /// EventSub 接続を切断する
+    func disconnect() async {
+        isIntentionallyDisconnected = true
+
+        receiveLoopTask?.cancel()
+        receiveLoopTask = nil
+
+        await webSocketClient.disconnect()
+        sessionId = nil
+
+        connectionStateContinuation?.yield(.disconnected)
+    }
+
+    // MARK: - サブスクリプション管理
+
+    /// 指定チャンネルの channel.chat.message サブスクリプションを Helix API 経由で登録する
+    ///
+    /// - Parameters:
+    ///   - broadcasterId: チャンネルオーナーのユーザー ID
+    ///   - userId: 認証済みユーザー ID（自分の ID）
+    /// - Throws: session_id 未取得の場合は `EventSubClientError.sessionIdNotAvailable`
+    func subscribeChatMessage(broadcasterId: String, userId: String) async throws {
+        guard let sid = sessionId else {
+            throw EventSubClientError.sessionIdNotAvailable
+        }
+
+        let request = EventSubSubscriptionRequest(
+            type: "channel.chat.message",
+            version: "1",
+            condition: EventSubCondition(broadcasterUserId: broadcasterId, userId: userId),
+            transport: EventSubTransport(method: "websocket", sessionId: sid)
+        )
+
+        let response: EventSubSubscriptionResponse = try await apiClient.post(
+            url: Self.subscriptionsURL,
+            queryItems: nil,
+            body: request
+        )
+
+        // 登録されたサブスクリプション ID を broadcasterId と紐付けて保存する
+        if let subscriptionId = response.data.first?.id {
+            subscriptions[broadcasterId] = subscriptionId
+        }
+    }
+
+    /// 指定チャンネルのサブスクリプションを Helix API 経由で解除する
+    func unsubscribeChatMessage(broadcasterId: String) async throws {
+        guard let subscriptionId = subscriptions[broadcasterId] else { return }
+
+        let queryItems = [URLQueryItem(name: "id", value: subscriptionId)]
+        try await apiClient.delete(url: Self.subscriptionsURL, queryItems: queryItems)
+        subscriptions.removeValue(forKey: broadcasterId)
+    }
+
+    // MARK: - 受信ループ
+
+    /// メッセージ受信ループ
+    ///
+    /// WebSocket からメッセージを連続受信し、JSON をパースしてイベント種別ごとに処理する。
+    /// 予期せぬ切断時はバックオフ付き再接続を試みる。
+    private func receiveLoop() async {
+        while true {
+            do {
+                let raw = try await webSocketClient.receive()
+                await handleRawMessage(raw)
+            } catch {
+                if isIntentionallyDisconnected || Task.isCancelled {
+                    break
+                }
+                // 予期せぬ切断 → バックオフ付き再接続
+                await performReconnect()
+                break
+            }
+        }
+    }
+
+    /// JSON テキストメッセージを解析して処理する
+    private func handleRawMessage(_ raw: String) async {
+        guard let data = raw.data(using: .utf8),
+              let message = try? decoder.decode(EventSubMessage.self, from: data) else {
+            return
+        }
+
+        switch message.metadata.messageType {
+        case .sessionWelcome:
+            // session_id を保存して接続成功を通知する
+            sessionId = message.payload.session?.id
+            connectionStateContinuation?.yield(.connected)
+
+        case .sessionKeepalive:
+            // keepalive 受信 → タイムアウトカウントをリセット（現在は受信するだけ）
+            break
+
+        case .sessionReconnect:
+            // 新しい URL への再接続要求
+            // 現在の WebSocket を切断して receiveLoop の catch 経由で再接続する
+            if let urlString = message.payload.session?.reconnectUrl,
+               let url = URL(string: urlString) {
+                currentWebSocketURL = url
+            }
+            await webSocketClient.disconnect()
+
+        case .notification:
+            // channel.chat.message イベントを chatMessageEventStream に配信する
+            if let event = message.payload.event {
+                chatMessageContinuation?.yield(event)
+            }
+
+        case .revocation:
+            // サブスクリプション失効 → 該当エントリを subscriptions から削除する
+            if let subId = message.payload.subscription?.id {
+                subscriptions = subscriptions.filter { $0.value != subId }
+            }
+
+        case .unknown:
+            break
+        }
+    }
+
+    // MARK: - 自動再接続
+
+    /// 指数バックオフで再接続を繰り返し試行する
+    ///
+    /// `receiveLoop()` のエラー catch から呼ばれる時点では WebSocket は既に切断済みのため
+    /// ここで改めて disconnect() を呼ばない。
+    private func performReconnect() async {
+        while !isIntentionallyDisconnected {
+            reconnectAttempt += 1
+            connectionStateContinuation?.yield(.reconnecting(attempt: reconnectAttempt))
+
+            let delay = computeBackoffDelay(attempt: reconnectAttempt)
+            do {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            } catch {
+                return
+            }
+
+            if isIntentionallyDisconnected { return }
+
+            do {
+                try await webSocketClient.connect(to: currentWebSocketURL)
+                if isIntentionallyDisconnected { await webSocketClient.disconnect(); return }
+
+                // 再接続成功 → 受信ループを再起動
+                reconnectAttempt = 0
+                connectionStateContinuation?.yield(.connected)
+                receiveLoopTask = Task { await receiveLoop() }
+                return
+            } catch {
+                // 次のイテレーションで再試行
+            }
+        }
+    }
+
+    /// 指数バックオフ遅延を計算する
+    private func computeBackoffDelay(attempt: Int) -> TimeInterval {
+        let base = backoffConfig.initialDelay * pow(backoffConfig.multiplier, Double(attempt - 1))
+        let capped = min(base, backoffConfig.maxDelay)
+        let jitter = capped * backoffConfig.jitterRatio
+        return max(0, capped + Double.random(in: -jitter...jitter))
+    }
+}
+
+// MARK: - エラー
+
+/// TwitchEventSubClient が発生させるエラー
+enum EventSubClientError: Error, LocalizedError {
+    /// session_id が未取得の状態でサブスクリプション登録を試みた
+    case sessionIdNotAvailable
+
+    var errorDescription: String? {
+        switch self {
+        case .sessionIdNotAvailable:
+            return "EventSub の session_id がまだ取得できていません。接続後に再試行してください。"
+        }
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -47,6 +47,9 @@ final class ChannelManager {
     /// EventSub クライアントファクトリ（テスト時にモックを注入するために使用）
     private let makeEventSubClient: (@MainActor () -> any TwitchEventSubClientProtocol)?
 
+    /// EventSub 初回接続タスク（disconnectAll() でキャンセルできるように保持）
+    private var eventSubConnectTask: Task<Void, Never>?
+
     /// EventSub イベント受信ループタスク
     private var eventSubReceiveTask: Task<Void, Never>?
 
@@ -109,7 +112,8 @@ final class ChannelManager {
         if eventSubClient == nil, let factory = makeEventSubClient {
             let client = factory()
             eventSubClient = client
-            Task {
+            // disconnectAll() でキャンセルできるよう Task 参照を保持する
+            eventSubConnectTask = Task {
                 do {
                     try await client.connect()
                 } catch {
@@ -120,6 +124,7 @@ final class ChannelManager {
                     eventSubClient = nil
                     return
                 }
+                guard !Task.isCancelled else { return }
                 // EventSub イベント受信ループを起動する
                 await startEventSubReceiveLoop(client: client)
             }
@@ -267,6 +272,8 @@ final class ChannelManager {
         selectedChannel = nil
 
         // EventSub クライアントを切断してリソースを解放する
+        eventSubConnectTask?.cancel()
+        eventSubConnectTask = nil
         eventSubReceiveTask?.cancel()
         eventSubReceiveTask = nil
         if let client = eventSubClient {

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -110,7 +110,16 @@ final class ChannelManager {
             let client = factory()
             eventSubClient = client
             Task {
-                try? await client.connect()
+                do {
+                    try await client.connect()
+                } catch {
+                    // 接続失敗時は eventSubClient をリセットして次回 joinChannel で再生成できるようにする
+                    #if DEBUG
+                    print("[ChannelManager] EventSub connect 失敗: \(error) — eventSubClient をリセット")
+                    #endif
+                    eventSubClient = nil
+                    return
+                }
                 // EventSub イベント受信ループを起動する
                 await startEventSubReceiveLoop(client: client)
             }
@@ -131,8 +140,8 @@ final class ChannelManager {
     /// 該当する ChatViewModel の handleEventSubChatMessage に振り分ける。
     private func startEventSubReceiveLoop(client: any TwitchEventSubClientProtocol) async {
         eventSubReceiveTask?.cancel()
-        // Swift Concurrency: actor メソッドは actor context で実行されるため
-        // ループ内で self にアクセスするとデータ競合が発生しない
+        // @MainActor クラスのメソッドは MainActor 上で実行されるため、
+        // ループ内で self へのアクセスは MainActor により直列化される
         eventSubReceiveTask = Task { [weak self] in
             let stream = await client.chatMessageEventStream
             for await event in stream {
@@ -158,10 +167,17 @@ final class ChannelManager {
                 // subscribeChatMessage には認証済みユーザーの ID が必要
                 guard let userId = await self.authState.userId else { return }
                 guard let client = await self.eventSubClient else { return }
-                try? await client.subscribeChatMessage(
-                    broadcasterId: broadcasterId,
-                    userId: userId
-                )
+                do {
+                    try await client.subscribeChatMessage(
+                        broadcasterId: broadcasterId,
+                        userId: userId
+                    )
+                } catch {
+                    // 購読失敗は返信有効化に影響するがアプリは継続できる
+                    #if DEBUG
+                    print("[ChannelManager] EventSub subscribeChatMessage 失敗 broadcasterId=\(broadcasterId): \(error)")
+                    #endif
+                }
             }
         }
     }
@@ -179,7 +195,14 @@ final class ChannelManager {
 
         // room-id が確定済みならサブスクリプションを解除する
         if let broadcasterId = viewModel.currentRoomId {
-            try? await eventSubClient?.unsubscribeChatMessage(broadcasterId: broadcasterId)
+            do {
+                try await eventSubClient?.unsubscribeChatMessage(broadcasterId: broadcasterId)
+            } catch {
+                // 解除失敗は EventSub の 300 サブスクリプション上限に影響する可能性があるためログに残す
+                #if DEBUG
+                print("[ChannelManager] EventSub unsubscribeChatMessage 失敗 broadcasterId=\(broadcasterId): \(error)")
+                #endif
+            }
         }
 
         await viewModel.disconnect()

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -38,6 +38,18 @@ final class ChannelManager {
     /// IRC クライアントファクトリ（テスト時にモックを注入するために使用）
     private let makeIRCClient: @MainActor () -> any TwitchIRCClientProtocol
 
+    /// EventSub WebSocket クライアント（チャンネル横断で共有）
+    ///
+    /// 最初のチャンネル参加時に生成・接続し、全チャンネル退出後も維持する。
+    /// `disconnectAll()` 時に切断する。
+    private var eventSubClient: (any TwitchEventSubClientProtocol)?
+
+    /// EventSub クライアントファクトリ（テスト時にモックを注入するために使用）
+    private let makeEventSubClient: (@MainActor () -> any TwitchEventSubClientProtocol)?
+
+    /// EventSub イベント受信ループタスク
+    private var eventSubReceiveTask: Task<Void, Never>?
+
     // MARK: - 初期化
 
     /// ChannelManager を初期化する（本番用）
@@ -47,6 +59,9 @@ final class ChannelManager {
         self.authState = authState
         self.apiClient = HelixAPIClient(tokenProvider: authState)
         self.makeIRCClient = { TwitchIRCClient() }
+        self.makeEventSubClient = { [authState] in
+            TwitchEventSubClient(apiClient: HelixAPIClient(tokenProvider: authState))
+        }
     }
 
     /// ChannelManager を初期化する（テスト用: IRC クライアントファクトリを注入）
@@ -54,13 +69,16 @@ final class ChannelManager {
     /// - Parameters:
     ///   - authState: 認証状態
     ///   - makeIRCClient: IRC クライアントを生成するファクトリクロージャ
+    ///   - makeEventSubClient: EventSub クライアントを生成するファクトリクロージャ（nil で EventSub 無効化）
     init(
         authState: AuthState,
-        makeIRCClient: @escaping @MainActor () -> any TwitchIRCClientProtocol
+        makeIRCClient: @escaping @MainActor () -> any TwitchIRCClientProtocol,
+        makeEventSubClient: (@MainActor () -> any TwitchEventSubClientProtocol)? = nil
     ) {
         self.authState = authState
         self.apiClient = HelixAPIClient(tokenProvider: authState)
         self.makeIRCClient = makeIRCClient
+        self.makeEventSubClient = makeEventSubClient
     }
 
     // MARK: - 公開メソッド
@@ -87,9 +105,64 @@ final class ChannelManager {
         channelOrder.append(normalized)
         selectedChannel = normalized
 
+        // EventSub クライアントを初期化する（最初のチャンネル参加時のみ接続）
+        if eventSubClient == nil, let factory = makeEventSubClient {
+            let client = factory()
+            eventSubClient = client
+            Task {
+                try? await client.connect()
+                // EventSub イベント受信ループを起動する
+                await startEventSubReceiveLoop(client: client)
+            }
+        }
+
+        // room-id 確定時に EventSub サブスクリプションを登録するコールバックをセットする
+        setupRoomIdConfirmedCallback(for: viewModel, channelName: normalized)
+
         // バックグラウンドで接続開始（joinChannel がブロックされないように）
         Task {
             await viewModel.connect(to: normalized)
+        }
+    }
+
+    /// EventSub イベント受信ループを起動する
+    ///
+    /// 受信したイベントを broadcasterUserLogin からチャンネルを特定し、
+    /// 該当する ChatViewModel の handleEventSubChatMessage に振り分ける。
+    private func startEventSubReceiveLoop(client: any TwitchEventSubClientProtocol) async {
+        eventSubReceiveTask?.cancel()
+        // Swift Concurrency: actor メソッドは actor context で実行されるため
+        // ループ内で self にアクセスするとデータ競合が発生しない
+        eventSubReceiveTask = Task { [weak self] in
+            let stream = await client.chatMessageEventStream
+            for await event in stream {
+                await self?.routeEventSubChatMessage(event)
+            }
+        }
+    }
+
+    /// EventSub チャットメッセージイベントを対象チャンネルの ChatViewModel に振り分ける
+    private func routeEventSubChatMessage(_ event: EventSubChatEvent) {
+        let channelName = event.broadcasterUserLogin.lowercased()
+        channels[channelName]?.handleEventSubChatMessage(event)
+    }
+
+    /// ChatViewModel に room-id 確定コールバックをセットする
+    ///
+    /// room-id 確定時に EventSub の subscribeChatMessage を呼び出す。
+    /// 認証済みユーザーの ID は AuthState から取得する。
+    private func setupRoomIdConfirmedCallback(for viewModel: ChatViewModel, channelName: String) {
+        viewModel.onRoomIdConfirmed = { [weak self] broadcasterId in
+            guard let self else { return }
+            Task {
+                // subscribeChatMessage には認証済みユーザーの ID が必要
+                guard let userId = await self.authState.userId else { return }
+                guard let client = await self.eventSubClient else { return }
+                try? await client.subscribeChatMessage(
+                    broadcasterId: broadcasterId,
+                    userId: userId
+                )
+            }
         }
     }
 
@@ -103,6 +176,11 @@ final class ChannelManager {
         let normalized = channelLogin.lowercased()
 
         guard let viewModel = channels[normalized] else { return }
+
+        // room-id が確定済みならサブスクリプションを解除する
+        if let broadcasterId = viewModel.currentRoomId {
+            try? await eventSubClient?.unsubscribeChatMessage(broadcasterId: broadcasterId)
+        }
 
         await viewModel.disconnect()
         channels.removeValue(forKey: normalized)
@@ -164,5 +242,13 @@ final class ChannelManager {
         channels = [:]
         channelOrder = []
         selectedChannel = nil
+
+        // EventSub クライアントを切断してリソースを解放する
+        eventSubReceiveTask?.cancel()
+        eventSubReceiveTask = nil
+        if let client = eventSubClient {
+            await client.disconnect()
+        }
+        eventSubClient = nil
     }
 }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -557,6 +557,12 @@ final class ChatViewModel {
         let now = Date()
         let matchWindow: TimeInterval = 10
 
+        // 期限切れエントリを先に除去して辞書が無限に膨らむのを防ぐ
+        // EventSub 確認が来なかったメッセージが蓄積しないようにする
+        optimisticPendingMessages = optimisticPendingMessages.filter { _, sentAt in
+            now.timeIntervalSince(sentAt) < matchWindow
+        }
+
         // optimisticPendingMessages から候補を絞り込む
         // 条件: 対応する messages エントリのテキストが一致、かつ送信時刻が 10 秒以内
         let candidates = optimisticPendingMessages.filter { candidateId, sentAt in

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -124,6 +124,12 @@ final class ChatViewModel {
     /// ROOMSTATE 購読のポーリング条件として参照できるよう `private(set)` で公開する。
     private(set) var currentRoomId: String?
 
+    /// room-id が確定したときに呼ばれるコールバック
+    ///
+    /// ChannelManager が EventSub の subscribeChatMessage を呼ぶタイミングを知るために使用する。
+    /// room-id は最初の 1 回のみ確定するため、コールバックも 1 度だけ呼ばれる。
+    var onRoomIdConfirmed: ((String) -> Void)?
+
     /// 楽観的 UI メッセージの送信時刻マップ（messageId → 送信時刻）
     ///
     /// 複数のメッセージを連続送信した場合でも各メッセージを個別に rollback できるよう
@@ -317,6 +323,8 @@ final class ChatViewModel {
     private func applyRoomState(roomId: String) {
         if currentRoomId == nil {
             currentRoomId = roomId
+            // room-id 確定を ChannelManager に通知する（EventSub サブスクリプション登録に使用）
+            onRoomIdConfirmed?(roomId)
         }
     }
 
@@ -527,6 +535,46 @@ final class ChatViewModel {
     /// 送信エラーをリセットする（UI でエラー表示を消す際に呼ぶ）
     func clearSendError() {
         sendError = nil
+    }
+
+    /// EventSub `channel.chat.message` イベントを処理する
+    ///
+    /// `optimisticPendingMessages` に記録されている楽観的 UI メッセージと照合し、
+    /// 一致すれば本物の message ID で差し替え `isOptimistic` を false にする。
+    /// これにより、自分のメッセージへの返信機能が有効化される。
+    ///
+    /// マッチング条件:
+    /// 1. 送信者ログイン名が自分と一致
+    /// 2. メッセージテキストが完全一致
+    /// 3. 送信時刻が楽観的メッセージの追加時刻から 10 秒以内
+    ///
+    /// - Parameter event: EventSub から受信した channel.chat.message イベント
+    func handleEventSubChatMessage(_ event: EventSubChatEvent) {
+        // 自分のメッセージのみ照合する（他人のメッセージは IRC 経由で受信済み）
+        guard case .loggedIn(let login) = authState.status,
+              event.chatterUserLogin == login else { return }
+
+        let now = Date()
+        let matchWindow: TimeInterval = 10
+
+        // optimisticPendingMessages から候補を絞り込む
+        // 条件: 対応する messages エントリのテキストが一致、かつ送信時刻が 10 秒以内
+        let candidates = optimisticPendingMessages.filter { candidateId, sentAt in
+            guard let msg = messages.first(where: { $0.id == candidateId }) else { return false }
+            return msg.text == event.message.text
+                && abs(sentAt.timeIntervalSince(now)) < matchWindow
+        }
+
+        // 同一テキストの連投がある場合は最も古いエントリを優先（FIFO）
+        guard let (optimisticId, _) = candidates.min(by: { $0.value < $1.value }) else { return }
+
+        // messages 配列内で本物の ID に差し替える
+        if let index = messages.firstIndex(where: { $0.id == optimisticId }) {
+            messages[index] = ChatMessage(confirming: messages[index], withRealId: event.messageId)
+        }
+
+        // pending から除去する
+        optimisticPendingMessages.removeValue(forKey: optimisticId)
     }
 
     /// サーバーから受信した NOTICE を処理する

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -561,8 +561,10 @@ final class ChatViewModel {
         // 条件: 対応する messages エントリのテキストが一致、かつ送信時刻が 10 秒以内
         let candidates = optimisticPendingMessages.filter { candidateId, sentAt in
             guard let msg = messages.first(where: { $0.id == candidateId }) else { return false }
+            let elapsed = now.timeIntervalSince(sentAt)
             return msg.text == event.message.text
-                && abs(sentAt.timeIntervalSince(now)) < matchWindow
+                && elapsed >= 0
+                && elapsed < matchWindow
         }
 
         // 同一テキストの連投がある場合は最も古いエントリを優先（FIFO）

--- a/Tests/TwitchChatTests/AuthStateTests.swift
+++ b/Tests/TwitchChatTests/AuthStateTests.swift
@@ -35,7 +35,7 @@ struct AuthStateTests {
                 clientId: "testclientid",
                 login: "テスト配信者",
                 userId: "12345678",
-                scopes: ["chat:read", "chat:edit", "user:read:follows"],
+                scopes: ["chat:read", "chat:edit", "user:read:follows", "user:read:chat"],
                 expiresIn: 10000
             )
         )
@@ -233,13 +233,13 @@ struct AuthStateTests {
         let store = makeTestKeychainStore()
         try await store.save(key: "access_token", value: "テスト用トークン")
 
-        // 前提: chat:read と chat:edit を含む validateResponse を返すモック
+        // 前提: 必須スコープ（chat:edit・user:read:chat）を含む validateResponse を返すモック
         let mockClient = MockTwitchAuthClient(
             validateResponse: TwitchValidateResponse(
                 clientId: "testclientid",
                 login: "配信者ユーザー",
                 userId: "99999",
-                scopes: ["chat:read", "chat:edit"],
+                scopes: ["chat:read", "chat:edit", "user:read:chat"],
                 expiresIn: 14400
             )
         )

--- a/Tests/TwitchChatTests/AuthStateTests.swift
+++ b/Tests/TwitchChatTests/AuthStateTests.swift
@@ -67,13 +67,13 @@ struct AuthStateTests {
                 refreshToken: "新しいリフレッシュトークン",
                 expiresIn: 14400,
                 tokenType: "bearer",
-                scope: ["chat:read"]
+                scope: ["chat:read", "chat:edit", "user:read:chat"]
             ),
             validateResponse: TwitchValidateResponse(
                 clientId: "testclientid",
                 login: "テスト配信者",
                 userId: "12345678",
-                scopes: ["chat:read"],
+                scopes: ["chat:read", "chat:edit", "user:read:chat"],
                 expiresIn: 14400
             )
         )
@@ -125,13 +125,13 @@ struct AuthStateTests {
                 refreshToken: "テスト用リフレッシュトークン",
                 expiresIn: 14400,
                 tokenType: "bearer",
-                scope: ["chat:read"]
+                scope: ["chat:read", "chat:edit", "user:read:chat"]
             ),
             validateResponse: TwitchValidateResponse(
                 clientId: "testclientid",
                 login: "テスト配信者",
                 userId: "12345678",
-                scopes: ["chat:read"],
+                scopes: ["chat:read", "chat:edit", "user:read:chat"],
                 expiresIn: 14400
             )
         )
@@ -272,13 +272,13 @@ struct AuthStateTests {
                 refreshToken: "テスト用リフレッシュトークン",
                 expiresIn: 14400,
                 tokenType: "bearer",
-                scope: ["chat:read", "chat:edit"]
+                scope: ["chat:read", "chat:edit", "user:read:chat"]
             ),
             validateResponse: TwitchValidateResponse(
                 clientId: "testclientid",
                 login: "新規ログイン者",
                 userId: "11111",
-                scopes: ["chat:read", "chat:edit"],
+                scopes: ["chat:read", "chat:edit", "user:read:chat"],
                 expiresIn: 14400
             )
         )

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -348,4 +348,143 @@ struct ChannelManagerTests {
 
         #expect(manager.channelOrder == ["haishinsha3", "haishinsha1", "haishinsha2"])
     }
+
+    // MARK: - EventSub 組み込み
+
+    @Test("joinChannel 時に EventSub クライアントが接続される")
+    func testJoinChannelStartsEventSub() async throws {
+        // 前提: MockTwitchEventSubClient を注入できる ChannelManager を作成する
+        let mockEventSub = MockTwitchEventSubClient()
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            makeEventSubClient: { mockEventSub }
+        )
+
+        // 操作: チャンネルに参加する
+        await manager.joinChannel("haishinsha1")
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 検証: EventSub の connect() が呼ばれている
+        let connectCount = await mockEventSub.connectCallCount
+        #expect(connectCount == 1)
+    }
+
+    @Test("disconnectAll 時に EventSub クライアントが切断される")
+    func testDisconnectAllStopsEventSub() async throws {
+        // 前提: EventSub 接続済みの状態
+        let mockEventSub = MockTwitchEventSubClient()
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            makeEventSubClient: { mockEventSub }
+        )
+        await manager.joinChannel("haishinsha1")
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 操作: 全チャンネルから切断する
+        await manager.disconnectAll()
+
+        // 検証: EventSub の disconnect() が呼ばれている
+        let disconnected = await mockEventSub.disconnectCalled
+        #expect(disconnected == true)
+    }
+
+    @Test("roomId 確定時に ChatViewModel の onRoomIdConfirmed コールバックがセットされている")
+    func testRoomIdConfirmedCallbackIsConfigured() async throws {
+        // 前提: MockTwitchIRCClient と MockTwitchEventSubClient を使う
+        let mockIRC = MockTwitchIRCClient()
+        let mockEventSub = MockTwitchEventSubClient()
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { mockIRC },
+            makeEventSubClient: { mockEventSub }
+        )
+
+        // チャンネルに参加する
+        await manager.joinChannel("haishinsha1")
+        try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+
+        // 検証: 対応する ChatViewModel に onRoomIdConfirmed コールバックがセットされている
+        let viewModel = manager.channels["haishinsha1"]
+        #expect(viewModel?.onRoomIdConfirmed != nil)
+    }
+
+    @Test("roomId 確定時に EventSub のサブスクリプションが登録される（ログイン済み）")
+    func testRoomIdConfirmedTriggersEventSubSubscriptionWhenLoggedIn() async throws {
+        // 前提: MockTwitchIRCClient と MockTwitchEventSubClient を使う
+        // AuthState のユーザー ID を直接設定してログイン済み状態をシミュレートする
+        let mockIRC = MockTwitchIRCClient()
+        let mockEventSub = MockTwitchEventSubClient()
+        let authState = AuthState()
+        // テスト用に userId を直接設定する（実際のログインフローをバイパス）
+        await authState.setUserIdForTesting("テストユーザーID-12345")
+        let manager = ChannelManager(
+            authState: authState,
+            makeIRCClient: { mockIRC },
+            makeEventSubClient: { mockEventSub }
+        )
+
+        // チャンネルに参加して IRC 接続状態にする
+        await manager.joinChannel("haishinsha1")
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // ROOMSTATE で room-id を確定させる（ViewModel の onRoomIdConfirmed が呼ばれるはず）
+        await mockIRC.sendRoomState(roomId: "配信者ID-12345")
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 検証: EventSub の subscribeChatMessage が呼ばれている
+        let subscribeCount = await mockEventSub.subscribeChatMessageCallCount
+        #expect(subscribeCount >= 1)
+    }
+}
+
+// MARK: - MockTwitchEventSubClient
+
+/// EventSub クライアントのテスト用モック
+actor MockTwitchEventSubClient: TwitchEventSubClientProtocol {
+    let chatMessageEventStream: AsyncStream<EventSubChatEvent>
+    let connectionStateStream: AsyncStream<EventSubConnectionState>
+
+    private var chatContinuation: AsyncStream<EventSubChatEvent>.Continuation?
+    private var stateContinuation: AsyncStream<EventSubConnectionState>.Continuation?
+
+    private(set) var connectCallCount = 0
+    private(set) var disconnectCalled = false
+    private(set) var subscribeChatMessageCallCount = 0
+    private(set) var unsubscribeChatMessageCallCount = 0
+    private(set) var sessionId: String? = "mock-session-id"
+
+    init() {
+        var chatCont: AsyncStream<EventSubChatEvent>.Continuation?
+        self.chatMessageEventStream = AsyncStream { chatCont = $0 }
+        self.chatContinuation = chatCont
+
+        var stateCont: AsyncStream<EventSubConnectionState>.Continuation?
+        self.connectionStateStream = AsyncStream { stateCont = $0 }
+        self.stateContinuation = stateCont
+    }
+
+    func connect() async throws {
+        connectCallCount += 1
+        stateContinuation?.yield(.connected)
+    }
+
+    func disconnect() async {
+        disconnectCalled = true
+        stateContinuation?.yield(.disconnected)
+    }
+
+    func subscribeChatMessage(broadcasterId: String, userId: String) async throws {
+        subscribeChatMessageCallCount += 1
+    }
+
+    func unsubscribeChatMessage(broadcasterId: String) async throws {
+        unsubscribeChatMessageCallCount += 1
+    }
+
+    /// テスト用に chatMessage イベントを流し込む
+    func sendChatMessageEvent(_ event: EventSubChatEvent) {
+        chatContinuation?.yield(event)
+    }
 }

--- a/Tests/TwitchChatTests/ChatMessageTests.swift
+++ b/Tests/TwitchChatTests/ChatMessageTests.swift
@@ -479,4 +479,70 @@ struct ChatMessageTests {
         // 検証: replyParentMsgId が nil になる
         #expect(chatMessage.replyParentMsgId == nil)
     }
+
+    // MARK: - confirming init（EventSub ID 差し替え）
+
+    @Test("confirming init で id が本物の message ID に差し替わる")
+    func confirmingInitDiffersId() {
+        // 前提: 楽観的 UI メッセージを生成する（ローカル UUID を持つ）
+        let optimistic = ChatMessage(
+            localUsername: "testuseraccount",
+            text: "こんにちは！EventSubテスト"
+        )
+        // 楽観的メッセージは isOptimistic: true で、ローカル UUID を持つ
+        #expect(optimistic.isOptimistic == true)
+        let localId = optimistic.id
+
+        // 操作: EventSub で受信した本物の message ID で差し替える
+        let realMessageId = "cc106a7e-1a9f-4c07-8c4b-f5f7a0a87c15"
+        let confirmed = ChatMessage(confirming: optimistic, withRealId: realMessageId)
+
+        // 検証: id が本物の message ID に差し替わっている
+        #expect(confirmed.id == realMessageId)
+        #expect(confirmed.id != localId)
+    }
+
+    @Test("confirming init で isOptimistic が false になる")
+    func confirmingInitSetsIsOptimisticFalse() {
+        // 前提: 楽観的 UI メッセージ（isOptimistic: true）
+        let optimistic = ChatMessage(
+            localUsername: "testuseraccount",
+            text: "返信テスト用メッセージ"
+        )
+        #expect(optimistic.isOptimistic == true)
+
+        // 操作: 本物の ID で差し替える
+        let confirmed = ChatMessage(confirming: optimistic, withRealId: "real-msg-id-xyz")
+
+        // 検証: isOptimistic が false になり、返信ボタンが有効化される
+        #expect(confirmed.isOptimistic == false)
+    }
+
+    @Test("confirming init で他のフィールドがすべて保持される")
+    func confirmingInitPreservesOtherFields() {
+        // 前提: フィールドを指定して楽観的メッセージを生成する
+        let optimistic = ChatMessage(
+            localUsername: "testuseraccount",
+            displayName: "テストユーザー",
+            text: "フィールド保持テスト",
+            isAction: true,
+            roomId: "部屋ID-12345",
+            colorHex: "#FF4500",
+            badges: [],
+            replyParentMsgId: "親メッセージ-id-abc"
+        )
+
+        // 操作: 本物の ID で差し替える
+        let confirmed = ChatMessage(confirming: optimistic, withRealId: "real-msg-confirmed")
+
+        // 検証: id と isOptimistic 以外のフィールドがすべて保持される
+        #expect(confirmed.username == "testuseraccount")
+        #expect(confirmed.displayName == "テストユーザー")
+        #expect(confirmed.text == "フィールド保持テスト")
+        #expect(confirmed.isAction == true)
+        #expect(confirmed.roomId == "部屋ID-12345")
+        #expect(confirmed.colorHex == "#FF4500")
+        #expect(confirmed.replyParentMsgId == "親メッセージ-id-abc")
+        #expect(confirmed.isSystemNotice == false)
+    }
 }

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -643,13 +643,13 @@ struct ChatViewModelTests {
                 refreshToken: "テスト用リフレッシュトークン",
                 expiresIn: 14400,
                 tokenType: "bearer",
-                scope: ["chat:read", "chat:edit"]
+                scope: ["chat:read", "chat:edit", "user:read:chat"]
             ),
             validateResponse: TwitchValidateResponse(
                 clientId: "testclientid",
                 login: userLogin,
                 userId: "12345",
-                scopes: ["chat:read", "chat:edit"],
+                scopes: ["chat:read", "chat:edit", "user:read:chat"],
                 expiresIn: 14400
             )
         )

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -1050,4 +1050,110 @@ struct ChatViewModelTests {
             try await viewModel.sendMessage("/ban あらし太郎")
         }
     }
+
+    // MARK: - EventSub ID 差し替え（handleEventSubChatMessage）
+
+    @Test("EventSub イベントで楽観的メッセージの ID が本物の message ID に差し替わる")
+    func eventSubイベントで楽観的メッセージのIDが差し替わる() async throws {
+        // 前提: 認証接続済みの状態でメッセージを送信して楽観的メッセージを追加する
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "testuseraccount")
+        try await viewModel.sendMessage("EventSubテストメッセージ")
+        await waitFor { viewModel.messages.count >= 1 }
+
+        let optimistic = try #require(viewModel.messages.first)
+        #expect(optimistic.isOptimistic == true)
+        let localId = optimistic.id
+
+        // 操作: EventSub イベントで本物の ID を通知する
+        let event = EventSubChatEvent(
+            broadcasterUserId: "12826",
+            broadcasterUserLogin: "testchannel",
+            chatterUserId: "142672450",
+            chatterUserLogin: "testuseraccount",
+            messageId: "real-eventsub-msg-id-abc123",
+            message: EventSubChatMessageContent(text: "EventSubテストメッセージ")
+        )
+        viewModel.handleEventSubChatMessage(event)
+
+        // 検証: messages 配列の楽観的メッセージが本物の ID に差し替わっている
+        let confirmed = try #require(viewModel.messages.first)
+        #expect(confirmed.id == "real-eventsub-msg-id-abc123")
+        #expect(confirmed.id != localId)
+        #expect(confirmed.isOptimistic == false)
+    }
+
+    @Test("EventSub イベントで isOptimistic が false になり返信ボタンが有効化される")
+    func eventSubイベントでisOptimisticがfalseになる() async throws {
+        // 前提: 認証接続済みの状態でメッセージを送信する
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "testuseraccount")
+        try await viewModel.sendMessage("返信テスト用メッセージ")
+        await waitFor { viewModel.messages.count >= 1 }
+
+        // 前提: 楽観的メッセージが isOptimistic: true になっている
+        #expect(viewModel.messages.first?.isOptimistic == true)
+
+        // 操作: EventSub イベントで ID を確定させる
+        let event = EventSubChatEvent(
+            broadcasterUserId: "12826",
+            broadcasterUserLogin: "testchannel",
+            chatterUserId: "142672450",
+            chatterUserLogin: "testuseraccount",
+            messageId: "real-msg-id-for-reply",
+            message: EventSubChatMessageContent(text: "返信テスト用メッセージ")
+        )
+        viewModel.handleEventSubChatMessage(event)
+
+        // 検証: isOptimistic が false になっている（返信ボタン有効化）
+        #expect(viewModel.messages.first?.isOptimistic == false)
+    }
+
+    @Test("他人のメッセージの EventSub イベントは楽観的メッセージを差し替えない")
+    func 他人のメッセージのEventSubイベントは楽観的メッセージを差し替えない() async throws {
+        // 前提: 認証接続済みの状態でメッセージを送信する
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "testuseraccount")
+        try await viewModel.sendMessage("自分のメッセージ")
+        await waitFor { viewModel.messages.count >= 1 }
+
+        let localId = viewModel.messages.first?.id
+
+        // 操作: 他人（異なるログイン名）の EventSub イベントを通知する
+        let event = EventSubChatEvent(
+            broadcasterUserId: "12826",
+            broadcasterUserLogin: "testchannel",
+            chatterUserId: "999999",
+            chatterUserLogin: "otheruser",  // 自分とは異なるユーザー
+            messageId: "other-user-msg-id",
+            message: EventSubChatMessageContent(text: "自分のメッセージ")
+        )
+        viewModel.handleEventSubChatMessage(event)
+
+        // 検証: 楽観的メッセージの ID は差し替わっていない
+        #expect(viewModel.messages.first?.id == localId)
+        #expect(viewModel.messages.first?.isOptimistic == true)
+    }
+
+    @Test("テキストが一致しない EventSub イベントは楽観的メッセージを差し替えない")
+    func テキストが一致しないEventSubイベントは楽観的メッセージを差し替えない() async throws {
+        // 前提: 認証接続済みの状態でメッセージを送信する
+        let (viewModel, _) = try await makeConnectedViewModel(userLogin: "testuseraccount")
+        try await viewModel.sendMessage("送信したメッセージA")
+        await waitFor { viewModel.messages.count >= 1 }
+
+        let localId = viewModel.messages.first?.id
+
+        // 操作: テキストが異なる EventSub イベントを通知する
+        let event = EventSubChatEvent(
+            broadcasterUserId: "12826",
+            broadcasterUserLogin: "testchannel",
+            chatterUserId: "142672450",
+            chatterUserLogin: "testuseraccount",
+            messageId: "different-text-msg-id",
+            message: EventSubChatMessageContent(text: "全く別のメッセージB")  // テキスト不一致
+        )
+        viewModel.handleEventSubChatMessage(event)
+
+        // 検証: 楽観的メッセージの ID は差し替わっていない
+        #expect(viewModel.messages.first?.id == localId)
+        #expect(viewModel.messages.first?.isOptimistic == true)
+    }
 }

--- a/Tests/TwitchChatTests/EventSubModelsTests.swift
+++ b/Tests/TwitchChatTests/EventSubModelsTests.swift
@@ -1,9 +1,66 @@
 // EventSubModelsTests.swift
 // EventSub WebSocket メッセージ種別の JSON デコードテスト
 
-import Testing
 import Foundation
+import Testing
 @testable import TwitchChat
+
+// MARK: - サンプル JSON（関数外定義で function_body_length 制限を回避）
+
+/// notification (channel.chat.message) テスト用サンプル JSON
+private let notificationChatMessageJSON = """
+{
+  "metadata": {
+    "message_id": "befa7b53-d79d-478f-86b9-120f112b044e",
+    "message_type": "notification",
+    "message_timestamp": "2022-11-16T10:11:12.464757833Z",
+    "subscription_type": "channel.chat.message",
+    "subscription_version": "1"
+  },
+  "payload": {
+    "subscription": {
+      "id": "sub-id-123",
+      "status": "enabled",
+      "type": "channel.chat.message",
+      "version": "1",
+      "cost": 0,
+      "condition": {
+        "broadcaster_user_id": "12826",
+        "user_id": "142672450"
+      },
+      "transport": {
+        "method": "websocket",
+        "session_id": "AQoQILE98gtqShGmLD7AM6yJThAB"
+      },
+      "created_at": "2022-11-16T10:11:12.464757833Z"
+    },
+    "event": {
+      "broadcaster_user_id": "12826",
+      "broadcaster_user_login": "twitch",
+      "broadcaster_user_name": "Twitch",
+      "chatter_user_id": "142672450",
+      "chatter_user_login": "testuseraccount",
+      "chatter_user_name": "testUserAccount",
+      "message_id": "cc106a7e-1a9f-4c07-8c4b-f5f7a0a87c15",
+      "message": {
+        "text": "こんにちは！テストメッセージ",
+        "fragments": []
+      },
+      "color": "#00FF7F",
+      "badges": [],
+      "message_type": "text",
+      "cheer": null,
+      "reply": null,
+      "channel_points_custom_reward_id": null,
+      "source_broadcaster_user_id": null,
+      "source_broadcaster_user_login": null,
+      "source_broadcaster_user_name": null,
+      "source_message_id": null,
+      "source_channel_points_custom_reward_id": null
+    }
+  }
+}
+"""
 
 @Suite("EventSubModels")
 struct EventSubModelsTests {
@@ -104,62 +161,11 @@ struct EventSubModelsTests {
 
     @Test("notification (channel.chat.message) メッセージをデコードできる")
     func decodeNotificationChatMessage() throws {
-        let json = """
-        {
-          "metadata": {
-            "message_id": "befa7b53-d79d-478f-86b9-120f112b044e",
-            "message_type": "notification",
-            "message_timestamp": "2022-11-16T10:11:12.464757833Z",
-            "subscription_type": "channel.chat.message",
-            "subscription_version": "1"
-          },
-          "payload": {
-            "subscription": {
-              "id": "sub-id-123",
-              "status": "enabled",
-              "type": "channel.chat.message",
-              "version": "1",
-              "cost": 0,
-              "condition": {
-                "broadcaster_user_id": "12826",
-                "user_id": "142672450"
-              },
-              "transport": {
-                "method": "websocket",
-                "session_id": "AQoQILE98gtqShGmLD7AM6yJThAB"
-              },
-              "created_at": "2022-11-16T10:11:12.464757833Z"
-            },
-            "event": {
-              "broadcaster_user_id": "12826",
-              "broadcaster_user_login": "twitch",
-              "broadcaster_user_name": "Twitch",
-              "chatter_user_id": "142672450",
-              "chatter_user_login": "testuseraccount",
-              "chatter_user_name": "testUserAccount",
-              "message_id": "cc106a7e-1a9f-4c07-8c4b-f5f7a0a87c15",
-              "message": {
-                "text": "こんにちは！テストメッセージ",
-                "fragments": []
-              },
-              "color": "#00FF7F",
-              "badges": [],
-              "message_type": "text",
-              "cheer": null,
-              "reply": null,
-              "channel_points_custom_reward_id": null,
-              "source_broadcaster_user_id": null,
-              "source_broadcaster_user_login": null,
-              "source_broadcaster_user_name": null,
-              "source_message_id": null,
-              "source_channel_points_custom_reward_id": null
-            }
-          }
-        }
-        """
-        let data = try #require(json.data(using: .utf8))
+        // 前提: notificationChatMessageJSON（ファイル上部に定義）を使用
+        let data = try #require(notificationChatMessageJSON.data(using: .utf8))
         let message = try decoder.decode(EventSubMessage.self, from: data)
 
+        // 検証: メタデータとイベントフィールドが正しくデコードされている
         #expect(message.metadata.messageType == .notification)
         #expect(message.metadata.subscriptionType == "channel.chat.message")
 

--- a/Tests/TwitchChatTests/EventSubModelsTests.swift
+++ b/Tests/TwitchChatTests/EventSubModelsTests.swift
@@ -1,0 +1,232 @@
+// EventSubModelsTests.swift
+// EventSub WebSocket メッセージ種別の JSON デコードテスト
+
+import Testing
+import Foundation
+@testable import TwitchChat
+
+@Suite("EventSubModels")
+struct EventSubModelsTests {
+
+    private let decoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
+
+    // MARK: - session_welcome
+
+    @Test("session_welcome メッセージをデコードできる")
+    func decodeSessionWelcome() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "96a3f3b5-5dec-4eed-908e-e11ee657416c",
+            "message_type": "session_welcome",
+            "message_timestamp": "2023-07-19T14:56:51.634234626Z"
+          },
+          "payload": {
+            "session": {
+              "id": "AQoQILE98gtqShGmLD7AM6yJThAB",
+              "status": "connected",
+              "connected_at": "2023-07-19T14:56:51.616329898Z",
+              "keepalive_timeout_seconds": 10,
+              "reconnect_url": null
+            }
+          }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageId == "96a3f3b5-5dec-4eed-908e-e11ee657416c")
+        #expect(message.metadata.messageType == .sessionWelcome)
+        #expect(message.payload.session?.id == "AQoQILE98gtqShGmLD7AM6yJThAB")
+        #expect(message.payload.session?.keepaliveTimeoutSeconds == 10)
+        #expect(message.payload.session?.reconnectUrl == nil)
+        #expect(message.payload.event == nil)
+    }
+
+    // MARK: - session_keepalive
+
+    @Test("session_keepalive メッセージをデコードできる")
+    func decodeSessionKeepalive() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "84c1407e-1234-5678-abcd-ef0123456789",
+            "message_type": "session_keepalive",
+            "message_timestamp": "2023-07-19T10:11:12.634234626Z"
+          },
+          "payload": {}
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageType == .sessionKeepalive)
+        #expect(message.payload.session == nil)
+        #expect(message.payload.event == nil)
+    }
+
+    // MARK: - session_reconnect
+
+    @Test("session_reconnect メッセージをデコードできる")
+    func decodeSessionReconnect() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "84c1407e-aaaa-bbbb-cccc-dddddddddddd",
+            "message_type": "session_reconnect",
+            "message_timestamp": "2022-11-18T09:10:11.634234626Z"
+          },
+          "payload": {
+            "session": {
+              "id": "AQoQexAWVYKSTIu4ec_2VAryTfrm",
+              "status": "reconnecting",
+              "keepalive_timeout_seconds": null,
+              "reconnect_url": "wss://eventsub.wss.twitch.tv?reconnect_token=abc123",
+              "connected_at": "2022-11-16T10:11:12.634234626Z"
+            }
+          }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageType == .sessionReconnect)
+        #expect(message.payload.session?.id == "AQoQexAWVYKSTIu4ec_2VAryTfrm")
+        #expect(message.payload.session?.reconnectUrl == "wss://eventsub.wss.twitch.tv?reconnect_token=abc123")
+        #expect(message.payload.session?.keepaliveTimeoutSeconds == nil)
+    }
+
+    // MARK: - notification (channel.chat.message)
+
+    @Test("notification (channel.chat.message) メッセージをデコードできる")
+    func decodeNotificationChatMessage() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "befa7b53-d79d-478f-86b9-120f112b044e",
+            "message_type": "notification",
+            "message_timestamp": "2022-11-16T10:11:12.464757833Z",
+            "subscription_type": "channel.chat.message",
+            "subscription_version": "1"
+          },
+          "payload": {
+            "subscription": {
+              "id": "sub-id-123",
+              "status": "enabled",
+              "type": "channel.chat.message",
+              "version": "1",
+              "cost": 0,
+              "condition": {
+                "broadcaster_user_id": "12826",
+                "user_id": "142672450"
+              },
+              "transport": {
+                "method": "websocket",
+                "session_id": "AQoQILE98gtqShGmLD7AM6yJThAB"
+              },
+              "created_at": "2022-11-16T10:11:12.464757833Z"
+            },
+            "event": {
+              "broadcaster_user_id": "12826",
+              "broadcaster_user_login": "twitch",
+              "broadcaster_user_name": "Twitch",
+              "chatter_user_id": "142672450",
+              "chatter_user_login": "testuseraccount",
+              "chatter_user_name": "testUserAccount",
+              "message_id": "cc106a7e-1a9f-4c07-8c4b-f5f7a0a87c15",
+              "message": {
+                "text": "こんにちは！テストメッセージ",
+                "fragments": []
+              },
+              "color": "#00FF7F",
+              "badges": [],
+              "message_type": "text",
+              "cheer": null,
+              "reply": null,
+              "channel_points_custom_reward_id": null,
+              "source_broadcaster_user_id": null,
+              "source_broadcaster_user_login": null,
+              "source_broadcaster_user_name": null,
+              "source_message_id": null,
+              "source_channel_points_custom_reward_id": null
+            }
+          }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageType == .notification)
+        #expect(message.metadata.subscriptionType == "channel.chat.message")
+
+        let event = try #require(message.payload.event)
+        #expect(event.messageId == "cc106a7e-1a9f-4c07-8c4b-f5f7a0a87c15")
+        #expect(event.broadcasterUserLogin == "twitch")
+        #expect(event.chatterUserLogin == "testuseraccount")
+        #expect(event.message.text == "こんにちは！テストメッセージ")
+    }
+
+    // MARK: - revocation
+
+    @Test("revocation メッセージをデコードできる")
+    func decodeRevocation() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "84c1407e-rev-sub-revoked-000000",
+            "message_type": "revocation",
+            "message_timestamp": "2022-11-16T10:11:12.634234626Z",
+            "subscription_type": "channel.follow",
+            "subscription_version": "1"
+          },
+          "payload": {
+            "subscription": {
+              "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+              "status": "authorization_revoked",
+              "type": "channel.follow",
+              "version": "1",
+              "cost": 0,
+              "condition": {
+                "broadcaster_user_id": "12826",
+                "user_id": "142672450"
+              },
+              "transport": {
+                "method": "websocket",
+                "session_id": "AQoQILE98gtqShGmLD7AM6yJThAB"
+              },
+              "created_at": "2022-11-16T10:11:12.634234626Z"
+            }
+          }
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageType == .revocation)
+        #expect(message.payload.event == nil)
+    }
+
+    // MARK: - 不明な message_type
+
+    @Test("不明な message_type は unknown として扱われる")
+    func decodeUnknownMessageType() throws {
+        let json = """
+        {
+          "metadata": {
+            "message_id": "unknown-type-test-id",
+            "message_type": "some_future_type",
+            "message_timestamp": "2023-01-01T00:00:00.000000000Z"
+          },
+          "payload": {}
+        }
+        """
+        let data = try #require(json.data(using: .utf8))
+        let message = try decoder.decode(EventSubMessage.self, from: data)
+
+        #expect(message.metadata.messageType == .unknown)
+    }
+}

--- a/Tests/TwitchChatTests/TwitchEventSubClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchEventSubClientTests.swift
@@ -1,0 +1,342 @@
+// TwitchEventSubClientTests.swift
+// TwitchEventSubClient の単体テスト
+// MockWebSocketClient と MockHelixAPIClient を使用してネットワーク通信なしで検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - Helix API モック
+
+/// EventSub テスト用の Helix API クライアントモック
+///
+/// サブスクリプション登録 API の呼び出しを記録し、テスト可能なレスポンスを返す
+actor MockHelixAPIClientForEventSub: HelixAPIClientProtocol {
+    /// POST 呼び出し時に返すレスポンスボディ（JSON 文字列 → Data）
+    var postResponse: Data?
+
+    /// 送信されたリクエストボディの記録
+    private(set) var capturedPostBodies: [Data] = []
+
+    /// DELETE 呼び出し時の記録
+    private(set) var deletedURLs: [URL] = []
+
+    /// POST 呼び出し回数
+    private(set) var postCallCount = 0
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        throw URLError(.unsupportedURL)
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T {
+        postCallCount += 1
+        // リクエストボディをエンコードして記録する
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(body) {
+            capturedPostBodies.append(data)
+        }
+        guard let responseData = postResponse else {
+            throw URLError(.badServerResponse)
+        }
+        let decoder = JSONDecoder()
+        return try decoder.decode(T.self, from: responseData)
+    }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        postCallCount += 1
+        let encoder = JSONEncoder()
+        if let data = try? encoder.encode(body) {
+            capturedPostBodies.append(data)
+        }
+    }
+
+    func patch<Body: Encodable & Sendable>(url: URL, queryItems: [URLQueryItem]?, body: Body) async throws {
+        // EventSub テストでは使用しない
+    }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        deletedURLs.append(url)
+    }
+
+    /// POST レスポンスを JSON 文字列でセットする
+    func setPostResponse(_ json: String) {
+        postResponse = json.data(using: .utf8)
+    }
+}
+
+// MARK: - ヘルパー
+
+/// EventSub テストで使用するサンプル JSON メッセージ
+private enum EventSubSampleMessages {
+    static let welcome = """
+    {
+      "metadata": {
+        "message_id": "welcome-msg-id-001",
+        "message_type": "session_welcome",
+        "message_timestamp": "2023-07-19T14:56:51.634234626Z"
+      },
+      "payload": {
+        "session": {
+          "id": "test-session-id-abc123",
+          "status": "connected",
+          "connected_at": "2023-07-19T14:56:51.616329898Z",
+          "keepalive_timeout_seconds": 10,
+          "reconnect_url": null
+        }
+      }
+    }
+    """
+
+    static let keepalive = """
+    {
+      "metadata": {
+        "message_id": "keepalive-msg-id-002",
+        "message_type": "session_keepalive",
+        "message_timestamp": "2023-07-19T14:57:00.000000000Z"
+      },
+      "payload": {}
+    }
+    """
+
+    static func notification(
+        broadcasterLogin: String = "twitch",
+        chatterLogin: String = "testuseraccount",
+        messageId: String = "real-msg-id-xyz",
+        text: String = "こんにちは！"
+    ) -> String {
+        """
+        {
+          "metadata": {
+            "message_id": "notif-meta-id-003",
+            "message_type": "notification",
+            "message_timestamp": "2022-11-16T10:11:12.464757833Z",
+            "subscription_type": "channel.chat.message",
+            "subscription_version": "1"
+          },
+          "payload": {
+            "subscription": {
+              "id": "sub-id-001",
+              "status": "enabled",
+              "type": "channel.chat.message"
+            },
+            "event": {
+              "broadcaster_user_id": "12826",
+              "broadcaster_user_login": "\(broadcasterLogin)",
+              "broadcaster_user_name": "\(broadcasterLogin)",
+              "chatter_user_id": "142672450",
+              "chatter_user_login": "\(chatterLogin)",
+              "chatter_user_name": "\(chatterLogin)",
+              "message_id": "\(messageId)",
+              "message": {
+                "text": "\(text)",
+                "fragments": []
+              },
+              "color": "#00FF7F",
+              "badges": [],
+              "message_type": "text",
+              "cheer": null,
+              "reply": null,
+              "channel_points_custom_reward_id": null,
+              "source_broadcaster_user_id": null,
+              "source_broadcaster_user_login": null,
+              "source_broadcaster_user_name": null,
+              "source_message_id": null,
+              "source_channel_points_custom_reward_id": null
+            }
+          }
+        }
+        """
+    }
+
+    static func reconnect(newUrl: String) -> String {
+        """
+        {
+          "metadata": {
+            "message_id": "reconnect-msg-id-004",
+            "message_type": "session_reconnect",
+            "message_timestamp": "2022-11-18T09:10:11.634234626Z"
+          },
+          "payload": {
+            "session": {
+              "id": "new-session-id-xyz",
+              "status": "reconnecting",
+              "keepalive_timeout_seconds": null,
+              "reconnect_url": "\(newUrl)",
+              "connected_at": "2022-11-16T10:11:12.634234626Z"
+            }
+          }
+        }
+        """
+    }
+}
+
+/// EventSub サブスクリプション登録の成功レスポンス JSON
+private let subscriptionSuccessJSON = """
+{
+  "data": [
+    {
+      "id": "registered-sub-id-001",
+      "status": "enabled",
+      "type": "channel.chat.message"
+    }
+  ]
+}
+"""
+
+// MARK: - テストスイート
+
+@Suite("TwitchEventSubClient")
+struct TwitchEventSubClientTests {
+
+    // MARK: - Welcome 処理
+
+    @Test("Welcome メッセージで session_id が保存される")
+    func welcomeMessageStoresSessionId() async throws {
+        // 前提: MockWebSocketClient と MockHelixAPIClient を使って EventSub クライアントを初期化する
+        let mockWS = MockWebSocketClient()
+        let mockAPI = MockHelixAPIClientForEventSub()
+        await mockAPI.setPostResponse(subscriptionSuccessJSON)
+        let client = TwitchEventSubClient(
+            webSocketClient: mockWS,
+            apiClient: mockAPI,
+            backoffConfig: .fastTest
+        )
+
+        // Welcome メッセージを事前にキューに入れる
+        await mockWS.enqueueMessage(EventSubSampleMessages.welcome)
+
+        // 操作: 接続する（session_id が保存されるはず）
+        Task { try await client.connect() }
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 検証: session_id が保存されている
+        let sessionId = await client.sessionId
+        #expect(sessionId == "test-session-id-abc123")
+    }
+
+    // MARK: - サブスクリプション登録
+
+    @Test("subscribeChatMessage でサブスクリプションが Helix API 経由で登録される")
+    func subscribeChatMessageCallsHelixAPI() async throws {
+        // 前提: Welcome メッセージを受信して session_id を確定させる
+        let mockWS = MockWebSocketClient()
+        let mockAPI = MockHelixAPIClientForEventSub()
+        await mockAPI.setPostResponse(subscriptionSuccessJSON)
+        let client = TwitchEventSubClient(
+            webSocketClient: mockWS,
+            apiClient: mockAPI,
+            backoffConfig: .fastTest
+        )
+        await mockWS.enqueueMessage(EventSubSampleMessages.welcome)
+        Task { try await client.connect() }
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 操作: サブスクリプションを登録する
+        try await client.subscribeChatMessage(broadcasterId: "配信者ID-12345", userId: "自分ID-67890")
+
+        // 検証: Helix API の POST が呼ばれている
+        let callCount = await mockAPI.postCallCount
+        #expect(callCount == 1)
+    }
+
+    // MARK: - notification イベント配信
+
+    @Test("notification イベントが chatMessageEventStream に配信される")
+    func notificationEventIsDeliveredToStream() async throws {
+        // 前提: Welcome + Notification メッセージをキューに入れる
+        let mockWS = MockWebSocketClient()
+        let mockAPI = MockHelixAPIClientForEventSub()
+        await mockAPI.setPostResponse(subscriptionSuccessJSON)
+        let client = TwitchEventSubClient(
+            webSocketClient: mockWS,
+            apiClient: mockAPI,
+            backoffConfig: .fastTest
+        )
+        await mockWS.enqueueMessage(EventSubSampleMessages.welcome)
+        await mockWS.enqueueMessage(
+            EventSubSampleMessages.notification(
+                broadcasterLogin: "testchannel",
+                chatterLogin: "testuseraccount",
+                messageId: "real-msg-id-eventsub",
+                text: "EventSubテストメッセージ"
+            )
+        )
+
+        // 操作: 接続してイベントストリームを 1 件受信する
+        Task { try await client.connect() }
+
+        let stream = await client.chatMessageEventStream
+        var receivedEvent: EventSubChatEvent?
+        for await event in stream {
+            receivedEvent = event
+            break
+        }
+
+        // 検証: notification イベントが受信できている
+        let event = try #require(receivedEvent)
+        #expect(event.messageId == "real-msg-id-eventsub")
+        #expect(event.chatterUserLogin == "testuseraccount")
+        #expect(event.message.text == "EventSubテストメッセージ")
+    }
+
+    // MARK: - 意図的切断
+
+    @Test("disconnect() 後は再接続しない")
+    func intentionalDisconnectDoesNotReconnect() async throws {
+        // 前提: クライアントを接続する
+        let mockWS = MockWebSocketClient()
+        let mockAPI = MockHelixAPIClientForEventSub()
+        await mockAPI.setPostResponse(subscriptionSuccessJSON)
+        let client = TwitchEventSubClient(
+            webSocketClient: mockWS,
+            apiClient: mockAPI,
+            backoffConfig: .fastTest
+        )
+        await mockWS.enqueueMessage(EventSubSampleMessages.welcome)
+        Task { try await client.connect() }
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 操作: 意図的に切断する
+        await client.disconnect()
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+
+        // 検証: connect 呼び出し回数が 1 回のまま（再接続していない）
+        let connectCount = await mockWS.connectCallCount
+        #expect(connectCount == 1)
+    }
+
+    // MARK: - Reconnect メッセージ処理
+
+    @Test("session_reconnect メッセージで disconnect が呼ばれる")
+    func reconnectMessageTriggersDisconnect() async throws {
+        // 前提: MockWebSocketClient を使う
+        let mockWS = MockWebSocketClient()
+        let mockAPI = MockHelixAPIClientForEventSub()
+        await mockAPI.setPostResponse(subscriptionSuccessJSON)
+        let client = TwitchEventSubClient(
+            webSocketClient: mockWS,
+            apiClient: mockAPI,
+            backoffConfig: .fastTest
+        )
+
+        // Welcome → Reconnect メッセージをキューに入れる
+        await mockWS.enqueueMessage(EventSubSampleMessages.welcome)
+        await mockWS.enqueueMessage(
+            EventSubSampleMessages.reconnect(newUrl: "wss://eventsub.wss.twitch.tv?reconnect_token=abc123")
+        )
+
+        // 操作: 接続する（Reconnect メッセージを受信すると disconnect が呼ばれる）
+        Task { try await client.connect() }
+        try await Task.sleep(nanoseconds: 200_000_000) // 200ms
+
+        // 検証: session_reconnect の処理として disconnect が少なくとも 1 回呼ばれている
+        // reconnect 後の実際の再接続（connectCallCount >= 2）は並列実行時のタイミング依存のため
+        // disconnect の発生のみを確認する（TwitchIRCClientTests の RECONNECT テストと同様の制約）
+        let disconnectCount = await mockWS.disconnectCallCount
+        #expect(disconnectCount >= 1)
+    }
+}

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -54,7 +54,11 @@ actor MockWebSocketClient: WebSocketClientProtocol {
         }
     }
 
+    /// disconnect() の呼び出し回数（reconnect 検証用）
+    private(set) var disconnectCallCount = 0
+
     func disconnect() async {
+        disconnectCallCount += 1
         isConnected = false
         if pendingReceiveContinuations.isEmpty {
             // receive() が待機中でない（メッセージ処理中に disconnect が呼ばれた）場合、


### PR DESCRIPTION
## Summary

- EventSub WebSocket (`wss://eventsub.wss.twitch.tv/ws`) の `channel.chat.message` イベントを購読し、自分が送信した楽観的メッセージに Twitch の本物の message ID を紐付ける
- ID 確定後に `isOptimistic = false` に更新するため、送信済みメッセージにも返信ボタンが有効化される
- ChannelManager レベルで EventSub 接続を 1 本共有（最大 300 サブスクリプション制限に対応）

## Changes

### 新規ファイル
- `Sources/TwitchChat/Models/EventSubModels.swift` — EventSub WebSocket メッセージの Codable モデル群
- `Sources/TwitchChat/Models/EventSubSubscriptionModels.swift` — Helix API サブスクリプション登録用モデル
- `Sources/TwitchChat/Services/TwitchEventSubClient.swift` — EventSub クライアント actor（指数バックオフ再接続・session_reconnect 対応）
- `Tests/TwitchChatTests/EventSubModelsTests.swift` — JSON デコードテスト（6ケース）
- `Tests/TwitchChatTests/TwitchEventSubClientTests.swift` — クライアントテスト（5ケース）

### 既存ファイル変更
- `ChatMessage.swift` — `init(confirming:withRealId:)` でフィールドを保持しつつ ID と `isOptimistic` を差し替え
- `ChatViewModel.swift` — `handleEventSubChatMessage()` でテキスト一致 + 10秒以内マッチング・`onRoomIdConfirmed` コールバック追加
- `ChannelManager.swift` — EventSub 接続・サブスクリプション管理・イベント振り分けを統合
- `AuthConfig.swift` — `user:read:chat` スコープを追加

## Test plan

- [x] `swift build` でコンパイルエラーなし
- [x] `swift test` で全テスト通過（既存フレーキーテスト PING/PONG タイムアウト・RECONNECT は今回の変更と無関係）
- [x] `TwitchEventSubClient` の5テスト通過
- [x] `EventSubModels` の6テスト通過
- [x] `ChatMessage.init(confirming:)` の3テスト通過
- [x] `ChatViewModel.handleEventSubChatMessage()` の4テスト通過
- [x] `ChannelManager` の EventSub 統合テスト3ケース通過

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * チャットメッセージのリアルタイム確認機能を追加しました。ローカルで送信されたメッセージが、サーバーから返されたメッセージIDで自動的に確認されるようになります
  * EventSubウェブソケット接続により、チャットイベントのストリーミング配信を開始しました
  * OAuth認可スコープを拡張し、チャット読み取り権限が追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->