### PR TITLE
feat: ログイン時・アプリ起動時にユーザーエモートを事前取得してピッカー表示を高速化する

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -38,7 +38,8 @@ struct TwitchChatApp: App {
                     await authState.restoreSession()
                     if case .loggedIn = authState.status {
                         followedStreamStore.startAutoRefresh()
-                        // フォロー中全チャンネルを起動時に一回取得してキャッシュする
+                        // フォロー中全チャンネルとユーザーエモートを並行で事前取得する
+                        Task { await channelManager.preloadUserEmotes() }
                         await followedChannelStore.fetchAll()
                     }
                 }
@@ -46,6 +47,7 @@ struct TwitchChatApp: App {
                     switch newStatus {
                     case .loggedIn:
                         followedStreamStore.startAutoRefresh()
+                        Task { await channelManager.preloadUserEmotes() }
                         Task { await followedChannelStore.fetchAll() }
                     case .loggedOut:
                         followedStreamStore.stopAutoRefresh()

--- a/Sources/TwitchChat/Auth/AuthConfig.swift
+++ b/Sources/TwitchChat/Auth/AuthConfig.swift
@@ -34,6 +34,7 @@ enum AuthConfig {
     /// - `chat:edit`: IRC チャット書き込み（コメント投稿に使用）
     /// - `user:read:follows`: フォロー中の配信中ストリーム一覧取得に使用
     /// - `user:read:chat`: EventSub `channel.chat.message` 購読（楽観的 UI の ID 確定に使用）
+    /// - `user:read:emotes`: ユーザーが使用可能な全エモート取得（サブスク・ビッツ・Hype等）
     /// - `moderator:manage:banned_users`: バン・タイムアウト操作（Helix API /moderation/bans）
     /// - `moderator:manage:chat_settings`: エモートオンリー・スロー・サブスクライバーモード等
     /// - `moderator:manage:chat_messages`: チャットクリア・メッセージ削除
@@ -42,6 +43,7 @@ enum AuthConfig {
         "chat:edit",
         "user:read:follows",
         "user:read:chat",
+        "user:read:emotes",
         "moderator:manage:banned_users",
         "moderator:manage:chat_settings",
         "moderator:manage:chat_messages"

--- a/Sources/TwitchChat/Auth/AuthState.swift
+++ b/Sources/TwitchChat/Auth/AuthState.swift
@@ -77,6 +77,12 @@ public final class AuthState {
     /// チャットクリア・メッセージ削除に必要なスコープを保有しているか
     var canManageChatMessages: Bool { grantedScopes.contains("moderator:manage:chat_messages") }
 
+    /// ユーザーが使用可能なエモート取得に必要な `user:read:emotes` スコープを保有しているか
+    ///
+    /// `false` の場合、`/helix/chat/emotes/user` の呼び出しをスキップする（graceful degradation）。
+    /// 旧トークンユーザーは再ログイン後にスコープが付与される。
+    var canReadUserEmotes: Bool { grantedScopes.contains("user:read:emotes") }
+
     // MARK: - プライベートプロパティ
 
     private let authClient: any TwitchAuthClientProtocol

--- a/Sources/TwitchChat/Models/EmoteDefinition.swift
+++ b/Sources/TwitchChat/Models/EmoteDefinition.swift
@@ -12,6 +12,35 @@ struct HelixEmotesResponse: Decodable, Sendable {
     let data: [HelixEmote]
 }
 
+/// Helix `GET /helix/chat/emotes/user` レスポンス
+///
+/// ユーザーが利用可能な全エモート（サブスク・ビッツ・Hype等）を返す。
+/// cursor が nil または空の場合は最終ページ。
+/// Twitch API は `{"data": [...], "pagination": {"cursor": "..."}}` の構造で返す。
+struct HelixUserEmotesResponse: Decodable, Sendable {
+    let data: [HelixEmote]
+    let pagination: Pagination?
+
+    /// ページネーション情報
+    struct Pagination: Decodable, Sendable {
+        /// ページネーション用カーソル。最終ページの場合は nil
+        let cursor: String?
+    }
+
+    /// ページネーション用カーソル（`pagination.cursor` のショートカット）
+    var cursor: String? { pagination?.cursor }
+
+    /// テスト・楽観的 UI 等で手動生成する際のイニシャライザ
+    ///
+    /// - Parameters:
+    ///   - data: エモート一覧
+    ///   - cursor: ページネーション用カーソル（省略可能。デフォルト nil）
+    init(data: [HelixEmote], cursor: String? = nil) {
+        self.data = data
+        self.pagination = cursor.map { Pagination(cursor: $0) }
+    }
+}
+
 /// Helix エモート定義
 ///
 /// - エモートピッカーでのグリッド表示・テキスト挿入に使用する
@@ -36,6 +65,9 @@ struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
     /// グローバルエモートは "0"。チャンネルサブスクエモートはチャンネル固有のID。
     let emoteSetId: String?
 
+    /// エモートを所有するチャンネルのユーザー ID（`/helix/chat/emotes/user` のみ返す。省略される場合は nil）
+    let ownerId: String?
+
     /// アニメーション GIF に対応しているかどうか
     ///
     /// `format` 配列に `"animated"` が含まれる場合は `true`。
@@ -53,12 +85,14 @@ struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
     ///   - format: 対応フォーマット一覧
     ///   - emoteType: エモート種別（省略可能）
     ///   - emoteSetId: エモートセット ID（省略可能。デフォルト nil）
-    init(id: String, name: String, format: [String], emoteType: String?, emoteSetId: String? = nil) {
+    ///   - ownerId: エモートを所有するチャンネルのユーザー ID（省略可能。デフォルト nil）
+    init(id: String, name: String, format: [String], emoteType: String?, emoteSetId: String? = nil, ownerId: String? = nil) {
         self.id = id
         self.name = name
         self.format = format
         self.emoteType = emoteType
         self.emoteSetId = emoteSetId
+        self.ownerId = ownerId
     }
 
     enum CodingKeys: String, CodingKey {
@@ -67,5 +101,6 @@ struct HelixEmote: Decodable, Sendable, Identifiable, Equatable {
         case format
         case emoteType = "emote_type"
         case emoteSetId = "emote_set_id"
+        case ownerId = "owner_id"
     }
 }

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -75,6 +75,8 @@ actor BadgeStore {
                 self.isGlobalLoaded = true
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
+            } catch HelixAPIError.unauthorized {
+                // Helix API が 401 を返した場合（トークン失効等）は次回接続時に再取得する
             } catch is AuthConfigError {
                 // Client ID 未設定（開発環境・テスト実行時）は正常状態のためスキップ
             } catch {
@@ -102,6 +104,8 @@ actor BadgeStore {
             channelBadges = Self.buildMapping(from: response.data)
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
+        } catch HelixAPIError.unauthorized {
+            // Helix API が 401 を返した場合（トークン失効等）はスキップ
         } catch {
             // 設定不備・サーバーエラー等の恒久エラーは診断できるよう記録する
             assertionFailure("チャンネルバッジフェッチ失敗（channelId: \(channelId)）: \(error)")

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -163,6 +163,9 @@ actor EmoteStore {
             return
         }
         let task = Task {
+            #if DEBUG
+            print("[EmoteStore] fetchUserEmotes: フェッチ開始 userId=\(userId)")
+            #endif
             /// ページネーションループの上限（無限ループ防止）
             let maxPages = 100
             var accumulated: [HelixEmote] = []
@@ -190,8 +193,16 @@ actor EmoteStore {
                 self.isUserEmotesLoaded = true
                 // ユーザーエモートのロード完了をピッカーに通知する
                 self.notifyUserEmoteSetsUpdated()
+                #if DEBUG
+                print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件")
+                #endif
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン・スコープ未付与時はスキップ
+            } catch HelixAPIError.unauthorized {
+                // Helix API が 401 を返した場合（スコープ不足・トークン失効）はスキップ
+                #if DEBUG
+                print("[EmoteStore] fetchUserEmotes: 401 unauthorized — user:read:emotes スコープ未付与の可能性")
+                #endif
             } catch let error as URLError where error.code == .cancelled {
                 // Task キャンセル（disconnect 等）による中断は正常系のためスキップ
             } catch is CancellationError {

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -21,6 +21,9 @@ actor EmoteStore {
     /// Helix チャンネルエモートエンドポイント
     private static let helixChannelEmotesURL = URL(string: "https://api.twitch.tv/helix/chat/emotes")!
 
+    /// Helix ユーザーエモートエンドポイント
+    private static let helixUserEmotesURL = URL(string: "https://api.twitch.tv/helix/chat/emotes/user")!
+
     // MARK: - 状態
 
     /// グローバルエモート一覧
@@ -29,11 +32,22 @@ actor EmoteStore {
     /// チャンネルエモート一覧
     private var channelEmotes: [HelixEmote] = []
 
+    /// ユーザーが使用可能なエモート一覧（/helix/chat/emotes/user から取得）
+    ///
+    /// サブスクしている他チャンネルのエモート・ビッツエモート・Hypeトレインエモート等を含む。
+    private var userEmotes: [HelixEmote] = []
+
     /// グローバルエモート取得済みフラグ
     private var isGlobalLoaded = false
 
+    /// ユーザーエモート取得済みフラグ
+    private var isUserEmotesLoaded = false
+
     /// 進行中のグローバルエモートフェッチタスク（並行重複排除用）
     private var globalEmotesTask: Task<Void, Never>?
+
+    /// 進行中のユーザーエモートフェッチタスク（並行重複排除用）
+    private var userEmotesTask: Task<Void, Never>?
 
     /// Helix API クライアント
     private let apiClient: any HelixAPIClientProtocol
@@ -128,15 +142,77 @@ actor EmoteStore {
         }
     }
 
+    /// ユーザーが使用可能なエモート定義をフェッチする
+    ///
+    /// `/helix/chat/emotes/user` エンドポイントを使用してサブスク中の他チャンネルエモート、
+    /// ビッツエモート、Hypeトレインエモート等を取得する。cursor ベースのページネーションに対応。
+    ///
+    /// - Parameter userId: 認証済みユーザーの Twitch ユーザー ID（数字のみ）
+    ///
+    /// - Note: `user:read:emotes` スコープが必要。スコープ未付与の場合はスキップする。
+    /// トークン未設定（未ログイン）の場合もスキップする。
+    func fetchUserEmotes(userId: String) async {
+        // Twitch の user_id は ASCII 十進数のみで構成される（URLパラメータインジェクション対策）
+        guard !userId.isEmpty, userId.allSatisfy({ $0.isASCII && $0.isNumber }) else { return }
+        guard !isUserEmotesLoaded else { return }
+        // 進行中タスクがあれば完了を待って返す（TOCTOU 防止）
+        if let existing = userEmotesTask {
+            await existing.value
+            return
+        }
+        let task = Task {
+            /// ページネーションループの上限（無限ループ防止）
+            let maxPages = 100
+            var accumulated: [HelixEmote] = []
+            var cursor: String?
+            var pageCount = 0
+            do {
+                repeat {
+                    var queryItems: [URLQueryItem] = [URLQueryItem(name: "user_id", value: userId)]
+                    if let after = cursor {
+                        queryItems.append(URLQueryItem(name: "after", value: after))
+                    }
+                    let response: HelixUserEmotesResponse = try await self.apiClient.get(
+                        url: Self.helixUserEmotesURL,
+                        queryItems: queryItems
+                    )
+                    accumulated += response.data
+                    cursor = response.cursor.flatMap { $0.isEmpty ? nil : $0 }
+                    pageCount += 1
+                    if pageCount >= maxPages {
+                        assertionFailure("ユーザーエモートページネーションが上限 \(maxPages) ページに達しました")
+                        break
+                    }
+                } while cursor != nil
+                self.userEmotes = accumulated
+                self.isUserEmotesLoaded = true
+            } catch let error as URLError where error.code == .userAuthenticationRequired {
+                // 未ログイン・スコープ未付与時はスキップ
+            } catch let error as URLError where error.code == .cancelled {
+                // Task キャンセル（disconnect 等）による中断は正常系のためスキップ
+            } catch is CancellationError {
+                // Swift concurrency のキャンセル伝播は正常系のためスキップ
+            } catch is AuthConfigError {
+                // Client ID 未設定（開発環境・テスト実行時）は正常状態のためスキップ
+            } catch {
+                // 設定不備・サーバーエラー等の恒久エラーは診断できるよう記録する
+                assertionFailure("ユーザーエモートフェッチ失敗（userId: \(userId)）: \(error)")
+            }
+        }
+        userEmotesTask = task
+        await task.value
+        userEmotesTask = nil
+    }
+
     /// エモート名でエモートを検索する
     ///
-    /// チャンネルエモートを優先し、見つからない場合はグローバルエモートを検索する。
+    /// チャンネルエモートを優先し、次にユーザーエモート、最後にグローバルエモートを検索する。
     /// 大文字小文字を区別する完全一致で検索する（Twitch エモート名は大文字小文字を区別するため）。
     ///
     /// - Parameter name: エモート名（例: "LUL", "PogChamp"）
     /// - Returns: 見つかった HelixEmote、存在しない場合は nil
     func emote(byName name: String) -> HelixEmote? {
-        (channelEmotes + globalEmotes).first(where: { $0.name == name })
+        allEmotes().first(where: { $0.name == name })
     }
 
     /// テキスト内のエモート名を検索し、EmotePosition 配列を返す
@@ -149,7 +225,7 @@ actor EmoteStore {
     /// - Returns: 検出されたエモートの位置情報（startIndex 昇順）
     func emotePositions(in text: String) -> [EmotePosition] {
         guard !text.isEmpty else { return [] }
-        let allEmotes = channelEmotes + globalEmotes
+        let allEmotes = allEmotes()
         guard !allEmotes.isEmpty else { return [] }
 
         var positions: [EmotePosition] = []
@@ -187,10 +263,35 @@ actor EmoteStore {
 
     /// ピッカー用エモート一覧を返す
     ///
-    /// チャンネルエモートを先頭に、グローバルエモートをその後に並べて返す。
-    /// チャンネル固有エモートをより目立たせるための順序。
+    /// チャンネルエモート → ユーザーエモート → グローバルエモートの優先順で並べ、
+    /// ID ベースの重複排除を行って返す。
+    ///
+    /// - チャンネル固有エモートが最優先（現在視聴中チャンネル）
+    /// - ユーザーエモートはサブスク中の他チャンネル・ビッツ・Hype等
+    /// - グローバルエモートは最後尾
     func allEmotes() -> [HelixEmote] {
-        channelEmotes + globalEmotes
+        var seen = Set<String>()
+        var result: [HelixEmote] = []
+        for emote in channelEmotes where seen.insert(emote.id).inserted {
+            result.append(emote)
+        }
+        for emote in userEmotes where seen.insert(emote.id).inserted {
+            result.append(emote)
+        }
+        for emote in globalEmotes where seen.insert(emote.id).inserted {
+            result.append(emote)
+        }
+        return result
+    }
+
+    /// ユーザーエモートの ID セットを返す
+    ///
+    /// `EmotePickerViewModel` が使用可否を判定するために使用する。
+    /// `/helix/chat/emotes/user` から取得したエモートのIDのみ含む。
+    ///
+    /// - Returns: ユーザーエモートの ID の Set
+    func userEmoteIdSet() -> Set<String> {
+        Set(userEmotes.map(\.id))
     }
 
     /// ユーザーが使用可能なエモートセット ID を更新する
@@ -271,6 +372,23 @@ actor EmoteStore {
         globalEmotesTask = nil
     }
 
+    /// ユーザーエモートのキャッシュをクリアする
+    ///
+    /// disconnect / ログアウト時に呼び出すことで、前回接続時のエモートを持ち越さないようにする。
+    /// チャンネル切替時は呼び出し不要（ユーザーエモートはユーザースコープのため）。
+    func resetUserEmotes() {
+        userEmotes = []
+        isUserEmotesLoaded = false
+    }
+
+    /// 進行中のユーザーエモートフェッチタスクをキャンセルする
+    ///
+    /// disconnect 時に呼び出すことで、不要なネットワークリクエストを中断できる
+    func cancelUserEmotesFetch() {
+        userEmotesTask?.cancel()
+        userEmotesTask = nil
+    }
+
     // MARK: - テスト用メソッド
 
 #if DEBUG
@@ -283,6 +401,12 @@ actor EmoteStore {
     /// チャンネルエモート一覧を直接設定する（テスト用）
     func setChannelEmotes(_ emotes: [HelixEmote]) {
         channelEmotes = emotes
+    }
+
+    /// ユーザーエモート一覧を直接設定する（テスト用）
+    func setUserEmotes(_ emotes: [HelixEmote]) {
+        userEmotes = emotes
+        isUserEmotesLoaded = true
     }
 
     /// ユーザーエモートセットを直接設定する（テスト用）

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -128,6 +128,8 @@ actor EmoteStore {
                 queryItems: [URLQueryItem(name: "broadcaster_id", value: broadcasterId)]
             )
             channelEmotes = response.data
+            // チャンネルエモートのロード完了をピッカーに通知する
+            notifyUserEmoteSetsUpdated()
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
         } catch let error as URLError where error.code == .cancelled {
@@ -186,6 +188,8 @@ actor EmoteStore {
                 } while cursor != nil
                 self.userEmotes = accumulated
                 self.isUserEmotesLoaded = true
+                // ユーザーエモートのロード完了をピッカーに通知する
+                self.notifyUserEmoteSetsUpdated()
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン・スコープ未付与時はスキップ
             } catch let error as URLError where error.code == .cancelled {

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -182,6 +182,9 @@ actor EmoteStore {
                         queryItems: queryItems
                     )
                     accumulated += response.data
+                    // ページ取得ごとにピッカーを段階更新して最初のページから即座に表示する
+                    self.userEmotes = accumulated
+                    self.notifyUserEmoteSetsUpdated()
                     cursor = response.cursor.flatMap { $0.isEmpty ? nil : $0 }
                     pageCount += 1
                     if pageCount >= maxPages {
@@ -189,12 +192,10 @@ actor EmoteStore {
                         break
                     }
                 } while cursor != nil
-                self.userEmotes = accumulated
+                // 全ページ完了後に再フェッチ防止フラグを立てる
                 self.isUserEmotesLoaded = true
-                // ユーザーエモートのロード完了をピッカーに通知する
-                self.notifyUserEmoteSetsUpdated()
                 #if DEBUG
-                print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件")
+                print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件（\(pageCount)ページ）")
                 #endif
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン・スコープ未付与時はスキップ

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -170,36 +170,11 @@ actor EmoteStore {
             #if DEBUG
             print("[EmoteStore] fetchUserEmotes: フェッチ開始 userId=\(userId)")
             #endif
-            /// ページネーションループの上限（無限ループ防止）
-            let maxPages = 100
-            var accumulated: [HelixEmote] = []
-            var cursor: String?
-            var pageCount = 0
             do {
-                repeat {
-                    var queryItems: [URLQueryItem] = [URLQueryItem(name: "user_id", value: userId)]
-                    if let after = cursor {
-                        queryItems.append(URLQueryItem(name: "after", value: after))
-                    }
-                    let response: HelixUserEmotesResponse = try await self.apiClient.get(
-                        url: Self.helixUserEmotesURL,
-                        queryItems: queryItems
-                    )
-                    accumulated += response.data
-                    // ページ取得ごとにピッカーを段階更新して最初のページから即座に表示する
-                    self.userEmotes = accumulated
-                    self.notifyUserEmoteSetsUpdated()
-                    cursor = response.cursor.flatMap { $0.isEmpty ? nil : $0 }
-                    pageCount += 1
-                    if pageCount >= maxPages {
-                        assertionFailure("ユーザーエモートページネーションが上限 \(maxPages) ページに達しました")
-                        break
-                    }
-                } while cursor != nil
-                // 全ページ完了後に再フェッチ防止フラグを立てる
+                let accumulated = try await self.performUserEmotesFetch(userId: userId)
                 self.isUserEmotesLoaded = true
                 #if DEBUG
-                print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件（\(pageCount)ページ）")
+                print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件")
                 #endif
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン・スコープ未付与時はスキップ
@@ -222,6 +197,41 @@ actor EmoteStore {
         userEmotesTask = task
         await task.value
         userEmotesTask = nil
+    }
+
+    /// ユーザーエモートの cursor ページネーションフェッチを実行して全エモートを返す
+    ///
+    /// ページ取得ごとに `userEmotes` を更新してピッカーの段階表示を有効にする。
+    ///
+    /// - Parameter userId: 認証済みユーザーの Twitch ユーザー ID
+    /// - Returns: 全ページから収集した HelixEmote 配列
+    private func performUserEmotesFetch(userId: String) async throws -> [HelixEmote] {
+        /// ページネーションループの上限（無限ループ防止）
+        let maxPages = 100
+        var accumulated: [HelixEmote] = []
+        var cursor: String?
+        var pageCount = 0
+        repeat {
+            var queryItems: [URLQueryItem] = [URLQueryItem(name: "user_id", value: userId)]
+            if let after = cursor {
+                queryItems.append(URLQueryItem(name: "after", value: after))
+            }
+            let response: HelixUserEmotesResponse = try await self.apiClient.get(
+                url: Self.helixUserEmotesURL,
+                queryItems: queryItems
+            )
+            accumulated += response.data
+            // ページ取得ごとにピッカーを段階更新して最初のページから即座に表示する
+            self.userEmotes = accumulated
+            self.notifyUserEmoteSetsUpdated()
+            cursor = response.cursor.flatMap { $0.isEmpty ? nil : $0 }
+            pageCount += 1
+            if pageCount >= maxPages {
+                assertionFailure("ユーザーエモートページネーションが上限 \(maxPages) ページに達しました")
+                break
+            }
+        } while cursor != nil
+        return accumulated
     }
 
     /// エモート名でエモートを検索する

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -212,6 +212,8 @@ actor EmoteStore {
         var cursor: String?
         var pageCount = 0
         repeat {
+            // キャンセル済みの場合はループを抜けて古いデータを書き込まない
+            guard !Task.isCancelled else { return accumulated }
             var queryItems: [URLQueryItem] = [URLQueryItem(name: "user_id", value: userId)]
             if let after = cursor {
                 queryItems.append(URLQueryItem(name: "after", value: after))

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -99,6 +99,8 @@ actor EmoteStore {
                 self.isGlobalLoaded = true
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
+            } catch HelixAPIError.unauthorized {
+                // Helix API が 401 を返した場合（トークン失効等）は次回接続時に再取得する
             } catch let error as URLError where error.code == .cancelled {
                 // Task キャンセル（disconnect 等）による中断は正常系のためスキップ
             } catch is CancellationError {
@@ -132,6 +134,8 @@ actor EmoteStore {
             notifyUserEmoteSetsUpdated()
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
+        } catch HelixAPIError.unauthorized {
+            // Helix API が 401 を返した場合（トークン失効等）はスキップ
         } catch let error as URLError where error.code == .cancelled {
             // Task キャンセル（disconnect 等）による中断は正常系のためスキップ
         } catch is CancellationError {
@@ -310,6 +314,16 @@ actor EmoteStore {
         Set(userEmotes.map(\.id))
     }
 
+    /// 現在のユーザーエモート一覧のスナップショットを返す
+    ///
+    /// `ChannelManager` が新しい `ChatViewModel` のエモートストアにユーザーエモートを
+    /// シードする際に使用する。スナップショットはプリロード完了分のみを含む。
+    ///
+    /// - Returns: 現在のユーザーエモート一覧（未ロードの場合は空配列）
+    func userEmotesSnapshot() -> [HelixEmote] {
+        userEmotes
+    }
+
     /// ユーザーが使用可能なエモートセット ID を更新する
     ///
     /// USERSTATE の `emote-sets` タグを受信するたびに呼び出す。
@@ -405,6 +419,19 @@ actor EmoteStore {
         userEmotesTask = nil
     }
 
+    /// ユーザーエモート一覧を直接設定する
+    ///
+    /// `ChannelManager` が新規接続チャンネルの `ChatViewModel` にプリロード済み
+    /// ユーザーエモートをシードするために使用する。
+    /// `isUserEmotesLoaded` を `true` に設定するため、その後の `fetchUserEmotes` は
+    /// emote-sets 変化がない限りスキップされる。
+    ///
+    /// - Parameter emotes: シードするユーザーエモート一覧
+    func setUserEmotes(_ emotes: [HelixEmote]) {
+        userEmotes = emotes
+        isUserEmotesLoaded = true
+    }
+
     // MARK: - テスト用メソッド
 
 #if DEBUG
@@ -417,12 +444,6 @@ actor EmoteStore {
     /// チャンネルエモート一覧を直接設定する（テスト用）
     func setChannelEmotes(_ emotes: [HelixEmote]) {
         channelEmotes = emotes
-    }
-
-    /// ユーザーエモート一覧を直接設定する（テスト用）
-    func setUserEmotes(_ emotes: [HelixEmote]) {
-        userEmotes = emotes
-        isUserEmotesLoaded = true
     }
 
     /// ユーザーエモートセットを直接設定する（テスト用）

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -35,6 +35,15 @@ final class ChannelManager {
 
     private let authState: AuthState
     private let apiClient: any HelixAPIClientProtocol
+
+    /// ログイン時にユーザーエモートを事前取得するストア
+    ///
+    /// 各チャンネルの `ChatViewModel` が持つ個別のエモートストアとは別に、
+    /// アプリ起動・ログイン時にユーザーエモートをフェッチしておくために使用する。
+    /// `joinChannel` で新しい `ChatViewModel` を作成する際にスナップショットをシードする
+    /// ことで、エモートピッカーが即座に使用可能エモートを表示できるようになる。
+    private let preloadEmoteStore: EmoteStore
+
     /// IRC クライアントファクトリ（テスト時にモックを注入するために使用）
     private let makeIRCClient: @MainActor () -> any TwitchIRCClientProtocol
 
@@ -60,7 +69,9 @@ final class ChannelManager {
     /// - Parameter authState: 認証状態（IRC 接続と Helix API 呼び出しに使用）
     init(authState: AuthState) {
         self.authState = authState
-        self.apiClient = HelixAPIClient(tokenProvider: authState)
+        let helixClient = HelixAPIClient(tokenProvider: authState)
+        self.apiClient = helixClient
+        self.preloadEmoteStore = EmoteStore(apiClient: helixClient)
         self.makeIRCClient = { TwitchIRCClient() }
         self.makeEventSubClient = { [authState] in
             TwitchEventSubClient(apiClient: HelixAPIClient(tokenProvider: authState))
@@ -73,18 +84,34 @@ final class ChannelManager {
     ///   - authState: 認証状態
     ///   - makeIRCClient: IRC クライアントを生成するファクトリクロージャ
     ///   - makeEventSubClient: EventSub クライアントを生成するファクトリクロージャ（nil で EventSub 無効化）
+    ///   - preloadEmoteStore: ユーザーエモートプリロード用ストア（nil の場合はデフォルトを生成）
     init(
         authState: AuthState,
         makeIRCClient: @escaping @MainActor () -> any TwitchIRCClientProtocol,
-        makeEventSubClient: (@MainActor () -> any TwitchEventSubClientProtocol)? = nil
+        makeEventSubClient: (@MainActor () -> any TwitchEventSubClientProtocol)? = nil,
+        preloadEmoteStore: EmoteStore? = nil
     ) {
         self.authState = authState
-        self.apiClient = HelixAPIClient(tokenProvider: authState)
+        let helixClient = HelixAPIClient(tokenProvider: authState)
+        self.apiClient = helixClient
+        self.preloadEmoteStore = preloadEmoteStore ?? EmoteStore(apiClient: helixClient)
         self.makeIRCClient = makeIRCClient
         self.makeEventSubClient = makeEventSubClient
     }
 
     // MARK: - 公開メソッド
+
+    /// ログイン時・アプリ起動時にユーザーエモートを事前取得する
+    ///
+    /// プリロードストアでユーザーエモートをフェッチしておくことで、`joinChannel` 呼び出し時に
+    /// 新しい `ChatViewModel` のエモートストアへ即座にシードできるようにする。
+    /// `user:read:emotes` スコープがない場合や未ログイン時はスキップする。
+    ///
+    /// `TwitchChatApp` のログイン検知（`.loggedIn` 状態遷移・セッション復元）から呼び出す。
+    func preloadUserEmotes() async {
+        guard let userId = authState.userId, authState.canReadUserEmotes else { return }
+        await preloadEmoteStore.fetchUserEmotes(userId: userId)
+    }
 
     /// 指定チャンネルに参加する
     ///
@@ -104,6 +131,14 @@ final class ChannelManager {
         // 新規接続
         let ircClient = makeIRCClient()
         let viewModel = ChatViewModel(ircClient: ircClient, authState: authState, apiClient: apiClient)
+
+        // プリロード済みユーザーエモートをシードして初回ピッカー表示を高速化する
+        // connect() より前にシードすることで、USERSTATE 到着前からエモートが利用可能になる
+        let userEmotesSnapshot = await preloadEmoteStore.userEmotesSnapshot()
+        if !userEmotesSnapshot.isEmpty {
+            await viewModel.emoteStore.setUserEmotes(userEmotesSnapshot)
+        }
+
         channels[normalized] = viewModel
         channelOrder.append(normalized)
         selectedChannel = normalized
@@ -280,5 +315,9 @@ final class ChannelManager {
             await client.disconnect()
         }
         eventSubClient = nil
+
+        // プリロードストアをリセットして次回ログイン時に再フェッチできるようにする
+        await preloadEmoteStore.cancelUserEmotesFetch()
+        await preloadEmoteStore.resetUserEmotes()
     }
 }

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -185,7 +185,7 @@ final class ChannelManager {
         eventSubReceiveTask = Task { [weak self] in
             let stream = await client.chatMessageEventStream
             for await event in stream {
-                await self?.routeEventSubChatMessage(event)
+                self?.routeEventSubChatMessage(event)
             }
         }
     }
@@ -205,8 +205,8 @@ final class ChannelManager {
             guard let self else { return }
             Task {
                 // subscribeChatMessage には認証済みユーザーの ID が必要
-                guard let userId = await self.authState.userId else { return }
-                guard let client = await self.eventSubClient else { return }
+                guard let userId = self.authState.userId else { return }
+                guard let client = self.eventSubClient else { return }
                 do {
                     try await client.subscribeChatMessage(
                         broadcasterId: broadcasterId,

--- a/Sources/TwitchChat/ViewModels/ChatSendError.swift
+++ b/Sources/TwitchChat/ViewModels/ChatSendError.swift
@@ -1,0 +1,132 @@
+// ChatSendError.swift
+// チャットメッセージ送信エラーの定義
+// ChatViewModel で使用する送信エラー型を独立したファイルとして管理する
+
+import Foundation
+
+/// チャットメッセージ送信時のエラー
+enum ChatSendError: Error, LocalizedError, Equatable {
+    /// 送信テキストが空（トリム後）
+    case empty
+    /// 送信テキストが 500 文字を超えている
+    case tooLong
+    /// 送信できる状態でない（未接続・未ログイン・スコープ不足）
+    case notReady
+    /// クライアント側レートリミット超過（送信前の事前チェック）
+    ///
+    /// - Parameter retryAfter: 送信可能になるまでの残り秒数
+    case clientRateLimited(retryAfter: TimeInterval)
+    /// レートリミット超過（msg_ratelimit）
+    case rateLimited
+    /// 重複メッセージの連投（msg_duplicate）
+    case duplicate
+    /// エモートオンリーモード（msg_emoteonly）
+    case emoteOnly
+    /// フォロワー限定モード（msg_followersonly / msg_followersonly_followed / msg_followersonly_zero）
+    case followersOnly
+    /// サブスクライバー限定モード（msg_subsonly）
+    case subscribersOnly
+    /// スローモード中（msg_slowmode）
+    case slowMode
+    /// BAN またはチャンネル停止（msg_banned / msg_channel_suspended / tos_ban）
+    case banned
+    /// タイムアウト中（msg_timedout）
+    case timedOut
+    /// メール/電話番号認証が必要（msg_verified_email / msg_requires_verified_phone_number）
+    case verificationRequired
+    /// 上記以外のサーバー起因エラー（エラー文言をそのまま保持）
+    case serverRejected(String)
+    /// 未知のスラッシュコマンド（補完候補にないコマンドを入力した場合）
+    case unknownCommand(String)
+    /// チャンネル接続前でまだ room-id が不明（まだメッセージを受信していない）
+    case roomIdNotAvailable
+    /// モデレーションコマンドに必要なOAuthスコープが付与されていない
+    ///
+    /// - Parameter required: 必要なスコープ一覧（例: ["channel:moderate"]）
+    case scopeInsufficient(required: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case .empty:
+            return "メッセージを入力してください"
+        case .tooLong:
+            return "メッセージは500文字以内にしてください"
+        case .notReady:
+            return "コメントの投稿にはログインが必要です"
+        case .clientRateLimited(let retryAfter):
+            // retryAfter が 0 以下になる場合でも「あと 1 秒」と表示して混乱を防ぐ
+            let seconds = max(1, Int(ceil(retryAfter)))
+            return "送信頻度が上限に達しました。あと \(seconds) 秒後に再試行してください"
+        case .rateLimited:
+            return "メッセージの送信頻度が速すぎます。少し待ってから送信してください"
+        case .duplicate:
+            return "直前と同じメッセージは連投できません"
+        case .emoteOnly:
+            return "このチャンネルはエモートのみ送信できます"
+        case .followersOnly:
+            return "このチャンネルはフォロワー限定モードです"
+        case .subscribersOnly:
+            return "このチャンネルはサブスクライバー限定モードです"
+        case .slowMode:
+            return "スローモード中です。時間を空けて送信してください"
+        case .banned:
+            return "このチャンネルで投稿が制限されています"
+        case .timedOut:
+            return "タイムアウト中は投稿できません"
+        case .verificationRequired:
+            return "投稿にはメール/電話番号の認証が必要です"
+        case .serverRejected(let message):
+            return "送信できませんでした: \(message)"
+        case .unknownCommand(let name):
+            return "不明なコマンドです: /\(name)"
+        case .roomIdNotAvailable:
+            return "チャンネル情報を取得中です。しばらくしてから再試行してください"
+        case .scopeInsufficient(let required):
+            return "このコマンドには追加の権限が必要です（\(required.joined(separator: ", "))）。再ログインしてください"
+        }
+    }
+
+    /// TwitchNotice を ChatSendError に変換する
+    ///
+    /// 送信エラーに相当しない NOTICE（情報系通知など）は nil を返す。
+    ///
+    /// - Parameter notice: サーバーから受信した TwitchNotice
+    /// - Returns: 対応する ChatSendError、または変換対象外の場合は nil
+    static func from(notice: TwitchNotice) -> ChatSendError? {
+        guard let msgId = notice.msgId else { return nil }
+        if let mapped = msgIdToError[msgId] {
+            return mapped
+        }
+        // "msg_" プレフィックスを持つ未知の msg-id はサーバー起因エラーとして扱う
+        if msgId.hasPrefix("msg_") {
+            return .serverRejected(notice.message)
+        }
+        // 情報系通知（host_on, host_off, raid 等）は nil を返してスキップする
+        return nil
+    }
+
+    /// msg-id → ChatSendError のマッピングテーブル
+    ///
+    /// 複数の msg-id が同じエラーに対応する場合は同じ case を指定する。
+    private static let msgIdToError: [String: ChatSendError] = {
+        let entries: [(String, ChatSendError)] = [
+            ("msg_ratelimit",                          .rateLimited),
+            ("msg_duplicate",                          .duplicate),
+            ("msg_emoteonly",                          .emoteOnly),
+            ("msg_followersonly",                      .followersOnly),
+            ("msg_followersonly_followed",             .followersOnly),
+            ("msg_followersonly_zero",                 .followersOnly),
+            ("msg_subsonly",                           .subscribersOnly),
+            ("msg_slowmode",                           .slowMode),
+            ("msg_banned",                             .banned),
+            ("msg_channel_suspended",                  .banned),
+            ("tos_ban",                                .banned),
+            ("no_permission",                          .banned),
+            ("msg_suspended",                          .banned),
+            ("msg_timedout",                           .timedOut),
+            ("msg_verified_email",                     .verificationRequired),
+            ("msg_requires_verified_phone_number",     .verificationRequired)
+        ]
+        return Dictionary(uniqueKeysWithValues: entries)
+    }()
+}

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -270,23 +270,7 @@ final class ChatViewModel {
             let stream = await self.ircClient.userStateStream
             for await userState in stream {
                 guard !Task.isCancelled else { break }
-                self.currentUserState = userState
-                // emote-sets 変化を先に取得してからストアを更新する
-                let previousEmoteSets = await self.emoteStore.userAvailableEmoteSets()
-                await self.emoteStore.updateUserEmoteSets(userState.emoteSets)
-                if let userId = self.authState.userId, self.authState.canReadUserEmotes {
-                    // emote-sets が実際に変化した場合（サブスク追加/終了）はユーザーエモートを再フェッチ
-                    // nil → 値 は初回 USERSTATE のため変化とみなさず、フェッチは connect() 時のタスクに任せる
-                    if let previous = previousEmoteSets, previous != userState.emoteSets {
-                        #if DEBUG
-                        print("[ChatViewModel] emote-sets 変化を検出 — ユーザーエモートを再フェッチ")
-                        #endif
-                        await self.emoteStore.resetUserEmotes()
-                    }
-                    // 未ロード・再ログイン後・emote-sets 変化後のいずれもここで起動
-                    // isUserEmotesLoaded フラグが内部でガードするため重複フェッチなし
-                    self.userEmoteFetchTask = Task { await self.emoteStore.fetchUserEmotes(userId: userId) }
-                }
+                await self.handleUserStateUpdate(userState)
             }
         }
         // ROOMSTATE を購読して room-id を早期設定する（PRIVMSG より先に取得可能）
@@ -298,6 +282,31 @@ final class ChatViewModel {
                 self.applyRoomState(roomId: roomId)
             }
         }
+    }
+
+    /// USERSTATE 受信時のエモートセット更新処理を行う
+    ///
+    /// USERSTATE で通知された emote-sets を EmoteStore に反映し、
+    /// 変化があった場合はユーザーエモートの再フェッチを起動する。
+    ///
+    /// - Parameter userState: 受信した USERSTATE 情報
+    private func handleUserStateUpdate(_ userState: TwitchUserState) async {
+        currentUserState = userState
+        // emote-sets 変化を先に取得してからストアを更新する
+        let previousEmoteSets = await emoteStore.userAvailableEmoteSets()
+        await emoteStore.updateUserEmoteSets(userState.emoteSets)
+        guard let userId = authState.userId, authState.canReadUserEmotes else { return }
+        // emote-sets が実際に変化した場合（サブスク追加/終了）はユーザーエモートを再フェッチ
+        // nil → 値 は初回 USERSTATE のため変化とみなさず、フェッチは connect() 時のタスクに任せる
+        if let previous = previousEmoteSets, previous != userState.emoteSets {
+            #if DEBUG
+            print("[ChatViewModel] emote-sets 変化を検出 — ユーザーエモートを再フェッチ")
+            #endif
+            await emoteStore.resetUserEmotes()
+        }
+        // 未ロード・再ログイン後・emote-sets 変化後のいずれもここで起動
+        // isUserEmotesLoaded フラグが内部でガードするため重複フェッチなし
+        userEmoteFetchTask = Task { await emoteStore.fetchUserEmotes(userId: userId) }
     }
 
     /// チャンネルから切断する
@@ -675,133 +684,4 @@ final class ChatViewModel {
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespaces)
     }
-}
-
-// MARK: - 送信エラー定義
-
-/// チャットメッセージ送信時のエラー
-enum ChatSendError: Error, LocalizedError, Equatable {
-    /// 送信テキストが空（トリム後）
-    case empty
-    /// 送信テキストが 500 文字を超えている
-    case tooLong
-    /// 送信できる状態でない（未接続・未ログイン・スコープ不足）
-    case notReady
-    /// クライアント側レートリミット超過（送信前の事前チェック）
-    ///
-    /// - Parameter retryAfter: 送信可能になるまでの残り秒数
-    case clientRateLimited(retryAfter: TimeInterval)
-    /// レートリミット超過（msg_ratelimit）
-    case rateLimited
-    /// 重複メッセージの連投（msg_duplicate）
-    case duplicate
-    /// エモートオンリーモード（msg_emoteonly）
-    case emoteOnly
-    /// フォロワー限定モード（msg_followersonly / msg_followersonly_followed / msg_followersonly_zero）
-    case followersOnly
-    /// サブスクライバー限定モード（msg_subsonly）
-    case subscribersOnly
-    /// スローモード中（msg_slowmode）
-    case slowMode
-    /// BAN またはチャンネル停止（msg_banned / msg_channel_suspended / tos_ban）
-    case banned
-    /// タイムアウト中（msg_timedout）
-    case timedOut
-    /// メール/電話番号認証が必要（msg_verified_email / msg_requires_verified_phone_number）
-    case verificationRequired
-    /// 上記以外のサーバー起因エラー（エラー文言をそのまま保持）
-    case serverRejected(String)
-    /// 未知のスラッシュコマンド（補完候補にないコマンドを入力した場合）
-    case unknownCommand(String)
-    /// チャンネル接続前でまだ room-id が不明（まだメッセージを受信していない）
-    case roomIdNotAvailable
-    /// モデレーションコマンドに必要なOAuthスコープが付与されていない
-    ///
-    /// - Parameter required: 必要なスコープ一覧（例: ["channel:moderate"]）
-    case scopeInsufficient(required: [String])
-
-    var errorDescription: String? {
-        switch self {
-        case .empty:
-            return "メッセージを入力してください"
-        case .tooLong:
-            return "メッセージは500文字以内にしてください"
-        case .notReady:
-            return "コメントの投稿にはログインが必要です"
-        case .clientRateLimited(let retryAfter):
-            // retryAfter が 0 以下になる場合でも「あと 1 秒」と表示して混乱を防ぐ
-            let seconds = max(1, Int(ceil(retryAfter)))
-            return "送信頻度が上限に達しました。あと \(seconds) 秒後に再試行してください"
-        case .rateLimited:
-            return "メッセージの送信頻度が速すぎます。少し待ってから送信してください"
-        case .duplicate:
-            return "直前と同じメッセージは連投できません"
-        case .emoteOnly:
-            return "このチャンネルはエモートのみ送信できます"
-        case .followersOnly:
-            return "このチャンネルはフォロワー限定モードです"
-        case .subscribersOnly:
-            return "このチャンネルはサブスクライバー限定モードです"
-        case .slowMode:
-            return "スローモード中です。時間を空けて送信してください"
-        case .banned:
-            return "このチャンネルで投稿が制限されています"
-        case .timedOut:
-            return "タイムアウト中は投稿できません"
-        case .verificationRequired:
-            return "投稿にはメール/電話番号の認証が必要です"
-        case .serverRejected(let message):
-            return "送信できませんでした: \(message)"
-        case .unknownCommand(let name):
-            return "不明なコマンドです: /\(name)"
-        case .roomIdNotAvailable:
-            return "チャンネル情報を取得中です。しばらくしてから再試行してください"
-        case .scopeInsufficient(let required):
-            return "このコマンドには追加の権限が必要です（\(required.joined(separator: ", "))）。再ログインしてください"
-        }
-    }
-
-    /// TwitchNotice を ChatSendError に変換する
-    ///
-    /// 送信エラーに相当しない NOTICE（情報系通知など）は nil を返す。
-    ///
-    /// - Parameter notice: サーバーから受信した TwitchNotice
-    /// - Returns: 対応する ChatSendError、または変換対象外の場合は nil
-    static func from(notice: TwitchNotice) -> ChatSendError? {
-        guard let msgId = notice.msgId else { return nil }
-        if let mapped = msgIdToError[msgId] {
-            return mapped
-        }
-        // "msg_" プレフィックスを持つ未知の msg-id はサーバー起因エラーとして扱う
-        if msgId.hasPrefix("msg_") {
-            return .serverRejected(notice.message)
-        }
-        // 情報系通知（host_on, host_off, raid 等）は nil を返してスキップする
-        return nil
-    }
-
-    /// msg-id → ChatSendError のマッピングテーブル
-    ///
-    /// 複数の msg-id が同じエラーに対応する場合は同じ case を指定する。
-    private static let msgIdToError: [String: ChatSendError] = {
-        let entries: [(String, ChatSendError)] = [
-            ("msg_ratelimit",                          .rateLimited),
-            ("msg_duplicate",                          .duplicate),
-            ("msg_emoteonly",                          .emoteOnly),
-            ("msg_followersonly",                      .followersOnly),
-            ("msg_followersonly_followed",             .followersOnly),
-            ("msg_followersonly_zero",                 .followersOnly),
-            ("msg_subsonly",                           .subscribersOnly),
-            ("msg_slowmode",                           .slowMode),
-            ("msg_banned",                             .banned),
-            ("msg_channel_suspended",                  .banned),
-            ("tos_ban",                                .banned),
-            ("no_permission",                          .banned),
-            ("msg_suspended",                          .banned),
-            ("msg_timedout",                           .timedOut),
-            ("msg_verified_email",                     .verificationRequired),
-            ("msg_requires_verified_phone_number",     .verificationRequired)
-        ]
-        return Dictionary(uniqueKeysWithValues: entries)
-    }()
 }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -271,11 +271,20 @@ final class ChatViewModel {
             for await userState in stream {
                 guard !Task.isCancelled else { break }
                 self.currentUserState = userState
-                // emote-sets タグを EmoteStore に反映して、エモートピッカーの使用可否判定を更新する
+                // emote-sets 変化を先に取得してからストアを更新する
+                let previousEmoteSets = await self.emoteStore.userAvailableEmoteSets()
                 await self.emoteStore.updateUserEmoteSets(userState.emoteSets)
-                // 再ログイン後に user:read:emotes スコープが付与された場合もフェッチを起動する
-                // fetchUserEmotes は isUserEmotesLoaded フラグで重複フェッチを防止するため安全
                 if let userId = self.authState.userId, self.authState.canReadUserEmotes {
+                    // emote-sets が実際に変化した場合（サブスク追加/終了）はユーザーエモートを再フェッチ
+                    // nil → 値 は初回 USERSTATE のため変化とみなさず、フェッチは connect() 時のタスクに任せる
+                    if let previous = previousEmoteSets, previous != userState.emoteSets {
+                        #if DEBUG
+                        print("[ChatViewModel] emote-sets 変化を検出 — ユーザーエモートを再フェッチ")
+                        #endif
+                        await self.emoteStore.resetUserEmotes()
+                    }
+                    // 未ロード・再ログイン後・emote-sets 変化後のいずれもここで起動
+                    // isUserEmotesLoaded フラグが内部でガードするため重複フェッチなし
                     self.userEmoteFetchTask = Task { await self.emoteStore.fetchUserEmotes(userId: userId) }
                 }
             }

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -230,6 +230,7 @@ final class ChatViewModel {
             userStateReceiveTask?.cancel()
             globalBadgeFetchTask?.cancel()
             globalEmoteFetchTask?.cancel()
+            userEmoteFetchTask?.cancel()
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -199,6 +199,14 @@ final class ChatViewModel {
         // ユーザースコープのため接続時に1回のみ取得し、チャンネル切替時には再取得しない
         if let userId = authState.userId, authState.canReadUserEmotes {
             userEmoteFetchTask = Task { await emoteStore.fetchUserEmotes(userId: userId) }
+        } else {
+            #if DEBUG
+            if authState.userId == nil {
+                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: userId が未取得（未ログイン）")
+            } else if !authState.canReadUserEmotes {
+                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: user:read:emotes スコープなし（再ログインで取得可能）")
+            }
+            #endif
         }
 
         startStreamTasks()

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -95,6 +95,11 @@ final class ChatViewModel {
     /// チャンネルエモートフェッチタスク（切断時にキャンセル）
     private var channelEmoteFetchTask: Task<Void, Never>?
 
+    /// ユーザーエモートフェッチタスク（切断時にキャンセル）
+    ///
+    /// ユーザーエモートはユーザースコープのため接続時に1回のみフェッチ（チャンネル切替時は再取得不要）
+    private var userEmoteFetchTask: Task<Void, Never>?
+
     /// NOTICE 受信ループタスク（切断時にキャンセル）
     private var noticeReceiveTask: Task<Void, Never>?
 
@@ -190,6 +195,12 @@ final class ChatViewModel {
         globalBadgeFetchTask = Task { await badgeStore.fetchGlobalBadges() }
         globalEmoteFetchTask = Task { await emoteStore.fetchGlobalEmotes() }
 
+        // ユーザーエモートを並行フェッチ（user:read:emotes スコープがある場合のみ）
+        // ユーザースコープのため接続時に1回のみ取得し、チャンネル切替時には再取得しない
+        if let userId = authState.userId, authState.canReadUserEmotes {
+            userEmoteFetchTask = Task { await emoteStore.fetchUserEmotes(userId: userId) }
+        }
+
         startStreamTasks()
 
         do {
@@ -278,11 +289,14 @@ final class ChatViewModel {
         channelBadgeFetchTask?.cancel()
         globalEmoteFetchTask?.cancel()
         channelEmoteFetchTask?.cancel()
+        userEmoteFetchTask?.cancel()
         // BadgeStore / EmoteStore 内部の unstructured task もキャンセルする（キャンセル伝播漏れの防止）
         await badgeStore.cancelGlobalFetch()
         await emoteStore.cancelGlobalFetch()
-        // disconnect 時にユーザーエモートセットをリセットし、前回接続の情報を持ち越さない
+        await emoteStore.cancelUserEmotesFetch()
+        // disconnect 時にユーザーエモートセット・ユーザーエモートをリセットし、前回接続の情報を持ち越さない
         await emoteStore.resetUserEmoteSets()
+        await emoteStore.resetUserEmotes()
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -337,12 +337,19 @@ final class ChatViewModel {
     ///
     /// PRIVMSG より先に届くため、接続直後のモデレーションコマンドが使えるようになる。
     /// room-id が既に設定済みの場合は上書きしない。
-    /// チャンネルバッジ・エモートのフェッチは appendMessage() で行う。
+    /// チャンネルエモートは ROOMSTATE 受信時にフェッチ開始し、ピッカーを開いたときに
+    /// 素早く表示できるようにする。バッジのフェッチは appendMessage() で行う。
     private func applyRoomState(roomId: String) {
         if currentRoomId == nil {
             currentRoomId = roomId
             // room-id 確定を ChannelManager に通知する（EventSub サブスクリプション登録に使用）
             onRoomIdConfirmed?(roomId)
+            // PRIVMSG より先に room-id が取得できるため、チャンネルエモートを早期フェッチする
+            // channelEmotesFetched フラグで重複フェッチを防止する（appendMessage() との排他制御）
+            if !channelEmotesFetched {
+                channelEmotesFetched = true
+                channelEmoteFetchTask = Task { await emoteStore.fetchChannelEmotes(broadcasterId: roomId) }
+            }
         }
     }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -273,6 +273,11 @@ final class ChatViewModel {
                 self.currentUserState = userState
                 // emote-sets タグを EmoteStore に反映して、エモートピッカーの使用可否判定を更新する
                 await self.emoteStore.updateUserEmoteSets(userState.emoteSets)
+                // 再ログイン後に user:read:emotes スコープが付与された場合もフェッチを起動する
+                // fetchUserEmotes は isUserEmotesLoaded フラグで重複フェッチを防止するため安全
+                if let userId = self.authState.userId, self.authState.canReadUserEmotes {
+                    self.userEmoteFetchTask = Task { await self.emoteStore.fetchUserEmotes(userId: userId) }
+                }
             }
         }
         // ROOMSTATE を購読して room-id を早期設定する（PRIVMSG より先に取得可能）

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -42,6 +42,11 @@ final class EmotePickerViewModel {
     /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
     private var userEmoteSets: Set<String>?
 
+    /// `/helix/chat/emotes/user` から取得したユーザーエモートの ID セット
+    ///
+    /// このセットに含まれるエモートは USERSTATE の emoteSetId チェックによらず常に使用可能。
+    private var userEmoteIds: Set<String> = []
+
     // MARK: - 初期化
 
     /// EmotePickerViewModel を初期化する
@@ -62,6 +67,7 @@ final class EmotePickerViewModel {
         await emoteStore.fetchGlobalEmotes()
         allEmotes = await emoteStore.allEmotes()
         userEmoteSets = await emoteStore.userAvailableEmoteSets()
+        userEmoteIds = await emoteStore.userEmoteIdSet()
         applyFilter()
     }
 
@@ -75,18 +81,29 @@ final class EmotePickerViewModel {
             await emoteStore.waitForNextUserEmoteSetsUpdate()
             guard !Task.isCancelled else { break }
             userEmoteSets = await emoteStore.userAvailableEmoteSets()
+            userEmoteIds = await emoteStore.userEmoteIdSet()
+            // allEmotes はエモート定義が変わった場合のみ更新（再フィルタコストを抑える）
+            let newAllEmotes = await emoteStore.allEmotes()
+            if newAllEmotes != allEmotes {
+                allEmotes = newAllEmotes
+            }
+            applyFilter()
         }
     }
 
     /// エモートがユーザーにとって使用可能かどうかを返す
     ///
-    /// - `userEmoteSets` が `nil`（USERSTATE 未受信）の場合は全て true
-    /// - `emote.emoteSetId` が nil の場合は安全側に倒して true
-    /// - それ以外は emoteSetId が userEmoteSets に含まれるか判定する
+    /// 判定優先順位:
+    /// 1. `/helix/chat/emotes/user` から取得したユーザーエモート ID に含まれる場合は常に true
+    /// 2. `userEmoteSets` が `nil`（USERSTATE 未受信）の場合は全て true
+    /// 3. `emote.emoteSetId` が nil の場合は安全側に倒して true
+    /// 4. それ以外は emoteSetId が userEmoteSets に含まれるか判定する
     ///
     /// - Parameter emote: 判定対象のエモート
     /// - Returns: 使用可能な場合は true
     func isAvailable(_ emote: HelixEmote) -> Bool {
+        // ユーザーエモートは /helix/chat/emotes/user から取得済みのため常に使用可能
+        if userEmoteIds.contains(emote.id) { return true }
         guard let sets = userEmoteSets else { return true }
         guard let emoteSetId = emote.emoteSetId else { return true }
         return sets.contains(emoteSetId)

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -390,6 +390,46 @@ struct ChannelManagerTests {
         #expect(disconnected == true)
     }
 
+    // MARK: - ユーザーエモートプリロード
+
+    @Test("joinChannel でプリロード済みユーザーエモートが ChatViewModel のエモートストアにシードされる")
+    func testJoinChannelSeedsPreloadedUserEmotes() async throws {
+        // 前提: プリロードエモートストアにユーザーエモートを設定済み
+        let preloadStore = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await preloadStore.setUserEmotes([.ユーザーエモート別チャンネルSub])
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            preloadEmoteStore: preloadStore
+        )
+
+        // 操作: チャンネルに参加する
+        await manager.joinChannel("haishinsha1")
+
+        // 検証: 新しく作成された ChatViewModel のエモートストアにプリロードエモートが含まれること
+        let viewModel = try #require(manager.channels["haishinsha1"])
+        let allEmotes = await viewModel.emoteStore.allEmotes()
+        #expect(allEmotes.contains(where: { $0.id == HelixEmote.ユーザーエモート別チャンネルSub.id }))
+    }
+
+    @Test("プリロードエモートが空の場合 joinChannel 後の ChatViewModel のエモートストアにもユーザーエモートなし")
+    func testJoinChannelWithEmptyPreloadHasNoUserEmotes() async throws {
+        // 前提: プリロードエモートストアにユーザーエモートが設定されていない
+        let preloadStore = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            preloadEmoteStore: preloadStore
+        )
+
+        await manager.joinChannel("haishinsha1")
+
+        // 検証: プリロードなしのため ChatViewModel のエモートストアにユーザーエモートがない
+        let viewModel = try #require(manager.channels["haishinsha1"])
+        let userEmoteIdSet = await viewModel.emoteStore.userEmoteIdSet()
+        #expect(userEmoteIdSet.isEmpty)
+    }
+
     @Test("roomId 確定時に ChatViewModel の onRoomIdConfirmed コールバックがセットされている")
     func testRoomIdConfirmedCallbackIsConfigured() async throws {
         // 前提: MockTwitchIRCClient と MockTwitchEventSubClient を使う

--- a/Tests/TwitchChatTests/EmoteDefinitionTests.swift
+++ b/Tests/TwitchChatTests/EmoteDefinitionTests.swift
@@ -258,4 +258,109 @@ struct EmoteDefinitionTests {
         let emote = HelixEmote(id: "112291", name: "KEKHeim", format: ["static"], emoteType: "globals")
         #expect(emote.isAnimated == false)
     }
+
+    // MARK: - owner_id のデコード
+
+    @Test("owner_id を含むエモートを正しくデコードできる")
+    func testDecodeEmoteWithOwnerId() throws {
+        // 前提: /helix/chat/emotes/user レスポンスに含まれる owner_id フィールド
+        let json = """
+        {
+          "data": [
+            {
+              "id": "emotesv2_hypetrain_test",
+              "name": "Hypeトレインエモート",
+              "format": ["static"],
+              "emote_type": "hypetrain",
+              "emote_set_id": "77777",
+              "owner_id": "11111111"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].ownerId == "11111111")
+    }
+
+    @Test("owner_id が省略されている場合は ownerId が nil になる")
+    func testDecodeEmoteWithMissingOwnerId() throws {
+        // 前提: グローバル・チャンネルエモート等 owner_id を含まないエンドポイントのレスポンス
+        let json = """
+        {
+          "data": [
+            {
+              "id": "425618",
+              "name": "LUL",
+              "format": ["static", "animated"],
+              "emote_type": "globals"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].ownerId == nil)
+    }
+
+    // MARK: - HelixUserEmotesResponse のデコード
+
+    @Test("HelixUserEmotesResponse を cursor あり で正しくデコードできる")
+    func testDecodeUserEmotesResponseWithCursor() throws {
+        // 前提: /helix/chat/emotes/user の複数ページある場合のレスポンス
+        let json = """
+        {
+          "data": [
+            {
+              "id": "emotesv2_sub_other_channel",
+              "name": "他チャンネルサブスクエモート",
+              "format": ["static"],
+              "emote_type": "subscriptions",
+              "emote_set_id": "99999",
+              "owner_id": "12345678"
+            }
+          ],
+          "pagination": {
+            "cursor": "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MX19"
+          }
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixUserEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].name == "他チャンネルサブスクエモート")
+        #expect(response.data[0].ownerId == "12345678")
+        #expect(response.cursor == "eyJiIjpudWxsLCJhIjp7Ik9mZnNldCI6MX19")
+    }
+
+    @Test("HelixUserEmotesResponse を cursor なし（最終ページ）で正しくデコードできる")
+    func testDecodeUserEmotesResponseWithoutCursor() throws {
+        // 前提: /helix/chat/emotes/user の最終ページ（cursor フィールドなし）
+        let json = """
+        {
+          "data": [
+            {
+              "id": "emotesv2_bits_test",
+              "name": "ビッツ応援エモート",
+              "format": ["static", "animated"],
+              "emote_type": "bitstier",
+              "emote_set_id": "88888",
+              "owner_id": "87654321"
+            }
+          ]
+        }
+        """
+        let data = Data(json.utf8)
+        let response = try JSONDecoder().decode(HelixUserEmotesResponse.self, from: data)
+
+        #expect(response.data.count == 1)
+        #expect(response.data[0].name == "ビッツ応援エモート")
+        #expect(response.data[0].emoteType == "bitstier")
+        #expect(response.cursor == nil)
+    }
 }

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -218,4 +218,53 @@ struct EmotePickerViewModelTests {
         // 検証: emoteSetId 不明なエモートは安全側に倒して使用可能
         #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
     }
+
+    // MARK: - ユーザーエモート使用可否判定
+
+    @Test("ユーザーエモートは emoteSetId が userEmoteSets に含まれなくても常に使用可能")
+    @MainActor
+    func testUserEmoteIsAlwaysAvailable() async throws {
+        // 前提: USERSTATE はグローバルセット "0" のみ（別チャンネルのセットは未保有）
+        // しかし /helix/chat/emotes/user から取得したエモートはサブスク済みのため使用可能
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([])
+        await store.setUserEmoteSets(Set(["0"]))
+        await store.setUserEmotes([
+            HelixEmote(id: "user_sub_1", name: "別チャンネルSub", format: ["static"], emoteType: "subscriptions", emoteSetId: "999999")
+        ])
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: ユーザーエモートは userEmoteSets に関係なく使用可能
+        let targetEmote = try #require(
+            viewModel.filteredEmotes.first(where: { $0.name == "別チャンネルSub" }),
+            "テスト対象エモートが filteredEmotes に見つかりません"
+        )
+        #expect(viewModel.isAvailable(targetEmote) == true)
+    }
+
+    @Test("ユーザーエモートでないチャンネルエモートは従来通り emoteSetId で判定する")
+    @MainActor
+    func testNonUserEmoteUsesEmoteSetIdCheck() async throws {
+        // 前提: チャンネルエモートだが userEmotes には含まれていない（未サブスク）
+        // グローバルセット "0" のみ保持
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([])
+        await store.setUserEmoteSets(Set(["0"]))
+        await store.setChannelEmotes([
+            HelixEmote(id: "ch_unsub", name: "未サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "55555")
+        ])
+        // ユーザーエモートは空（このチャンネルにはサブスクしていない）
+
+        let viewModel = EmotePickerViewModel(emoteStore: store)
+        await viewModel.loadEmotes()
+
+        // 検証: ユーザーエモートでないエモートは emoteSetId チェックが適用される
+        let targetEmote = try #require(
+            viewModel.filteredEmotes.first(where: { $0.name == "未サブスクエモート" }),
+            "テスト対象エモートが filteredEmotes に見つかりません"
+        )
+        #expect(viewModel.isAvailable(targetEmote) == false)
+    }
 }

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -7,19 +7,81 @@ import Testing
 
 // MARK: - テスト用モック
 
+/// フェッチ回数を Sendable なクラスで安全に計測するカウンター
+final class FetchCounter: @unchecked Sendable {
+    var value = 0
+}
+
+/// 特定エンドポイントへのフェッチ回数をカウントするモッククライアント
+///
+/// - `countedEndpoint` に含まれる URL パターンへのリクエスト数のみを計測する
+/// - `/emotes/user` URL の場合は `HelixUserEmotesResponse`、それ以外は `HelixEmotesResponse` を返す
+struct CountingMockClient: HelixAPIClientProtocol {
+    let counter: FetchCounter
+    /// カウント対象とする URL パターン（例: "/emotes/user", "/emotes/global"）
+    let countedEndpoint: String
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        if url.absoluteString.contains(countedEndpoint) {
+            counter.value += 1
+        }
+        if url.absoluteString.contains("/emotes/user") {
+            if let response = HelixUserEmotesResponse(data: [], cursor: nil) as? T {
+                return response
+            }
+        } else {
+            if let response = HelixEmotesResponse(data: []) as? T {
+                return response
+            }
+        }
+        throw URLError(.badServerResponse)
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T { throw URLError(.badServerResponse) }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws { throw URLError(.badServerResponse) }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws { throw URLError(.badServerResponse) }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws { throw URLError(.badServerResponse) }
+}
+
 /// HelixAPIClientProtocol のテスト用モック（EmoteStore テスト専用）
 ///
 /// - `shouldThrowAuthError = true` の場合は未ログイン状態をシミュレート
-/// - `stubbedEmotes` にエモート配列を設定するとそれを返す
+/// - `stubbedEmotes` にエモート配列を設定するとグローバル・チャンネルエモートエンドポイントで返す
+/// - `stubbedUserEmotesPages` にページ配列を設定するとユーザーエモートエンドポイントでページネーション返す
 /// - いずれも未設定の場合はサーバーエラーを throw する
 struct MockHelixAPIClientForEmote: HelixAPIClientProtocol {
     var shouldThrowAuthError: Bool = false
     var stubbedEmotes: [HelixEmote]?
 
+    /// ユーザーエモートのページ配列。index 0 が 1 ページ目、index 1 が 2 ページ目...
+    /// cursor は次ページのインデックス文字列（"1", "2", ...）として返す
+    var stubbedUserEmotesPages: [[HelixEmote]] = []
+
     func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
         if shouldThrowAuthError {
             throw URLError(.userAuthenticationRequired)
         }
+        // ユーザーエモートエンドポイント（/helix/chat/emotes/user）
+        if url.absoluteString.contains("/emotes/user") {
+            let afterCursor = queryItems?.first(where: { $0.name == "after" })?.value
+            let pageIndex = afterCursor.flatMap(Int.init) ?? 0
+            let pageData = pageIndex < stubbedUserEmotesPages.count ? stubbedUserEmotesPages[pageIndex] : []
+            let hasNextPage = (pageIndex + 1) < stubbedUserEmotesPages.count
+            let nextCursor = hasNextPage ? String(pageIndex + 1) : nil
+            if let response = HelixUserEmotesResponse(data: pageData, cursor: nextCursor) as? T {
+                return response
+            }
+        }
+        // グローバル・チャンネルエモートエンドポイント
         if let emotes = stubbedEmotes, let response = HelixEmotesResponse(data: emotes) as? T {
             return response
         }
@@ -52,6 +114,16 @@ extension HelixEmote {
     static let グローバルエモートPogChamp = HelixEmote(id: "305954156", name: "PogChamp", format: ["static"], emoteType: "globals")
     /// テスト用チャンネルエモート（サブスク）
     static let チャンネルエモートHype = HelixEmote(id: "emotesv2_abc", name: "配信者Hype", format: ["static"], emoteType: "subscriptions")
+    /// テスト用ユーザーエモート（別チャンネルサブスク）
+    static let ユーザーエモート別チャンネルSub = HelixEmote(
+        id: "emotesv2_user_sub", name: "別チャンネルSub", format: ["static"],
+        emoteType: "subscriptions", emoteSetId: "99999"
+    )
+    /// テスト用ユーザーエモート（ビッツ）
+    static let ユーザーエモートBits = HelixEmote(
+        id: "emotesv2_bits_test", name: "ビッツ応援エモート", format: ["static", "animated"],
+        emoteType: "bitstier", emoteSetId: "88888"
+    )
 }
 
 @Suite("EmoteStoreTests")
@@ -162,42 +234,8 @@ struct EmoteStoreTests {
 
     @Test("グローバルエモートは1回だけフェッチされる（isGlobalLoaded フラグ）")
     func testGlobalEmotesFetchedOnce() async {
-        // フェッチ回数を Sendable なクラスで安全に計測する
-        final class FetchCounter: @unchecked Sendable {
-            var value = 0
-        }
         let counter = FetchCounter()
-
-        // フェッチ回数をカウントするモック
-        struct CountingMockClient: HelixAPIClientProtocol {
-            let counter: FetchCounter
-
-            func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
-                counter.value += 1
-                if let response = HelixEmotesResponse(data: []) as? T {
-                    return response
-                }
-                throw URLError(.badServerResponse)
-            }
-
-            func post<Body: Encodable & Sendable, T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?, body: Body) async throws -> T {
-                throw URLError(.badServerResponse)
-            }
-
-            func postNoContent<Body: Encodable & Sendable>(url: URL, queryItems: [URLQueryItem]?, body: Body) async throws {
-                throw URLError(.badServerResponse)
-            }
-
-            func patch<Body: Encodable & Sendable>(url: URL, queryItems: [URLQueryItem]?, body: Body) async throws {
-                throw URLError(.badServerResponse)
-            }
-
-            func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
-                throw URLError(.badServerResponse)
-            }
-        }
-
-        let store = EmoteStore(apiClient: CountingMockClient(counter: counter))
+        let store = EmoteStore(apiClient: CountingMockClient(counter: counter, countedEndpoint: "/emotes/global"))
 
         // 2回呼んでも1回しかフェッチしない
         await store.fetchGlobalEmotes()
@@ -358,5 +396,230 @@ struct EmoteStoreTests {
         // 検証: ユーザーのエモートセットは保持される
         let emoteSets = await store.userAvailableEmoteSets()
         #expect(emoteSets == Set(["0", "33"]))
+    }
+
+    // MARK: - ユーザーエモート取得
+
+    @Test("fetchUserEmotes で1ページのユーザーエモートを取得できる")
+    func testFetchUserEmotesSinglePage() async {
+        // 前提: /helix/chat/emotes/user が1ページ分のエモートを返す
+        let mockClient = MockHelixAPIClientForEmote(
+            stubbedUserEmotesPages: [[.ユーザーエモート別チャンネルSub]]
+        )
+        let store = EmoteStore(apiClient: mockClient)
+
+        await store.fetchUserEmotes(userId: "123456789")
+        let emotes = await store.allEmotes()
+
+        // 検証: ユーザーエモートが取得されて allEmotes に含まれる
+        #expect(emotes.contains(where: { $0.name == "別チャンネルSub" }))
+    }
+
+    @Test("fetchUserEmotes が2ページにわたるエモートをすべて取得する")
+    func testFetchUserEmotesPagination() async {
+        // 前提: /helix/chat/emotes/user が2ページに分かれて返す
+        let page1 = [HelixEmote(id: "emotesv2_p1", name: "サブスクエモートページ1", format: ["static"], emoteType: "subscriptions")]
+        let page2 = [HelixEmote(id: "emotesv2_p2", name: "サブスクエモートページ2", format: ["static"], emoteType: "subscriptions")]
+        let mockClient = MockHelixAPIClientForEmote(stubbedUserEmotesPages: [page1, page2])
+        let store = EmoteStore(apiClient: mockClient)
+
+        await store.fetchUserEmotes(userId: "123456789")
+        let emotes = await store.allEmotes()
+
+        // 検証: 両ページのエモートがすべて取得される
+        #expect(emotes.contains(where: { $0.name == "サブスクエモートページ1" }))
+        #expect(emotes.contains(where: { $0.name == "サブスクエモートページ2" }))
+    }
+
+    @Test("未ログイン状態ではユーザーエモートフェッチをスキップする")
+    func testFetchUserEmotesSkipsWhenNotLoggedIn() async {
+        // 前提: 認証エラーが発生する状態（未ログイン）
+        let mockClient = MockHelixAPIClientForEmote(shouldThrowAuthError: true)
+        let store = EmoteStore(apiClient: mockClient)
+
+        await store.fetchUserEmotes(userId: "123456789")
+        let emotes = await store.allEmotes()
+
+        // 検証: 認証エラー時はエモートが空のまま
+        #expect(emotes.isEmpty)
+    }
+
+    @Test("userId が空文字の場合はユーザーエモートフェッチをスキップする")
+    func testFetchUserEmotesSkipsEmptyUserId() async {
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        // 空文字でクラッシュしないことを確認
+        await store.fetchUserEmotes(userId: "")
+        let emotes = await store.allEmotes()
+
+        #expect(emotes.isEmpty)
+    }
+
+    @Test("userId が数字以外を含む場合はユーザーエモートフェッチをスキップする")
+    func testFetchUserEmotesSkipsInvalidUserId() async {
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        // インジェクション防止のためのバリデーション
+        await store.fetchUserEmotes(userId: "invalid_user_id")
+        let emotes = await store.allEmotes()
+
+        #expect(emotes.isEmpty)
+    }
+
+    @Test("ユーザーエモートは1回だけフェッチされる")
+    func testUserEmotesFetchedOnce() async {
+        let counter = FetchCounter()
+        let store = EmoteStore(apiClient: CountingMockClient(counter: counter, countedEndpoint: "/emotes/user"))
+
+        // 2回呼んでも1回しかフェッチしない
+        await store.fetchUserEmotes(userId: "123456789")
+        await store.fetchUserEmotes(userId: "123456789")
+
+        #expect(counter.value == 1)
+    }
+
+    // MARK: - ユーザーエモート重複排除・優先順位
+
+    @Test("allEmotes の順序はチャンネル → ユーザー → グローバルになる")
+    func testAllEmotesOrdering() async {
+        // 前提: 3種類のエモートを設定
+        let channelEmote = HelixEmote(id: "ch_1", name: "チャンネルエモート", format: ["static"], emoteType: "subscriptions")
+        let userEmote = HelixEmote(id: "user_1", name: "他チャンネルサブスクエモート", format: ["static"], emoteType: "subscriptions")
+        let globalEmote = HelixEmote(id: "global_1", name: "グローバルエモートLUL", format: ["static"], emoteType: "globals")
+
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setChannelEmotes([channelEmote])
+        await store.setUserEmotes([userEmote])
+        await store.setGlobalEmotes([globalEmote])
+
+        let emotes = await store.allEmotes()
+
+        // 検証: チャンネル → ユーザー → グローバルの順
+        guard emotes.count == 3 else {
+            Issue.record("エモート件数が期待値と異なります: \(emotes.count)")
+            return
+        }
+        #expect(emotes[0].id == "ch_1")
+        #expect(emotes[1].id == "user_1")
+        #expect(emotes[2].id == "global_1")
+    }
+
+    @Test("allEmotes でチャンネルとユーザーエモートが同じ ID の場合は重複排除される")
+    func testAllEmotesDedupesChannelAndUserEmotes() async {
+        // 前提: チャンネルエモートとユーザーエモートで同じIDが重複する
+        let sharedEmote = HelixEmote(id: "emotesv2_shared", name: "共有エモート", format: ["static"], emoteType: "subscriptions")
+
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setChannelEmotes([sharedEmote])
+        await store.setUserEmotes([sharedEmote])
+
+        let emotes = await store.allEmotes()
+
+        // 検証: 同じIDのエモートは1件のみ
+        let duplicates = emotes.filter { $0.id == "emotesv2_shared" }
+        #expect(duplicates.count == 1)
+    }
+
+    @Test("allEmotes でグローバルとユーザーエモートが同じ ID の場合は重複排除される")
+    func testAllEmotesDedupesGlobalAndUserEmotes() async {
+        // 前提: ユーザーエモートAPIがグローバルエモートも返す場合
+        let globalEmote = HelixEmote(id: "425618", name: "LUL", format: ["static"], emoteType: "globals")
+
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([globalEmote])
+        await store.setUserEmotes([globalEmote])
+
+        let emotes = await store.allEmotes()
+
+        // 検証: 同じIDのグローバルエモートは1件のみ
+        let duplicates = emotes.filter { $0.id == "425618" }
+        #expect(duplicates.count == 1)
+    }
+
+    // MARK: - ユーザーエモート名前逆引き
+
+    @Test("emote(byName:) でユーザーエモートを名前で検索できる")
+    func testEmoteByNameFindsUserEmote() async {
+        // 前提: ユーザーエモートのみ設定
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
+
+        let found = await store.emote(byName: "別チャンネルSub")
+
+        // 検証: ユーザーエモートが名前で検索できる
+        #expect(found?.id == "emotesv2_user_sub")
+    }
+
+    @Test("emote(byName:) でチャンネルエモートはユーザーエモートより優先される")
+    func testEmoteByNamePrefersChannelOverUserEmote() async {
+        // 前提: 同名のエモートがチャンネルとユーザー両方に存在
+        let channelEmote = HelixEmote(id: "channel_id", name: "重複エモート", format: ["static"], emoteType: "subscriptions")
+        let userEmote = HelixEmote(id: "user_id", name: "重複エモート", format: ["static"], emoteType: "subscriptions")
+
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setChannelEmotes([channelEmote])
+        await store.setUserEmotes([userEmote])
+
+        let found = await store.emote(byName: "重複エモート")
+
+        // 検証: チャンネルエモートが優先される
+        #expect(found?.id == "channel_id")
+    }
+
+    // MARK: - ユーザーエモートリセット
+
+    @Test("resetUserEmotes でユーザーエモートがクリアされる")
+    func testResetUserEmotes() async {
+        // 前提: ユーザーエモートを設定した後リセット
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
+
+        await store.resetUserEmotes()
+        let emotes = await store.allEmotes()
+
+        // 検証: リセット後はユーザーエモートが消える
+        #expect(emotes.isEmpty)
+    }
+
+    @Test("resetUserEmotes 後に fetchUserEmotes を呼ぶと再取得できる")
+    func testFetchUserEmotesAfterReset() async {
+        // 前提: フェッチ → リセット → 再フェッチの流れ
+        let mockClient = MockHelixAPIClientForEmote(
+            stubbedUserEmotesPages: [[.ユーザーエモートBits]]
+        )
+        let store = EmoteStore(apiClient: mockClient)
+
+        await store.fetchUserEmotes(userId: "123456789")
+        await store.resetUserEmotes()
+
+        // リセット後は再フェッチ可能
+        await store.fetchUserEmotes(userId: "123456789")
+        let emotes = await store.allEmotes()
+
+        #expect(emotes.contains(where: { $0.name == "ビッツ応援エモート" }))
+    }
+
+    // MARK: - userEmoteIdSet
+
+    @Test("userEmoteIdSet はユーザーエモートのIDセットを返す")
+    func testUserEmoteIdSet() async {
+        // 前提: 複数のユーザーエモートを設定
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub, .ユーザーエモートBits])
+
+        let ids = await store.userEmoteIdSet()
+
+        // 検証: 設定したエモートのIDセットが返る
+        #expect(ids == Set(["emotesv2_user_sub", "emotesv2_bits_test"]))
+    }
+
+    @Test("userEmoteIdSet はユーザーエモートが空の場合に空セットを返す")
+    func testUserEmoteIdSetEmpty() async {
+        // 前提: ユーザーエモート未設定
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        let ids = await store.userEmoteIdSet()
+
+        #expect(ids.isEmpty)
     }
 }

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -7,9 +7,13 @@ import Testing
 
 // MARK: - テスト用モック
 
-/// フェッチ回数を Sendable なクラスで安全に計測するカウンター
-final class FetchCounter: @unchecked Sendable {
-    var value = 0
+/// フェッチ回数をデータレースなく計測するカウンター
+actor FetchCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
 }
 
 /// 特定エンドポイントへのフェッチ回数をカウントするモッククライアント
@@ -23,7 +27,7 @@ struct CountingMockClient: HelixAPIClientProtocol {
 
     func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
         if url.absoluteString.contains(countedEndpoint) {
-            counter.value += 1
+            await counter.increment()
         }
         if url.absoluteString.contains("/emotes/user") {
             if let response = HelixUserEmotesResponse(data: [], cursor: nil) as? T {
@@ -241,7 +245,7 @@ struct EmoteStoreTests {
         await store.fetchGlobalEmotes()
         await store.fetchGlobalEmotes()
 
-        #expect(counter.value == 1)
+        #expect(await counter.value == 1)
     }
 
     // MARK: - エモート名逆引き
@@ -475,7 +479,7 @@ struct EmoteStoreTests {
         await store.fetchUserEmotes(userId: "123456789")
         await store.fetchUserEmotes(userId: "123456789")
 
-        #expect(counter.value == 1)
+        #expect(await counter.value == 1)
     }
 
     // MARK: - ユーザーエモート重複排除・優先順位

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -622,4 +622,44 @@ struct EmoteStoreTests {
 
         #expect(ids.isEmpty)
     }
+
+    // MARK: - userEmotesSnapshot
+
+    @Test("userEmotesSnapshot はユーザーエモートが未設定の場合に空配列を返す")
+    func testUserEmotesSnapshotEmpty() async {
+        // 前提: ユーザーエモートが設定されていない
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        let snapshot = await store.userEmotesSnapshot()
+
+        // 検証: ユーザーエモート未設定のため空配列
+        #expect(snapshot.isEmpty)
+    }
+
+    @Test("userEmotesSnapshot は現在のユーザーエモート一覧を返す")
+    func testUserEmotesSnapshotReturnsCurrentEmotes() async {
+        // 前提: ユーザーエモートを直接設定済み
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub, .ユーザーエモートBits])
+
+        let snapshot = await store.userEmotesSnapshot()
+
+        // 検証: 設定したユーザーエモートが全件返る
+        #expect(snapshot.count == 2)
+        #expect(snapshot.contains(where: { $0.id == HelixEmote.ユーザーエモート別チャンネルSub.id }))
+        #expect(snapshot.contains(where: { $0.id == HelixEmote.ユーザーエモートBits.id }))
+    }
+
+    @Test("userEmotesSnapshot は resetUserEmotes 後に空配列を返す")
+    func testUserEmotesSnapshotAfterReset() async {
+        // 前提: ユーザーエモートを設定してからリセット
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
+        await store.resetUserEmotes()
+
+        let snapshot = await store.userEmotesSnapshot()
+
+        // 検証: リセット後はスナップショットが空
+        #expect(snapshot.isEmpty)
+    }
 }

--- a/Tests/TwitchChatTests/TwitchIRCClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchIRCClientTests.swift
@@ -571,8 +571,8 @@ struct TwitchIRCClientTests {
             try await client.connect(to: "配信者EEE", accessToken: nil, userLogin: nil)
         }
 
-        // PING が 2 回以上送信されるまで待機（最大 2 秒、並行テスト実行時の遅延を許容）
-        let waitSucceeded = await waitFor(timeout: 2.0) {
+        // PING が 2 回以上送信されるまで待機（最大 10 秒、CI の並行テスト実行時の Task.sleep オーバーシュートを許容）
+        let waitSucceeded = await waitFor(timeout: 10.0) {
             let sent = await mockWS.sentMessages
             return sent.filter { $0 == "PING :tmi.twitch.tv" }.count >= 2
         }


### PR DESCRIPTION
## Summary

- `ChannelManager` にプリロード専用 `EmoteStore` (`preloadEmoteStore`) を追加し、ログイン時・アプリ起動時に `GET /helix/chat/emotes/user` を事前取得する
- `TwitchChatApp` の `.loggedIn` 遷移・セッション復元後に `channelManager.preloadUserEmotes()` を呼び出し、フォロー中チャンネル取得と並行実行する
- `joinChannel` でプリロード済みユーザーエモートを新しい `ChatViewModel` のエモートストアへシードすることで、USERSTATE 到着前からエモートピッカーが即座に使用可能になる
- `EmoteStore.userEmotesSnapshot()` を追加、`setUserEmotes()` を公開メソッドに昇格（ChannelManager のシード処理で使用）
- `BadgeStore` / `EmoteStore` の `fetchGlobal` / `fetchChannel` に `HelixAPIError.unauthorized` キャッチを追加（テスト中の assertionFailure クラッシュを修正）

## Test plan

- [x] `EmoteStoreTests` - `userEmotesSnapshot()` の 3 ケース（空・設定済み・リセット後）
- [x] `ChannelManagerTests` - `joinChannel` でプリロード済みエモートがシードされるケース・シードなしケース
- [x] `swift build` でビルド成功確認
- [x] `swift test` で全テスト通過（TwitchIRCClient のタイミング依存テストは元々フレーキー）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `ChannelManager.swift` | `preloadEmoteStore`, `preloadUserEmotes()`, `joinChannel` シード, `disconnectAll` リセット |
| `TwitchChatApp.swift` | `loggedIn` / `restoreSession` 後に `preloadUserEmotes()` を呼び出す |
| `EmoteStore.swift` | `userEmotesSnapshot()` 追加, `setUserEmotes` 公開化, `unauthorized` キャッチ追加 |
| `BadgeStore.swift` | `fetchGlobal` / `fetchChannel` に `unauthorized` キャッチ追加 |
| `ChannelManagerTests.swift` | プリロードシードのテスト追加 |
| `EmoteStoreTests.swift` | `userEmotesSnapshot` テスト追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)