### PR TITLE
feat: エモートピッカーでサブスク未加入エモートをグレー表示して挿入不可にする

### DIFF
--- a/Sources/TwitchChat/Models/EmoteDefinition.swift
+++ b/Sources/TwitchChat/Models/EmoteDefinition.swift
@@ -17,6 +17,7 @@ struct HelixEmotesResponse: Decodable, Sendable {
 /// - エモートピッカーでのグリッド表示・テキスト挿入に使用する
 /// - `id` は CDN URL 生成（EmoteImageCache）および EmoteImageCache.isAnimated の判定に使用する
 /// - `format` に `"animated"` が含まれる場合は GIF アニメーション対応エモート
+/// - `emoteSetId` は USERSTATE の `emote-sets` タグと照合してユーザーの使用可否を判定する
 struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
     /// エモート ID（CDN URL 生成に使用）
     let id: String
@@ -30,6 +31,11 @@ struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
     /// エモート種別（例: "globals", "subscriptions"。省略される場合は nil）
     let emoteType: String?
 
+    /// エモートセット ID（USERSTATE の emote-sets タグと照合して使用可否を判定する。省略される場合は nil）
+    ///
+    /// グローバルエモートは "0"。チャンネルサブスクエモートはチャンネル固有のID。
+    let emoteSetId: String?
+
     /// アニメーション GIF に対応しているかどうか
     ///
     /// `format` 配列に `"animated"` が含まれる場合は `true`。
@@ -39,10 +45,27 @@ struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
         format.contains("animated")
     }
 
+    /// テスト・楽観的 UI 等で手動生成する際のイニシャライザ
+    ///
+    /// - Parameters:
+    ///   - id: エモート ID
+    ///   - name: エモート名
+    ///   - format: 対応フォーマット一覧
+    ///   - emoteType: エモート種別（省略可能）
+    ///   - emoteSetId: エモートセット ID（省略可能。デフォルト nil）
+    init(id: String, name: String, format: [String], emoteType: String?, emoteSetId: String? = nil) {
+        self.id = id
+        self.name = name
+        self.format = format
+        self.emoteType = emoteType
+        self.emoteSetId = emoteSetId
+    }
+
     enum CodingKeys: String, CodingKey {
         case id
         case name
         case format
         case emoteType = "emote_type"
+        case emoteSetId = "emote_set_id"
     }
 }

--- a/Sources/TwitchChat/Models/TwitchUserState.swift
+++ b/Sources/TwitchChat/Models/TwitchUserState.swift
@@ -29,8 +29,8 @@ struct TwitchUserState: Sendable, Equatable {
     /// ユーザーが使用可能なエモートセット ID の一覧
     ///
     /// USERSTATE の `emote-sets` タグをカンマ区切りで分割した Set<String>。
-    /// グローバルエモートセット "0" は常に含まれる。
-    /// タグが存在しない場合は空セット。
+    /// タグが存在してグローバルエモートにアクセスできる場合は "0" が含まれる。
+    /// タグが存在しない場合、または空文字の場合は空セットになる。
     let emoteSets: Set<String>
 
     /// IRCMessage から TwitchUserState を生成する

--- a/Sources/TwitchChat/Models/TwitchUserState.swift
+++ b/Sources/TwitchChat/Models/TwitchUserState.swift
@@ -26,6 +26,13 @@ struct TwitchUserState: Sendable, Equatable {
     /// バッジ一覧（broadcaster / moderator / subscriber 等）
     let badges: [Badge]
 
+    /// ユーザーが使用可能なエモートセット ID の一覧
+    ///
+    /// USERSTATE の `emote-sets` タグをカンマ区切りで分割した Set<String>。
+    /// グローバルエモートセット "0" は常に含まれる。
+    /// タグが存在しない場合は空セット。
+    let emoteSets: Set<String>
+
     /// IRCMessage から TwitchUserState を生成する
     ///
     /// USERSTATE コマンド以外の場合は nil を返す。
@@ -37,5 +44,11 @@ struct TwitchUserState: Sendable, Equatable {
         self.displayName = ircMessage.tags["display-name"].flatMap { $0.isEmpty ? nil : $0 }
         self.colorHex = ircMessage.tags["color"].flatMap { $0.isEmpty ? nil : $0 }
         self.badges = Badge.parse(ircMessage.tags["badges"] ?? "")
+        // emote-sets タグをカンマ区切りで分割して Set に変換する
+        if let rawEmoteSets = ircMessage.tags["emote-sets"], !rawEmoteSets.isEmpty {
+            self.emoteSets = Set(rawEmoteSets.split(separator: ",").map(String.init))
+        } else {
+            self.emoteSets = []
+        }
     }
 }

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -45,6 +45,13 @@ actor EmoteStore {
     /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
     private var userEmoteSets: Set<String>?
 
+    /// `userEmoteSets` 更新を待機している Continuation の一覧（ID → Continuation）
+    ///
+    /// `waitForNextUserEmoteSetsUpdate()` が呼ばれるたびに UUID キーで Continuation を登録し、
+    /// `updateUserEmoteSets` / `resetUserEmoteSets` が呼ばれたときに全件 resume する。
+    /// タスクキャンセル時は UUID で個別に resume して Continuation リークを防ぐ。
+    private var userEmoteSetsUpdateContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
+
     // MARK: - 初期化
 
     /// EmoteStore を初期化する
@@ -195,6 +202,16 @@ actor EmoteStore {
     /// - Parameter sets: USERSTATE の emote-sets タグから生成した Set<String>
     func updateUserEmoteSets(_ sets: Set<String>) {
         userEmoteSets = sets
+        notifyUserEmoteSetsUpdated()
+    }
+
+    /// ユーザーエモートセットをリセットする
+    ///
+    /// disconnect / ログアウト時に呼び出すことで、前回接続時のセット情報が
+    /// 次回接続に持ち越されないようにする。
+    func resetUserEmoteSets() {
+        userEmoteSets = nil
+        notifyUserEmoteSetsUpdated()
     }
 
     /// ユーザーが使用可能なエモートセット ID のスナップショットを返す
@@ -204,6 +221,38 @@ actor EmoteStore {
     /// - Returns: 使用可能なエモートセット ID の Set。`nil` の場合は USERSTATE 未受信。
     func userAvailableEmoteSets() -> Set<String>? {
         userEmoteSets
+    }
+
+    /// 次回の `userEmoteSets` 更新を待機する
+    ///
+    /// ピッカー表示中に USERSTATE が届いた場合に即座に追従するために使用する。
+    /// `updateUserEmoteSets` または `resetUserEmoteSets` が呼ばれたときに返る。
+    /// タスクキャンセル時は `withTaskCancellationHandler` が Continuation を resume して
+    /// リークを防ぐ。キャンセル時は resume するだけで CancellationError は投げない。
+    func waitForNextUserEmoteSetsUpdate() async {
+        guard !Task.isCancelled else { return }
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { cont in
+                userEmoteSetsUpdateContinuations[id] = cont
+            }
+        } onCancel: {
+            Task { await self.resumeContinuation(id: id) }
+        }
+        userEmoteSetsUpdateContinuations.removeValue(forKey: id)
+    }
+
+    /// 登録済みの全 Continuation を resume して更新を通知する
+    private func notifyUserEmoteSetsUpdated() {
+        let conts = userEmoteSetsUpdateContinuations
+        userEmoteSetsUpdateContinuations.removeAll()
+        conts.values.forEach { $0.resume() }
+    }
+
+    /// 指定 ID の Continuation を resume する（キャンセル時のリーク防止用）
+    private func resumeContinuation(id: UUID) {
+        guard let cont = userEmoteSetsUpdateContinuations.removeValue(forKey: id) else { return }
+        cont.resume()
     }
 
     /// チャンネルエモートのキャッシュをクリアする

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -43,7 +43,7 @@ actor EmoteStore {
     /// USERSTATE の `emote-sets` タグから更新される。
     /// - `nil`: USERSTATE 未受信（全エモートを使用可能として扱う）
     /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
-    private var userEmoteSets: Set<String>? = nil
+    private var userEmoteSets: Set<String>?
 
     // MARK: - 初期化
 

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -41,8 +41,9 @@ actor EmoteStore {
     /// ユーザーが使用可能なエモートセット ID の一覧
     ///
     /// USERSTATE の `emote-sets` タグから更新される。
-    /// 空の場合は USERSTATE 未受信状態（全エモートを使用可能として扱う）。
-    private var userEmoteSets: Set<String> = []
+    /// - `nil`: USERSTATE 未受信（全エモートを使用可能として扱う）
+    /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
+    private var userEmoteSets: Set<String>? = nil
 
     // MARK: - 初期化
 
@@ -200,8 +201,8 @@ actor EmoteStore {
     ///
     /// ViewModel が使用可否を判定するためのスナップショット取得に使用する。
     ///
-    /// - Returns: 使用可能なエモートセット ID の Set。空の場合は USERSTATE 未受信。
-    func userAvailableEmoteSets() -> Set<String> {
+    /// - Returns: 使用可能なエモートセット ID の Set。`nil` の場合は USERSTATE 未受信。
+    func userAvailableEmoteSets() -> Set<String>? {
         userEmoteSets
     }
 

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -38,6 +38,12 @@ actor EmoteStore {
     /// Helix API クライアント
     private let apiClient: any HelixAPIClientProtocol
 
+    /// ユーザーが使用可能なエモートセット ID の一覧
+    ///
+    /// USERSTATE の `emote-sets` タグから更新される。
+    /// 空の場合は USERSTATE 未受信状態（全エモートを使用可能として扱う）。
+    private var userEmoteSets: Set<String> = []
+
     // MARK: - 初期化
 
     /// EmoteStore を初期化する
@@ -179,6 +185,26 @@ actor EmoteStore {
         channelEmotes + globalEmotes
     }
 
+    /// ユーザーが使用可能なエモートセット ID を更新する
+    ///
+    /// USERSTATE の `emote-sets` タグを受信するたびに呼び出す。
+    /// チャンネル切替時は新チャンネルの USERSTATE が自動的に更新するため、
+    /// `resetChannelEmotes()` ではリセットしない。
+    ///
+    /// - Parameter sets: USERSTATE の emote-sets タグから生成した Set<String>
+    func updateUserEmoteSets(_ sets: Set<String>) {
+        userEmoteSets = sets
+    }
+
+    /// ユーザーが使用可能なエモートセット ID のスナップショットを返す
+    ///
+    /// ViewModel が使用可否を判定するためのスナップショット取得に使用する。
+    ///
+    /// - Returns: 使用可能なエモートセット ID の Set。空の場合は USERSTATE 未受信。
+    func userAvailableEmoteSets() -> Set<String> {
+        userEmoteSets
+    }
+
     /// チャンネルエモートのキャッシュをクリアする
     ///
     /// チャンネル切替時（connect 呼び出し前）に呼び出すことで、
@@ -207,6 +233,11 @@ actor EmoteStore {
     /// チャンネルエモート一覧を直接設定する（テスト用）
     func setChannelEmotes(_ emotes: [HelixEmote]) {
         channelEmotes = emotes
+    }
+
+    /// ユーザーエモートセットを直接設定する（テスト用）
+    func setUserEmoteSets(_ sets: Set<String>) {
+        userEmoteSets = sets
     }
 #endif
 }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -281,6 +281,8 @@ final class ChatViewModel {
         // BadgeStore / EmoteStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
         await badgeStore.cancelGlobalFetch()
         await emoteStore.cancelGlobalFetch()
+        // disconnect 時にユーザーエモートセットをリセットし、前回接続の情報を持ち越さない
+        await emoteStore.resetUserEmoteSets()
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -252,6 +252,8 @@ final class ChatViewModel {
             for await userState in stream {
                 guard !Task.isCancelled else { break }
                 self.currentUserState = userState
+                // emote-sets タグを EmoteStore に反映して、エモートピッカーの使用可否判定を更新する
+                await self.emoteStore.updateUserEmoteSets(userState.emoteSets)
             }
         }
         // ROOMSTATE を購読して room-id を早期設定する（PRIVMSG より先に取得可能）

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -35,6 +35,12 @@ final class EmotePickerViewModel {
     /// エモート定義ストア
     private let emoteStore: EmoteStore
 
+    /// ユーザーが使用可能なエモートセット ID のスナップショット
+    ///
+    /// `loadEmotes()` 呼び出し時に EmoteStore からスナップショットを取得する。
+    /// 空の場合は USERSTATE 未受信（全エモートを使用可能として扱う）。
+    private var userEmoteSets: Set<String> = []
+
     // MARK: - 初期化
 
     /// EmotePickerViewModel を初期化する
@@ -54,7 +60,22 @@ final class EmotePickerViewModel {
     func loadEmotes() async {
         await emoteStore.fetchGlobalEmotes()
         allEmotes = await emoteStore.allEmotes()
+        userEmoteSets = await emoteStore.userAvailableEmoteSets()
         applyFilter()
+    }
+
+    /// エモートがユーザーにとって使用可能かどうかを返す
+    ///
+    /// - `userEmoteSets` が空（USERSTATE 未受信）の場合は全て true
+    /// - `emote.emoteSetId` が nil の場合は安全側に倒して true
+    /// - それ以外は emoteSetId が userEmoteSets に含まれるか判定する
+    ///
+    /// - Parameter emote: 判定対象のエモート
+    /// - Returns: 使用可能な場合は true
+    func isAvailable(_ emote: HelixEmote) -> Bool {
+        guard !userEmoteSets.isEmpty else { return true }
+        guard let emoteSetId = emote.emoteSetId else { return true }
+        return userEmoteSets.contains(emoteSetId)
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -40,7 +40,7 @@ final class EmotePickerViewModel {
     /// `loadEmotes()` 呼び出し時に EmoteStore からスナップショットを取得する。
     /// - `nil`: USERSTATE 未受信（全エモートを使用可能として扱う）
     /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
-    private var userEmoteSets: Set<String>? = nil
+    private var userEmoteSets: Set<String>?
 
     // MARK: - 初期化
 

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -38,8 +38,9 @@ final class EmotePickerViewModel {
     /// ユーザーが使用可能なエモートセット ID のスナップショット
     ///
     /// `loadEmotes()` 呼び出し時に EmoteStore からスナップショットを取得する。
-    /// 空の場合は USERSTATE 未受信（全エモートを使用可能として扱う）。
-    private var userEmoteSets: Set<String> = []
+    /// - `nil`: USERSTATE 未受信（全エモートを使用可能として扱う）
+    /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
+    private var userEmoteSets: Set<String>? = nil
 
     // MARK: - 初期化
 
@@ -66,16 +67,16 @@ final class EmotePickerViewModel {
 
     /// エモートがユーザーにとって使用可能かどうかを返す
     ///
-    /// - `userEmoteSets` が空（USERSTATE 未受信）の場合は全て true
+    /// - `userEmoteSets` が `nil`（USERSTATE 未受信）の場合は全て true
     /// - `emote.emoteSetId` が nil の場合は安全側に倒して true
     /// - それ以外は emoteSetId が userEmoteSets に含まれるか判定する
     ///
     /// - Parameter emote: 判定対象のエモート
     /// - Returns: 使用可能な場合は true
     func isAvailable(_ emote: HelixEmote) -> Bool {
-        guard !userEmoteSets.isEmpty else { return true }
+        guard let sets = userEmoteSets else { return true }
         guard let emoteSetId = emote.emoteSetId else { return true }
-        return userEmoteSets.contains(emoteSetId)
+        return sets.contains(emoteSetId)
     }
 
     // MARK: - プライベートメソッド

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -65,6 +65,19 @@ final class EmotePickerViewModel {
         applyFilter()
     }
 
+    /// ピッカー表示中に USERSTATE が届いた場合にエモートの使用可否をリアルタイムで更新する
+    ///
+    /// View の `.task` モディファイアから呼び出す。View が消えると `.task` が
+    /// このメソッドのタスクをキャンセルし、`waitForNextUserEmoteSetsUpdate` が
+    /// resume されてループを抜けるため、Continuation リークは発生しない。
+    func observeUserEmoteSetsUpdates() async {
+        while !Task.isCancelled {
+            await emoteStore.waitForNextUserEmoteSetsUpdate()
+            guard !Task.isCancelled else { break }
+            userEmoteSets = await emoteStore.userAvailableEmoteSets()
+        }
+    }
+
     /// エモートがユーザーにとって使用可能かどうかを返す
     ///
     /// - `userEmoteSets` が `nil`（USERSTATE 未受信）の場合は全て true

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -41,13 +41,16 @@ struct EmotePickerView: View {
                 ScrollView {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 40))], spacing: 4) {
                         ForEach(viewModel.filteredEmotes) { emote in
+                            let available = viewModel.isAvailable(emote)
                             Button {
                                 onSelect(emote.name)
                             } label: {
-                                EmoteCellView(emoteId: emote.id, emoteName: emote.name)
+                                EmoteCellView(emoteId: emote.id, emoteName: emote.name, isAvailable: available)
                             }
                             .buttonStyle(.plain)
+                            .disabled(!available)
                             .accessibilityLabel(Text(emote.name))
+                            .accessibilityValue(available ? "" : "使用不可")
                         }
                     }
                     .padding(8)
@@ -65,11 +68,13 @@ struct EmotePickerView: View {
 /// - 画像は `EmoteImageCache.shared` を再利用して非同期取得する
 /// - アニメーション GIF は `AnimatedEmoteView` で再生する
 /// - `isAnimated` フラグは画像取得時にキャッシュし、毎レンダリングで再計算しない
-/// - ホバー時のツールチップでエモート名を表示する
+/// - `isAvailable` が false の場合は半透明表示し、右下にロックアイコンを重ねる
+/// - ホバー時のツールチップでエモート名（使用不可時はサブスク必要の旨）を表示する
 private struct EmoteCellView: View {
 
     let emoteId: String
     let emoteName: String
+    let isAvailable: Bool
 
     @State private var image: NSImage?
     @State private var isAnimated: Bool = false
@@ -94,7 +99,18 @@ private struct EmoteCellView: View {
         }
         .frame(width: 40, height: 40)
         .contentShape(Rectangle())
-        .help(emoteName)
+        // 使用不可エモートは半透明でグレーアウト表示する
+        .opacity(isAvailable ? 1.0 : 0.35)
+        // 使用不可エモートは右下にロックアイコンを表示してサブスク必要を示す
+        .overlay(alignment: .bottomTrailing) {
+            if !isAvailable {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .offset(x: 2, y: 2)
+            }
+        }
+        .help(isAvailable ? emoteName : "\(emoteName)（サブスクライブが必要です）")
         .task(id: emoteId) {
             image = await EmoteImageCache.shared.image(for: emoteId)
             isAnimated = EmoteImageCache.shared.isAnimated(emoteId: emoteId)

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -59,6 +59,8 @@ struct EmotePickerView: View {
         }
         .frame(width: 320, height: 300)
         .task { await viewModel.loadEmotes() }
+        // ピッカー表示中に USERSTATE が届いた場合の使用可否リアルタイム更新
+        .task { await viewModel.observeUserEmoteSetsUpdates() }
     }
 }
 

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -107,7 +107,7 @@ private struct EmoteCellView: View {
                 Image(systemName: "lock.fill")
                     .font(.system(size: 9))
                     .foregroundStyle(.secondary)
-                    .offset(x: 2, y: 2)
+                    .padding(2)
             }
         }
         .help(isAvailable ? emoteName : "\(emoteName)（サブスクライブが必要です）")

--- a/Tests/TwitchChatTests/EmoteDefinitionTests.swift
+++ b/Tests/TwitchChatTests/EmoteDefinitionTests.swift
@@ -152,6 +152,75 @@ struct EmoteDefinitionTests {
         #expect(emote1 != emote2)
     }
 
+    // MARK: - emote_set_id のデコード
+
+    @Test("emote_set_id を含むエモートを正しくデコードできる")
+    func testDecodeEmoteWithEmoteSetId() throws {
+        // 前提: emote_set_id を含むチャンネルエモートのサンプルレスポンス
+        let json = """
+        {
+          "data": [
+            {
+              "id": "304456832",
+              "name": "taborGrin",
+              "format": ["static"],
+              "emote_type": "subscriptions",
+              "emote_set_id": "301590448"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].emoteSetId == "301590448")
+    }
+
+    @Test("emote_set_id が省略されている場合は emoteSetId が nil になる")
+    func testDecodeEmoteWithMissingEmoteSetId() throws {
+        // 前提: emote_set_id を含まないエモートのサンプルレスポンス
+        let json = """
+        {
+          "data": [
+            {
+              "id": "425618",
+              "name": "LUL",
+              "format": ["static", "animated"],
+              "emote_type": "globals"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].emoteSetId == nil)
+    }
+
+    @Test("グローバルエモートの emote_set_id は '0' になる")
+    func testDecodeGlobalEmoteSetId() throws {
+        // 前提: Twitch のグローバルエモートは emote_set_id が "0"
+        let json = """
+        {
+          "data": [
+            {
+              "id": "425618",
+              "name": "LUL",
+              "format": ["static", "animated"],
+              "emote_type": "globals",
+              "emote_set_id": "0"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data[0].emoteSetId == "0")
+    }
+
     // MARK: - isAnimated computed property
 
     @Test("format に animated が含まれる場合 isAnimated が true になる")

--- a/Tests/TwitchChatTests/EmoteDefinitionTests.swift
+++ b/Tests/TwitchChatTests/EmoteDefinitionTests.swift
@@ -177,6 +177,29 @@ struct EmoteDefinitionTests {
         #expect(response.data[0].emoteSetId == "301590448")
     }
 
+    @Test("emote_set_id が明示的に null の場合は emoteSetId が nil になる")
+    func testDecodeEmoteWithExplicitNullEmoteSetId() throws {
+        // 前提: emote_set_id が明示的に null のエモートレスポンス
+        let json = """
+        {
+          "data": [
+            {
+              "id": "425618",
+              "name": "LUL",
+              "format": ["static", "animated"],
+              "emote_type": "globals",
+              "emote_set_id": null
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].emoteSetId == nil)
+    }
+
     @Test("emote_set_id が省略されている場合は emoteSetId が nil になる")
     func testDecodeEmoteWithMissingEmoteSetId() throws {
         // 前提: emote_set_id を含まないエモートのサンプルレスポンス
@@ -218,6 +241,7 @@ struct EmoteDefinitionTests {
         let data = Data(json.utf8)
         let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
 
+        #expect(response.data.count == 1)
         #expect(response.data[0].emoteSetId == "0")
     }
 

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -128,10 +128,10 @@ struct EmotePickerViewModelTests {
 
     // MARK: - isAvailable エモート使用可否判定
 
-    @Test("userEmoteSets が空の場合（USERSTATE 未受信）は全エモートが使用可能")
+    @Test("userEmoteSets が nil の場合（USERSTATE 未受信）は全エモートが使用可能")
     @MainActor
-    func testIsAvailableWhenUserEmoteSetsEmpty() async {
-        // 前提: USERSTATE を受信していない状態（userEmoteSets 空）
+    func testIsAvailableWhenUserEmoteSetsNil() async {
+        // 前提: USERSTATE を受信していない状態（userEmoteSets が nil）
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
         await store.setGlobalEmotes([
             HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0"),

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -131,7 +131,8 @@ struct EmotePickerViewModelTests {
     @Test("userEmoteSets が nil の場合（USERSTATE 未受信）は全エモートが使用可能")
     @MainActor
     func testIsAvailableWhenUserEmoteSetsNil() async {
-        // 前提: USERSTATE を受信していない状態（userEmoteSets が nil）
+        // 前提: USERSTATE を受信していない状態（updateUserEmoteSets を一度も呼んでいない）
+        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
         await store.setGlobalEmotes([
             HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0"),
@@ -141,7 +142,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: USERSTATE 未受信時は全エモートが使用可能
+        // 検証: USERSTATE 未受信（userEmoteSets が nil）のため全エモートが使用可能
         #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
         #expect(viewModel.isAvailable(viewModel.filteredEmotes[1]) == true)
     }
@@ -167,7 +168,9 @@ struct EmotePickerViewModelTests {
     @MainActor
     func testIsAvailableSubscriptionEmoteNotSubscribed() async {
         // 前提: グローバルセット "0" のみ保持している（未サブスク視聴者）
+        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0"]))
         await store.setChannelEmotes([
             HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
@@ -184,7 +187,9 @@ struct EmotePickerViewModelTests {
     @MainActor
     func testIsAvailableSubscriptionEmoteSubscribed() async {
         // 前提: チャンネルのエモートセット "12345" を保持している（サブスク済み視聴者）
+        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0", "12345"]))
         await store.setChannelEmotes([
             HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -125,4 +125,92 @@ struct EmotePickerViewModelTests {
 
         #expect(viewModel.filteredEmotes.isEmpty)
     }
+
+    // MARK: - isAvailable エモート使用可否判定
+
+    @Test("userEmoteSets が空の場合（USERSTATE 未受信）は全エモートが使用可能")
+    @MainActor
+    func testIsAvailableWhenUserEmoteSetsEmpty() async {
+        // 前提: USERSTATE を受信していない状態（userEmoteSets 空）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([
+            HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0"),
+            HelixEmote(id: "2", name: "サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: USERSTATE 未受信時は全エモートが使用可能
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[1]) == true)
+    }
+
+    @Test("グローバルエモート（emoteSetId: '0'）は使用可能セットに含まれる場合 true を返す")
+    @MainActor
+    func testIsAvailableGlobalEmote() async {
+        // 前提: USERSTATE を受信しグローバルセット "0" が含まれている
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmoteSets(Set(["0"]))
+        await store.setGlobalEmotes([
+            HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0")
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: グローバルエモートは使用可能
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+    }
+
+    @Test("サブスクエモートのセットIDがユーザーのセットに含まれない場合は false を返す")
+    @MainActor
+    func testIsAvailableSubscriptionEmoteNotSubscribed() async {
+        // 前提: グローバルセット "0" のみ保持している（未サブスク視聴者）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmoteSets(Set(["0"]))
+        await store.setChannelEmotes([
+            HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: サブスクしていないチャンネルのエモートは使用不可
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == false)
+    }
+
+    @Test("サブスクエモートのセットIDがユーザーのセットに含まれる場合は true を返す")
+    @MainActor
+    func testIsAvailableSubscriptionEmoteSubscribed() async {
+        // 前提: チャンネルのエモートセット "12345" を保持している（サブスク済み視聴者）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmoteSets(Set(["0", "12345"]))
+        await store.setChannelEmotes([
+            HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: サブスクしているチャンネルのエモートは使用可能
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+    }
+
+    @Test("emoteSetId が nil のエモートは常に使用可能を返す")
+    @MainActor
+    func testIsAvailableEmoteWithNilEmoteSetId() async {
+        // 前提: emoteSetId が nil のエモート（API レスポンスに emote_set_id が含まれない場合）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmoteSets(Set(["0"]))
+        await store.setGlobalEmotes([
+            HelixEmote(id: "3", name: "emoteSetIdなし", format: ["static"], emoteType: nil, emoteSetId: nil)
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: emoteSetId 不明なエモートは安全側に倒して使用可能
+        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+    }
 }

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -313,11 +313,12 @@ struct EmoteStoreTests {
 
     @Test("updateUserEmoteSets で設定した値が userAvailableEmoteSets で取得できる")
     func testUpdateUserEmoteSets() async {
-        // 前提: サブスクユーザーのエモートセットを設定する
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
 
-        // 検証: 設定したエモートセットが取得できる
+        // 操作: サブスクユーザーのエモートセットを設定する
         await store.updateUserEmoteSets(Set(["0", "33", "50"]))
+
+        // 検証: 設定したエモートセットが取得できる
         let emoteSets = await store.userAvailableEmoteSets()
         #expect(emoteSets == Set(["0", "33", "50"]))
     }
@@ -333,6 +334,16 @@ struct EmoteStoreTests {
         // 検証: 最後に設定した値が返される
         let emoteSets = await store.userAvailableEmoteSets()
         #expect(emoteSets == Set(["0", "793"]))
+    }
+
+    @Test("USERSTATE 未受信の場合は userAvailableEmoteSets が nil を返す")
+    func testUserAvailableEmoteSetsNilBeforeUserState() async {
+        // 前提: updateUserEmoteSets を一度も呼んでいない初期状態
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        // 検証: USERSTATE 未受信は nil（全エモート使用可能として扱う）
+        let emoteSets = await store.userAvailableEmoteSets()
+        #expect(emoteSets == nil)
     }
 
     @Test("resetChannelEmotes を呼んでも userEmoteSets はリセットされない")

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -308,4 +308,44 @@ struct EmoteStoreTests {
 
         #expect(positions.isEmpty)
     }
+
+    // MARK: - ユーザーエモートセット管理
+
+    @Test("updateUserEmoteSets で設定した値が userAvailableEmoteSets で取得できる")
+    func testUpdateUserEmoteSets() async {
+        // 前提: サブスクユーザーのエモートセットを設定する
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        // 検証: 設定したエモートセットが取得できる
+        await store.updateUserEmoteSets(Set(["0", "33", "50"]))
+        let emoteSets = await store.userAvailableEmoteSets()
+        #expect(emoteSets == Set(["0", "33", "50"]))
+    }
+
+    @Test("updateUserEmoteSets を複数回呼ぶと上書きされる")
+    func testUpdateUserEmoteSetsOverwrite() async {
+        // 前提: 最初は一般ユーザー、その後サブスクでエモートセットが増える
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        await store.updateUserEmoteSets(Set(["0"]))
+        await store.updateUserEmoteSets(Set(["0", "793"]))
+
+        // 検証: 最後に設定した値が返される
+        let emoteSets = await store.userAvailableEmoteSets()
+        #expect(emoteSets == Set(["0", "793"]))
+    }
+
+    @Test("resetChannelEmotes を呼んでも userEmoteSets はリセットされない")
+    func testResetChannelEmotesDoesNotResetUserEmoteSets() async {
+        // 前提: エモートセットを設定してからチャンネルリセットを呼ぶ
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.updateUserEmoteSets(Set(["0", "33"]))
+
+        // チャンネル切替時のリセット
+        await store.resetChannelEmotes()
+
+        // 検証: ユーザーのエモートセットは保持される
+        let emoteSets = await store.userAvailableEmoteSets()
+        #expect(emoteSets == Set(["0", "33"]))
+    }
 }

--- a/Tests/TwitchChatTests/TwitchUserStateTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserStateTests.swift
@@ -78,6 +78,41 @@ struct TwitchUserStateTests {
         #expect(userState.badges == [])
     }
 
+    // MARK: - 正常系: emote-sets タグのパース
+
+    @Test("emote-sets タグが複数のセットIDを含む場合は Set に変換される")
+    func emoteSetsTタグが複数IDを含む場合はSetに変換される() throws {
+        // 前提: 複数のエモートセットIDを含む USERSTATE（サブスクユーザー）
+        let rawMessage = "@badges=subscriber/12;color=#1E90FF;display-name=サブスクユーザー;emote-sets=0,33,50,793;mod=0 :tmi.twitch.tv USERSTATE #testchannel"
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
+
+        // 検証: emoteSets が正しく Set<String> に変換される
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.emoteSets == Set(["0", "33", "50", "793"]))
+    }
+
+    @Test("emote-sets タグがグローバルのみの場合は Set(['0']) になる")
+    func emoteSetsタグがグローバルのみの場合はSet0になる() throws {
+        // 前提: グローバルエモートセットのみの USERSTATE（未サブスクユーザー）
+        let rawMessage = "@badges=;color=;display-name=一般視聴者;emote-sets=0;mod=0 :tmi.twitch.tv USERSTATE #testchannel"
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
+
+        // 検証: emoteSets が Set(["0"]) になる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.emoteSets == Set(["0"]))
+    }
+
+    @Test("emote-sets タグが存在しない場合は空セットになる")
+    func emoteSetsタグが存在しない場合は空セットになる() throws {
+        // 前提: emote-sets タグを含まない USERSTATE（匿名接続など）
+        let rawMessage = ":tmi.twitch.tv USERSTATE #testchannel"
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
+
+        // 検証: emoteSets が空セットになる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.emoteSets.isEmpty)
+    }
+
     // MARK: - 異常系: USERSTATE 以外のコマンド
 
     @Test("PRIVMSG の IRCMessage からは nil を返す")

--- a/Tests/TwitchChatTests/TwitchUserStateTests.swift
+++ b/Tests/TwitchChatTests/TwitchUserStateTests.swift
@@ -81,7 +81,7 @@ struct TwitchUserStateTests {
     // MARK: - 正常系: emote-sets タグのパース
 
     @Test("emote-sets タグが複数のセットIDを含む場合は Set に変換される")
-    func emoteSetsTタグが複数IDを含む場合はSetに変換される() throws {
+    func emoteSetsタグが複数IDを含む場合はSetに変換される() throws {
         // 前提: 複数のエモートセットIDを含む USERSTATE（サブスクユーザー）
         let rawMessage = "@badges=subscriber/12;color=#1E90FF;display-name=サブスクユーザー;emote-sets=0,33,50,793;mod=0 :tmi.twitch.tv USERSTATE #testchannel"
         let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
@@ -109,6 +109,17 @@ struct TwitchUserStateTests {
         let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
 
         // 検証: emoteSets が空セットになる
+        let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
+        #expect(userState.emoteSets.isEmpty)
+    }
+
+    @Test("emote-sets タグが空文字の場合は空セットになる")
+    func emoteSetsタグが空文字の場合は空セットになる() throws {
+        // 前提: emote-sets タグが空文字の USERSTATE（edge case）
+        let rawMessage = "@badges=;color=;display-name=一般視聴者;emote-sets=;mod=0 :tmi.twitch.tv USERSTATE #testchannel"
+        let ircMessage = try #require(IRCMessageParser.parse(rawMessage), "IRCMessage のパースに失敗しました")
+
+        // 検証: emote-sets が空文字の場合も空セットになる
         let userState = try #require(TwitchUserState(from: ircMessage), "TwitchUserState の生成に失敗しました")
         #expect(userState.emoteSets.isEmpty)
     }


### PR DESCRIPTION
## Summary

- USERSTATE IRCメッセージの `emote-sets` タグを解析し、ユーザーが使用可能なエモートセットIDを追跡する
- Helix APIエモートレスポンスの `emote_set_id` フィールドと照合して使用可否を判定する
- 使用不可エモートはエモートピッカーで半透明（opacity 0.35）＋ロックアイコン表示し、クリックしても挿入されない
- 新しいOAuthスコープ不要（USERSTATE は IRC接続で自動送信）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `EmoteDefinition.swift` | `HelixEmote` に `emoteSetId: String?` を追加（`emote_set_id` をデコード） |
| `TwitchUserState.swift` | `emoteSets: Set<String>` を追加（`emote-sets` タグをパース） |
| `EmoteStore.swift` | `updateUserEmoteSets()` / `userAvailableEmoteSets()` を追加 |
| `ChatViewModel.swift` | USERSTATE受信時に `emoteStore.updateUserEmoteSets()` を呼び出すように変更 |
| `EmotePickerViewModel.swift` | `isAvailable(_:)` メソッドを追加、`userEmoteSets` を `Optional<Set<String>>` に変更 |
| `EmotePickerView.swift` | 使用不可エモートを半透明＋ロックアイコン表示、`.disabled(!available)` で挿入不可に |

## Test plan

- [ ] `swift test` で全テストが通過することを確認
- [ ] `swift build` でビルドが成功することを確認
- [ ] アプリ起動 → サブスクしていないチャンネルに接続 → エモートピッカーを開く
  - [ ] サブスク限定エモートがグレー表示＋ロックアイコン付きであること
  - [ ] グレーのエモートをクリックしても入力フォームに挿入されないこと
  - [ ] グローバルエモートは通常通り選択・挿入できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サブスクリプション必須のエモートが、ユーザーが保有していない場合に利用不可として表示されるようになりました。
  * 利用できないエモートは視覚的に薄くなり、ロックアイコンが表示されます。
  * アプリがユーザーのエモートアクセス権を正確に追跡・同期するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->