### PR TITLE
feat: エモートピッカーをチャンネルごとのセクション表示に刷新する

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -38,8 +38,11 @@ struct TwitchChatApp: App {
                     await authState.restoreSession()
                     if case .loggedIn = authState.status {
                         followedStreamStore.startAutoRefresh()
-                        // フォロー中全チャンネルとユーザーエモートを並行で事前取得する
-                        Task { await channelManager.preloadUserEmotes() }
+                        // ユーザーエモートをプリロードし、完了後に ownerId の表示名を事前キャッシュする
+                        Task {
+                            await channelManager.preloadUserEmotes()
+                            await channelManager.preloadEmoteOwnerDisplayNames(using: profileImageStore)
+                        }
                         await followedChannelStore.fetchAll()
                     }
                 }
@@ -47,7 +50,10 @@ struct TwitchChatApp: App {
                     switch newStatus {
                     case .loggedIn:
                         followedStreamStore.startAutoRefresh()
-                        Task { await channelManager.preloadUserEmotes() }
+                        Task {
+                            await channelManager.preloadUserEmotes()
+                            await channelManager.preloadEmoteOwnerDisplayNames(using: profileImageStore)
+                        }
                         Task { await followedChannelStore.fetchAll() }
                     case .loggedOut:
                         followedStreamStore.stopAutoRefresh()

--- a/Sources/TwitchChat/Models/EmotePickerSection.swift
+++ b/Sources/TwitchChat/Models/EmotePickerSection.swift
@@ -10,8 +10,7 @@ import Foundation
 /// - `currentChannel`: 現在視聴中のチャンネルのエモート
 /// - `subscribedChannel`: 購読中の他チャンネルのエモート（ビッツエモートを含む）
 /// - `hypeTrain`: ハイプトレインエモート（チャンネル横断の HYPE 枠）
-/// - `other`: ownerId を持たないその他の特殊エモート（リワード・プライム等）
-/// - `global`: Twitch グローバルエモート
+/// - `global`: Twitch グローバルエモート（ownerId なし特殊エモートを含む）
 struct EmotePickerSection: Identifiable, Equatable, Sendable {
 
     // MARK: - セクション種別
@@ -24,9 +23,7 @@ struct EmotePickerSection: Identifiable, Equatable, Sendable {
         case subscribedChannel(ownerId: String)
         /// ハイプトレインエモート（チャンネル横断の HYPE 枠）
         case hypeTrain
-        /// ownerId を持たないその他の特殊エモート（リワード・プライム・ターボ等）
-        case other
-        /// Twitch グローバルエモート
+        /// Twitch グローバルエモート（リワード・プライム等の ownerId なしエモートを含む）
         case global
     }
 
@@ -37,7 +34,6 @@ struct EmotePickerSection: Identifiable, Equatable, Sendable {
     /// - `currentChannel`: "current"
     /// - `subscribedChannel(ownerId)`: "channel-{ownerId}"
     /// - `hypeTrain`: "hype"
-    /// - `other`: "other"
     /// - `global`: "global"
     let id: String
 

--- a/Sources/TwitchChat/Models/EmotePickerSection.swift
+++ b/Sources/TwitchChat/Models/EmotePickerSection.swift
@@ -1,0 +1,58 @@
+// EmotePickerSection.swift
+// エモートピッカーのセクション定義モデル
+// エモートをチャンネルごとに分類してピッカーのセクション表示に使用する
+
+import Foundation
+
+/// エモートピッカーのセクション
+///
+/// エモートをチャンネルごとに分類して表示するためのモデル。
+/// - `currentChannel`: 現在視聴中のチャンネルのエモート
+/// - `subscribedChannel`: 購読中の他チャンネルのエモート（ビッツエモートを含む）
+/// - `hypeTrain`: ハイプトレインエモート（チャンネル横断の HYPE 枠）
+/// - `other`: ownerId を持たないその他の特殊エモート（リワード・プライム等）
+/// - `global`: Twitch グローバルエモート
+struct EmotePickerSection: Identifiable, Equatable, Sendable {
+
+    // MARK: - セクション種別
+
+    /// セクションの種別
+    enum Kind: Equatable, Sendable {
+        /// 現在視聴中のチャンネル
+        case currentChannel
+        /// 購読中の他チャンネル（ビッツエモートを含む）
+        case subscribedChannel(ownerId: String)
+        /// ハイプトレインエモート（チャンネル横断の HYPE 枠）
+        case hypeTrain
+        /// ownerId を持たないその他の特殊エモート（リワード・プライム・ターボ等）
+        case other
+        /// Twitch グローバルエモート
+        case global
+    }
+
+    // MARK: - プロパティ
+
+    /// セクションの一意識別子
+    ///
+    /// - `currentChannel`: "current"
+    /// - `subscribedChannel(ownerId)`: "channel-{ownerId}"
+    /// - `hypeTrain`: "hype"
+    /// - `other`: "other"
+    /// - `global`: "global"
+    let id: String
+
+    /// セクションの種別
+    let kind: Kind
+
+    /// セクションヘッダーに表示するタイトル
+    let title: String
+
+    /// セクションヘッダーのアイコン取得に使用する Twitch ユーザー ID
+    ///
+    /// `ProfileImageStore.profileImageUrl(for:)` に渡してチャンネルアイコンを取得する。
+    /// グローバル・ハイプトレイン・その他セクションは `nil`。
+    let iconUserId: String?
+
+    /// このセクションに含まれるエモート一覧
+    let emotes: [HelixEmote]
+}

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -75,6 +75,9 @@ actor BadgeStore {
                 self.isGlobalLoaded = true
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
+            } catch let error as URLError where error.code == .cancelled {
+                // タスクキャンセル（アプリ終了・再接続時）は正常系なのでスキップ
+                _ = error
             } catch HelixAPIError.unauthorized {
                 // Helix API が 401 を返した場合（トークン失効等）は次回接続時に再取得する
             } catch is AuthConfigError {

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -336,6 +336,24 @@ actor EmoteStore {
         userEmotes
     }
 
+    /// 現在のチャンネルエモート一覧のスナップショットを返す
+    ///
+    /// `EmotePickerViewModel` がセクション分けされたエモート一覧を構築する際に使用する。
+    ///
+    /// - Returns: 現在のチャンネルエモート一覧（未ロードの場合は空配列）
+    func channelEmotesSnapshot() -> [HelixEmote] {
+        channelEmotes
+    }
+
+    /// 現在のグローバルエモート一覧のスナップショットを返す
+    ///
+    /// `EmotePickerViewModel` がセクション分けされたエモート一覧を構築する際に使用する。
+    ///
+    /// - Returns: 現在のグローバルエモート一覧（未ロードの場合は空配列）
+    func globalEmotesSnapshot() -> [HelixEmote] {
+        globalEmotes
+    }
+
     /// ユーザーが使用可能なエモートセット ID を更新する
     ///
     /// USERSTATE の `emote-sets` タグを受信するたびに呼び出す。

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -480,5 +480,10 @@ actor EmoteStore {
     func setUserEmoteSets(_ sets: Set<String>) {
         userEmoteSets = sets
     }
+
+    /// エモートセット更新通知をテストから手動発火する（テスト用）
+    func notifyUserEmoteSetsUpdatedForTest() {
+        notifyUserEmoteSetsUpdated()
+    }
 #endif
 }

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -124,16 +124,23 @@ final class ProfileImageStore {
         // fetchedUserIds でフェッチ済み（URL が nil のユーザーを含む）を除外し、
         // @MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ
         let newUserIds = userIds.filter { !fetchedUserIds.contains($0) && !inFlightUserIds.contains($0) }
-        guard !newUserIds.isEmpty else { return }
 
-        // フェッチ中フラグを設定し、完了後に必ず解除する
-        inFlightUserIds.formUnion(newUserIds)
-        defer { inFlightUserIds.subtract(newUserIds) }
+        if !newUserIds.isEmpty {
+            // フェッチ中フラグを設定し、完了後に必ず解除する
+            inFlightUserIds.formUnion(newUserIds)
+            defer { inFlightUserIds.subtract(newUserIds) }
 
-        // Helix API の100件制限に合わせてチャンク分割してリクエスト
-        let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
-        for chunk in chunks {
-            await fetchChunk(userIds: chunk)
+            // Helix API の100件制限に合わせてチャンク分割してリクエスト
+            let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
+            for chunk in chunks {
+                await fetchChunk(userIds: chunk)
+            }
+        }
+
+        // 並行タスクがフェッチ中の ID がある場合はそれらの完了を待つ
+        // これにより呼び出し元は fetchUsers 返却後に確実に displayName を参照できる
+        while userIds.contains(where: { inFlightUserIds.contains($0) }) {
+            await Task.yield()
         }
     }
 

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -36,6 +36,9 @@ final class ProfileImageStore {
     /// userId → displayName のキャッシュ（エモートピッカーのセクションヘッダーに使用）
     private var displayNames: [String: String] = [:]
 
+    /// userId → login のキャッシュ（displayName のフォールバック表示に使用）
+    private var userLogins: [String: String] = [:]
+
     /// login → userId のマッピング（userId フェッチ時にもログイン名から参照できるよう記録する）
     private var loginToUserId: [String: String] = [:]
 
@@ -103,6 +106,14 @@ final class ProfileImageStore {
         displayNames[userId]
     }
 
+    /// 指定ユーザーIDのログイン名（login）を取得する
+    ///
+    /// - Parameter userId: Twitch ユーザーID
+    /// - Returns: ログイン名（未取得またはユーザーが存在しない場合は `nil`）
+    func login(for userId: String) -> String? {
+        userLogins[userId]
+    }
+
     /// 複数ユーザーのプロフィール画像URLを一括取得する
     ///
     /// - Parameter userIds: 取得対象の Twitch ユーザーID 一覧
@@ -151,6 +162,7 @@ final class ProfileImageStore {
     func clear() {
         profileImageUrls = [:]
         displayNames = [:]
+        userLogins = [:]
         loginToUserId = [:]
         fetchedUserIds = []
         fetchedLogins = []
@@ -197,6 +209,7 @@ final class ProfileImageStore {
                 fetchedLogins.insert(userData.login.lowercased())
                 // login → userId の対応を記録してログイン名から参照できるようにする
                 loginToUserId[userData.login.lowercased()] = userData.id
+                userLogins[userData.id] = userData.login
                 displayNames[userData.id] = userData.displayName
                 if let url = userData.profileImageUrl {
                     profileImageUrls[userData.id] = url

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -207,6 +207,8 @@ final class ProfileImageStore {
             // キャッシュ上限超過時は全消去してメモリ増大を防ぐ
             if profileImageUrls.count + response.data.count > Self.maxCacheEntries {
                 profileImageUrls.removeAll()
+                displayNames.removeAll()
+                userLogins.removeAll()
                 fetchedUserIds.removeAll()
                 fetchedLogins.removeAll()
                 loginToUserId.removeAll()

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -33,6 +33,9 @@ final class ProfileImageStore {
     /// userId → profileImageUrl のキャッシュ
     private var profileImageUrls: [String: URL] = [:]
 
+    /// userId → displayName のキャッシュ（エモートピッカーのセクションヘッダーに使用）
+    private var displayNames: [String: String] = [:]
+
     /// login → userId のマッピング（userId フェッチ時にもログイン名から参照できるよう記録する）
     private var loginToUserId: [String: String] = [:]
 
@@ -92,6 +95,14 @@ final class ProfileImageStore {
         loginToUserId[login.lowercased()]
     }
 
+    /// 指定ユーザーIDの表示名（display_name）を取得する
+    ///
+    /// - Parameter userId: Twitch ユーザーID
+    /// - Returns: 表示名（未取得またはユーザーが存在しない場合は `nil`）
+    func displayName(for userId: String) -> String? {
+        displayNames[userId]
+    }
+
     /// 複数ユーザーのプロフィール画像URLを一括取得する
     ///
     /// - Parameter userIds: 取得対象の Twitch ユーザーID 一覧
@@ -139,6 +150,7 @@ final class ProfileImageStore {
     /// ログアウト時など、データを消去したい場合に使用する
     func clear() {
         profileImageUrls = [:]
+        displayNames = [:]
         loginToUserId = [:]
         fetchedUserIds = []
         fetchedLogins = []
@@ -185,6 +197,7 @@ final class ProfileImageStore {
                 fetchedLogins.insert(userData.login.lowercased())
                 // login → userId の対応を記録してログイン名から参照できるようにする
                 loginToUserId[userData.login.lowercased()] = userData.id
+                displayNames[userData.id] = userData.displayName
                 if let url = userData.profileImageUrl {
                     profileImageUrls[userData.id] = url
                 }

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -113,6 +113,21 @@ final class ChannelManager {
         await preloadEmoteStore.fetchUserEmotes(userId: userId)
     }
 
+    /// プリロード済みユーザーエモートの ownerId に対応する表示名を ProfileImageStore に事前キャッシュする
+    ///
+    /// `preloadUserEmotes()` 完了後に呼ぶことで、エモートピッカーを開いた時点で
+    /// チャンネル表示名がキャッシュ済みになり、数字IDが表示されるのを防ぐ。
+    /// ownerId が nil または "0" のエモートはスキップする。
+    func preloadEmoteOwnerDisplayNames(using profileImageStore: ProfileImageStore) async {
+        let userEmotes = await preloadEmoteStore.userEmotesSnapshot()
+        var ids = Set<String>()
+        for emote in userEmotes {
+            if let ownerId = emote.ownerId, ownerId != "0" { ids.insert(ownerId) }
+        }
+        guard !ids.isEmpty else { return }
+        await profileImageStore.fetchUsers(userIds: Array(ids))
+    }
+
     /// 指定チャンネルに参加する
     ///
     /// - 未接続の場合: 新しい `ChatViewModel` を作成して接続開始し、選択状態にする

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -122,7 +122,7 @@ final class ChannelManager {
         let userEmotes = await preloadEmoteStore.userEmotesSnapshot()
         var ids = Set<String>()
         for emote in userEmotes {
-            if let ownerId = emote.ownerId, ownerId != "0" { ids.insert(ownerId) }
+            if let ownerId = emote.ownerId, ownerId != "0", !ownerId.isEmpty { ids.insert(ownerId) }
         }
         guard !ids.isEmpty else { return }
         await profileImageStore.fetchUsers(userIds: Array(ids))

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -245,9 +245,9 @@ final class EmotePickerViewModel {
 
     /// 分類済みエモートから EmotePickerSection 配列を組み立てる（空セクションは除外）
     ///
-    /// `fetchUsers()` 完了後に呼ぶことで `displayName` が確定した状態で判定できる。
-    /// displayName が取得できない ownerId（API が返さないサービスアカウント等）のエモートは
-    /// 数字 ID のセクションを作らず global セクションにまとめる。
+    /// セクションタイトルは `displayName ?? login ?? ownerId` の優先順位で決定する。
+    /// displayName / login が未取得の場合は ownerId を仮タイトルとして使い、
+    /// @Observable による自動更新でヘッダーが正しい名前に更新される。
     private func assembleSections(
         classified: (currentChannel: [HelixEmote], hype: [HelixEmote],
                      subscribedOwnerIds: [String], subscribedByOwnerId: [String: [HelixEmote]],
@@ -256,8 +256,6 @@ final class EmotePickerViewModel {
         seen: inout Set<String>
     ) -> [EmotePickerSection] {
         var sections: [EmotePickerSection] = []
-        // displayName が未取得の ownerId のエモートを一時的にここに集めて global に送る
-        var unnamedOwnerEmotes: [HelixEmote] = []
 
         if !classified.currentChannel.isEmpty {
             sections.append(EmotePickerSection(
@@ -268,15 +266,14 @@ final class EmotePickerViewModel {
         for ownerId in classified.subscribedOwnerIds {
             let emotes = classified.subscribedByOwnerId[ownerId] ?? []
             guard !emotes.isEmpty else { continue }
-            guard let name = profileImageStore.displayName(for: ownerId) else {
-                // displayName 未取得（サービスアカウント等で API がユーザーを返さない）→ global へ
-                for emote in emotes { seen.remove(emote.id) }
-                unnamedOwnerEmotes.append(contentsOf: emotes)
-                continue
-            }
+            // displayName → login → ownerId の順でタイトルを決定する
+            // displayName / login が未取得でも subscribedChannel セクションは作成し @Observable で後から更新する
+            let title = profileImageStore.displayName(for: ownerId)
+                ?? profileImageStore.login(for: ownerId)
+                ?? ownerId
             sections.append(EmotePickerSection(
                 id: "channel-\(ownerId)", kind: .subscribedChannel(ownerId: ownerId),
-                title: name, iconUserId: ownerId, emotes: emotes
+                title: title, iconUserId: ownerId, emotes: emotes
             ))
         }
         if !classified.hype.isEmpty {
@@ -284,8 +281,8 @@ final class EmotePickerViewModel {
                 id: "hype", kind: .hypeTrain, title: "HYPE", iconUserId: nil, emotes: classified.hype
             ))
         }
-        // ownerId なし / 空文字 / displayName 未取得エモートは global セクションにまとめて末尾に配置する
-        let globalEmotes = (unnamedOwnerEmotes + classified.other + global).filter { seen.insert($0.id).inserted }
+        // ownerId なし / 空文字エモートは global セクションにまとめて末尾に配置する
+        let globalEmotes = (classified.other + global).filter { seen.insert($0.id).inserted }
         if !globalEmotes.isEmpty {
             sections.append(EmotePickerSection(
                 id: "global", kind: .global, title: "グローバル", iconUserId: nil, emotes: globalEmotes

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -53,6 +53,15 @@ final class EmotePickerViewModel {
     /// このセットに含まれるエモートは USERSTATE の emoteSetId チェックによらず常に使用可能。
     private var userEmoteIds: Set<String> = []
 
+    /// 最後にセクションを構築したときのチャンネルエモート ID セット
+    ///
+    /// `observeUserEmoteSetsUpdates()` がエモートデータの変化を検知するために使用する。
+    /// USERSTATE のみの更新ではセクションを再構築しない最適化に使う。
+    private var lastBuiltChannelIds: Set<String> = []
+
+    /// 最後にセクションを構築したときのユーザーエモート ID セット
+    private var lastBuiltUserIds: Set<String> = []
+
     // MARK: - 初期化
 
     /// EmotePickerViewModel を初期化する
@@ -83,16 +92,35 @@ final class EmotePickerViewModel {
         await refreshSections()
     }
 
-    /// ピッカー表示中にエモートセットや USERSTATE が更新された場合にセクションをリアルタイムで再構築する
+    /// ピッカー表示中にエモートセット更新を監視し、変化に応じてセクションを更新する
     ///
-    /// View の `.task` モディファイアから呼び出す。View が消えると `.task` が
-    /// このメソッドのタスクをキャンセルし、`waitForNextUserEmoteSetsUpdate` が
-    /// resume されてループを抜けるため、Continuation リークは発生しない。
+    /// エモートデータ（チャンネル・ユーザーエモート）が変化した場合のみセクションを再構築する。
+    /// USERSTATE のみの更新（emote-sets 変化）はセクション再構築をスキップし、
+    /// 使用可否の再計算と再フィルタのみを行う。
+    /// これにより loadEmotes() との並行実行による表示名消失レースを防ぐ。
     func observeUserEmoteSetsUpdates() async {
         while !Task.isCancelled {
             await emoteStore.waitForNextUserEmoteSetsUpdate()
             guard !Task.isCancelled else { break }
-            await refreshSections()
+
+            userEmoteSets = await emoteStore.userAvailableEmoteSets()
+            userEmoteIds  = await emoteStore.userEmoteIdSet()
+
+            // エモートデータが変化した場合のみセクションを再構築する（USERSTATE のみの変化はスキップ）
+            let channel    = await emoteStore.channelEmotesSnapshot()
+            let user       = await emoteStore.userEmotesSnapshot()
+            let channelIds = Set(channel.map(\.id))
+            let userIds    = Set(user.map(\.id))
+
+            if channelIds != lastBuiltChannelIds || userIds != lastBuiltUserIds {
+                let global = await emoteStore.globalEmotesSnapshot()
+                await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
+                lastBuiltChannelIds = channelIds
+                lastBuiltUserIds    = userIds
+                allSections = buildSections(channel: channel, user: user, global: global)
+            }
+
+            applyFilter()
         }
     }
 
@@ -127,6 +155,8 @@ final class EmotePickerViewModel {
         userEmoteSets = await emoteStore.userAvailableEmoteSets()
         userEmoteIds  = await emoteStore.userEmoteIdSet()
         await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
+        lastBuiltChannelIds = Set(channel.map(\.id))
+        lastBuiltUserIds    = Set(user.map(\.id))
         allSections = buildSections(channel: channel, user: user, global: global)
         applyFilter()
     }

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -195,6 +195,9 @@ final class EmotePickerViewModel {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
             } else {
+                // ownerId なしエモートは global セクションで処理するため seen から除外する
+                // （assembleSections で global スナップショットと合算して dedup する）
+                seen.remove(emote.id)
                 otherEmotes.append(emote)
             }
         }
@@ -231,12 +234,8 @@ final class EmotePickerViewModel {
                 id: "hype", kind: .hypeTrain, title: "HYPE", iconUserId: nil, emotes: classified.hype
             ))
         }
-        if !classified.other.isEmpty {
-            sections.append(EmotePickerSection(
-                id: "other", kind: .other, title: "その他", iconUserId: nil, emotes: classified.other
-            ))
-        }
-        let globalEmotes = global.filter { seen.insert($0.id).inserted }
+        // ownerId なし特殊エモート（リワード・プライム等）は global セクションにまとめて常に末尾に配置する
+        let globalEmotes = (classified.other + global).filter { seen.insert($0.id).inserted }
         if !globalEmotes.isEmpty {
             sections.append(EmotePickerSection(
                 id: "global", kind: .global, title: "グローバル", iconUserId: nil, emotes: globalEmotes

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -168,7 +168,7 @@ final class EmotePickerViewModel {
         var ids = Set<String>()
         if let id = currentBroadcasterId { ids.insert(id) }
         for emote in channel + user {
-            if let ownerId = emote.ownerId, ownerId != "0" { ids.insert(ownerId) }
+            if let ownerId = emote.ownerId, ownerId != "0", !ownerId.isEmpty { ids.insert(ownerId) }
         }
         return Array(ids)
     }
@@ -231,11 +231,11 @@ final class EmotePickerViewModel {
                 otherEmotes.append(emote)
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
                 currentChannelEmotes.append(emote)
-            } else if let ownerId = emote.ownerId, ownerId != "0" {
+            } else if let ownerId = emote.ownerId, ownerId != "0", !ownerId.isEmpty {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
             } else {
-                // ownerId なし / "0" エモートは global セクションで処理するため seen から除外する
+                // ownerId なし / "0" / 空文字エモートは global セクションで処理するため seen から除外する
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
             }
@@ -244,6 +244,10 @@ final class EmotePickerViewModel {
     }
 
     /// 分類済みエモートから EmotePickerSection 配列を組み立てる（空セクションは除外）
+    ///
+    /// `fetchUsers()` 完了後に呼ぶことで `displayName` が確定した状態で判定できる。
+    /// displayName が取得できない ownerId（API が返さないサービスアカウント等）のエモートは
+    /// 数字 ID のセクションを作らず global セクションにまとめる。
     private func assembleSections(
         classified: (currentChannel: [HelixEmote], hype: [HelixEmote],
                      subscribedOwnerIds: [String], subscribedByOwnerId: [String: [HelixEmote]],
@@ -252,6 +256,8 @@ final class EmotePickerViewModel {
         seen: inout Set<String>
     ) -> [EmotePickerSection] {
         var sections: [EmotePickerSection] = []
+        // displayName が未取得の ownerId のエモートを一時的にここに集めて global に送る
+        var unnamedOwnerEmotes: [HelixEmote] = []
 
         if !classified.currentChannel.isEmpty {
             sections.append(EmotePickerSection(
@@ -262,10 +268,15 @@ final class EmotePickerViewModel {
         for ownerId in classified.subscribedOwnerIds {
             let emotes = classified.subscribedByOwnerId[ownerId] ?? []
             guard !emotes.isEmpty else { continue }
+            guard let name = profileImageStore.displayName(for: ownerId) else {
+                // displayName 未取得（サービスアカウント等で API がユーザーを返さない）→ global へ
+                for emote in emotes { seen.remove(emote.id) }
+                unnamedOwnerEmotes.append(contentsOf: emotes)
+                continue
+            }
             sections.append(EmotePickerSection(
                 id: "channel-\(ownerId)", kind: .subscribedChannel(ownerId: ownerId),
-                title: profileImageStore.displayName(for: ownerId) ?? ownerId,
-                iconUserId: ownerId, emotes: emotes
+                title: name, iconUserId: ownerId, emotes: emotes
             ))
         }
         if !classified.hype.isEmpty {
@@ -273,8 +284,8 @@ final class EmotePickerViewModel {
                 id: "hype", kind: .hypeTrain, title: "HYPE", iconUserId: nil, emotes: classified.hype
             ))
         }
-        // ownerId なし特殊エモート（リワード・プライム等）は global セクションにまとめて常に末尾に配置する
-        let globalEmotes = (classified.other + global).filter { seen.insert($0.id).inserted }
+        // ownerId なし / 空文字 / displayName 未取得エモートは global セクションにまとめて末尾に配置する
+        let globalEmotes = (unnamedOwnerEmotes + classified.other + global).filter { seen.insert($0.id).inserted }
         if !globalEmotes.isEmpty {
             sections.append(EmotePickerSection(
                 id: "global", kind: .global, title: "グローバル", iconUserId: nil, emotes: globalEmotes

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -1,23 +1,24 @@
 // EmotePickerViewModel.swift
 // エモートピッカー用 ViewModel
-// EmoteStore からエモート一覧を取得し、検索クエリに応じてフィルタリングする
+// EmoteStore からエモート一覧を取得し、チャンネルごとのセクションに分類してフィルタリングする
 
 import Foundation
 import Observation
 
 /// エモートピッカー用 ViewModel
 ///
-/// - `loadEmotes()` 呼び出しで EmoteStore から全エモートを取得する
-/// - `searchQuery` を変更すると即座に `filteredEmotes` がフィルタリングされる
-/// - フィルタリングは大文字小文字非区別の部分一致
+/// - `loadEmotes()` 呼び出しで EmoteStore から全エモートを取得し、チャンネルごとにセクション分けする
+/// - `searchQuery` を変更すると即座に `filteredSections` がフィルタリングされる
+/// - フィルタリングは大文字小文字非区別の部分一致（全セクションを横断）
+/// - セクション順: このチャンネル → 購読中の他チャンネル（API 取得順）→ HYPE → その他 → グローバル
 @Observable
 @MainActor
 final class EmotePickerViewModel {
 
     // MARK: - 公開プロパティ
 
-    /// フィルタリング済みエモート一覧（UI へのバインディング用）
-    private(set) var filteredEmotes: [HelixEmote] = []
+    /// フィルタリング済みセクション一覧（UI へのバインディング用）
+    private(set) var filteredSections: [EmotePickerSection] = []
 
     /// 検索クエリ（空文字の場合は全件表示）
     var searchQuery: String = "" {
@@ -29,15 +30,20 @@ final class EmotePickerViewModel {
 
     // MARK: - プライベートプロパティ
 
-    /// フィルタ前の全エモート一覧
-    private var allEmotes: [HelixEmote] = []
+    /// フィルタ前の全セクション一覧
+    private var allSections: [EmotePickerSection] = []
 
     /// エモート定義ストア
     private let emoteStore: EmoteStore
 
+    /// プロフィール画像・表示名ストア（セクションヘッダー用）
+    private let profileImageStore: ProfileImageStore
+
+    /// 現在視聴中のチャンネルの broadcaster_id
+    private let currentBroadcasterId: String?
+
     /// ユーザーが使用可能なエモートセット ID のスナップショット
     ///
-    /// `loadEmotes()` 呼び出し時に EmoteStore からスナップショットを取得する。
     /// - `nil`: USERSTATE 未受信（全エモートを使用可能として扱う）
     /// - 空 `Set`: USERSTATE 受信済みだが使用可能セットが空
     private var userEmoteSets: Set<String>?
@@ -51,24 +57,50 @@ final class EmotePickerViewModel {
 
     /// EmotePickerViewModel を初期化する
     ///
-    /// - Parameter emoteStore: エモート定義ストア
-    init(emoteStore: EmoteStore) {
+    /// - Parameters:
+    ///   - emoteStore: エモート定義ストア
+    ///   - profileImageStore: プロフィール画像・表示名ストア
+    ///   - currentBroadcasterId: 現在視聴中のチャンネルの broadcaster_id（未接続時は nil）
+    init(
+        emoteStore: EmoteStore,
+        profileImageStore: ProfileImageStore,
+        currentBroadcasterId: String?
+    ) {
         self.emoteStore = emoteStore
+        self.profileImageStore = profileImageStore
+        self.currentBroadcasterId = currentBroadcasterId
     }
 
     // MARK: - 公開メソッド
 
-    /// EmoteStore から全エモートを取得してフィルタを適用する
+    /// EmoteStore から全エモートを取得してセクションに分類し、フィルタを適用する
     ///
     /// グローバルエモートのフェッチを待ってからスナップショットを取得することで、
     /// 接続直後にピッカーを開いても「エモートが見つかりません」にならないようにする。
     /// ピッカーが表示されるタイミング（.task モディファイア）で呼び出す。
     func loadEmotes() async {
         await emoteStore.fetchGlobalEmotes()
-        allEmotes = await emoteStore.allEmotes()
+        let channel = await emoteStore.channelEmotesSnapshot()
+        let user    = await emoteStore.userEmotesSnapshot()
+        let global  = await emoteStore.globalEmotesSnapshot()
         userEmoteSets = await emoteStore.userAvailableEmoteSets()
-        userEmoteIds = await emoteStore.userEmoteIdSet()
+        userEmoteIds  = await emoteStore.userEmoteIdSet()
+
+        allSections = buildSections(channel: channel, user: user, global: global)
         applyFilter()
+
+        // ownerId からチャンネル名・アイコンを非同期で解決（ProfileImageStore が @Observable なので自動更新）
+        let ownerIds = allSections.compactMap { section -> String? in
+            switch section.kind {
+            case .subscribedChannel(let ownerId): return ownerId
+            case .currentChannel: return currentBroadcasterId
+            default: return nil
+            }
+        }
+        let uniqueOwnerIds = Array(Set(ownerIds))
+        if !uniqueOwnerIds.isEmpty {
+            Task { await self.profileImageStore.fetchUsers(userIds: uniqueOwnerIds) }
+        }
     }
 
     /// ピッカー表示中に USERSTATE が届いた場合にエモートの使用可否をリアルタイムで更新する
@@ -81,11 +113,14 @@ final class EmotePickerViewModel {
             await emoteStore.waitForNextUserEmoteSetsUpdate()
             guard !Task.isCancelled else { break }
             userEmoteSets = await emoteStore.userAvailableEmoteSets()
-            userEmoteIds = await emoteStore.userEmoteIdSet()
-            // allEmotes はエモート定義が変わった場合のみ更新（再フィルタコストを抑える）
-            let newAllEmotes = await emoteStore.allEmotes()
-            if newAllEmotes != allEmotes {
-                allEmotes = newAllEmotes
+            userEmoteIds  = await emoteStore.userEmoteIdSet()
+            // エモート定義が変わった場合のみセクションを再構築（再フィルタコストを抑える）
+            let channel = await emoteStore.channelEmotesSnapshot()
+            let user    = await emoteStore.userEmotesSnapshot()
+            let global  = await emoteStore.globalEmotesSnapshot()
+            let newSections = buildSections(channel: channel, user: user, global: global)
+            if newSections != allSections {
+                allSections = newSections
             }
             applyFilter()
         }
@@ -102,7 +137,6 @@ final class EmotePickerViewModel {
     /// - Parameter emote: 判定対象のエモート
     /// - Returns: 使用可能な場合は true
     func isAvailable(_ emote: HelixEmote) -> Bool {
-        // ユーザーエモートは /helix/chat/emotes/user から取得済みのため常に使用可能
         if userEmoteIds.contains(emote.id) { return true }
         guard let sets = userEmoteSets else { return true }
         guard let emoteSetId = emote.emoteSetId else { return true }
@@ -111,15 +145,126 @@ final class EmotePickerViewModel {
 
     // MARK: - プライベートメソッド
 
-    /// 現在の searchQuery に基づいて filteredEmotes を更新する
+    /// チャンネル / ユーザー / グローバルエモートからセクション配列を構築する
     ///
-    /// - 空クエリの場合は全件返す
-    /// - 大文字小文字を区別しない部分一致でフィルタリングする
+    /// - Parameters:
+    ///   - channel: チャンネルエモート一覧
+    ///   - user: ユーザーエモート一覧
+    ///   - global: グローバルエモート一覧
+    /// - Returns: 並び順が確定したセクション配列
+    private func buildSections(
+        channel: [HelixEmote],
+        user: [HelixEmote],
+        global: [HelixEmote]
+    ) -> [EmotePickerSection] {
+        var seen = Set<String>()
+        let classified = classifyEmotes(channel: channel, user: user, seen: &seen)
+        return assembleSections(classified: classified, global: global, seen: &seen)
+    }
+
+    /// エモートをセクション種別ごとに分類して中間構造を返す
+    ///
+    /// 分類ルール（優先順位）:
+    /// 1. `emoteType == "hypetrain"` → `hypeTrain` セクション
+    /// 2. `ownerId == currentBroadcasterId` → `currentChannel` セクション（channelEmotes 含む）
+    /// 3. `ownerId != nil` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
+    /// 4. `ownerId == nil` かつ hypetrain 以外 → `other` セクション
+    private func classifyEmotes(
+        channel: [HelixEmote],
+        user: [HelixEmote],
+        seen: inout Set<String>
+    ) -> (currentChannel: [HelixEmote], hype: [HelixEmote],
+          subscribedOwnerIds: [String], subscribedByOwnerId: [String: [HelixEmote]],
+          other: [HelixEmote]) {
+        var currentChannelEmotes: [HelixEmote] = []
+        var hypeEmotes: [HelixEmote] = []
+        // ownerId → 出現順を保持するため OrderedDictionary の代わりに配列＋辞書で管理
+        var subscribedOwnerIds: [String] = []
+        var subscribedByOwnerId: [String: [HelixEmote]] = [:]
+        var otherEmotes: [HelixEmote] = []
+
+        for emote in channel where seen.insert(emote.id).inserted {
+            currentChannelEmotes.append(emote)
+        }
+        for emote in user where seen.insert(emote.id).inserted {
+            if emote.emoteType == "hypetrain" {
+                hypeEmotes.append(emote)
+            } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
+                currentChannelEmotes.append(emote)
+            } else if let ownerId = emote.ownerId {
+                if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
+                subscribedByOwnerId[ownerId, default: []].append(emote)
+            } else {
+                otherEmotes.append(emote)
+            }
+        }
+        return (currentChannelEmotes, hypeEmotes, subscribedOwnerIds, subscribedByOwnerId, otherEmotes)
+    }
+
+    /// 分類済みエモートから EmotePickerSection 配列を組み立てる（空セクションは除外）
+    private func assembleSections(
+        classified: (currentChannel: [HelixEmote], hype: [HelixEmote],
+                     subscribedOwnerIds: [String], subscribedByOwnerId: [String: [HelixEmote]],
+                     other: [HelixEmote]),
+        global: [HelixEmote],
+        seen: inout Set<String>
+    ) -> [EmotePickerSection] {
+        var sections: [EmotePickerSection] = []
+
+        if !classified.currentChannel.isEmpty {
+            sections.append(EmotePickerSection(
+                id: "current", kind: .currentChannel, title: "このチャンネル",
+                iconUserId: currentBroadcasterId, emotes: classified.currentChannel
+            ))
+        }
+        for ownerId in classified.subscribedOwnerIds {
+            let emotes = classified.subscribedByOwnerId[ownerId] ?? []
+            guard !emotes.isEmpty else { continue }
+            sections.append(EmotePickerSection(
+                id: "channel-\(ownerId)", kind: .subscribedChannel(ownerId: ownerId),
+                title: profileImageStore.displayName(for: ownerId) ?? ownerId,
+                iconUserId: ownerId, emotes: emotes
+            ))
+        }
+        if !classified.hype.isEmpty {
+            sections.append(EmotePickerSection(
+                id: "hype", kind: .hypeTrain, title: "HYPE", iconUserId: nil, emotes: classified.hype
+            ))
+        }
+        if !classified.other.isEmpty {
+            sections.append(EmotePickerSection(
+                id: "other", kind: .other, title: "その他", iconUserId: nil, emotes: classified.other
+            ))
+        }
+        let globalEmotes = global.filter { seen.insert($0.id).inserted }
+        if !globalEmotes.isEmpty {
+            sections.append(EmotePickerSection(
+                id: "global", kind: .global, title: "グローバル", iconUserId: nil, emotes: globalEmotes
+            ))
+        }
+        return sections
+    }
+
+    /// 現在の searchQuery に基づいて filteredSections を更新する
+    ///
+    /// - 空クエリの場合は全セクションを返す
+    /// - 大文字小文字を区別しない部分一致でエモート名をフィルタする
+    /// - ヒットするエモートが 0 件のセクションは除外する
     private func applyFilter() {
         guard !searchQuery.isEmpty else {
-            filteredEmotes = allEmotes
+            filteredSections = allSections
             return
         }
-        filteredEmotes = allEmotes.filter { $0.name.localizedCaseInsensitiveContains(searchQuery) }
+        filteredSections = allSections.compactMap { section in
+            let matched = section.emotes.filter { $0.name.localizedCaseInsensitiveContains(searchQuery) }
+            guard !matched.isEmpty else { return nil }
+            return EmotePickerSection(
+                id: section.id,
+                kind: section.kind,
+                title: section.title,
+                iconUserId: section.iconUserId,
+                emotes: matched
+            )
+        }
     }
 }

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -80,20 +80,10 @@ final class EmotePickerViewModel {
     /// ピッカーが表示されるタイミング（.task モディファイア）で呼び出す。
     func loadEmotes() async {
         await emoteStore.fetchGlobalEmotes()
-        let channel = await emoteStore.channelEmotesSnapshot()
-        let user    = await emoteStore.userEmotesSnapshot()
-        let global  = await emoteStore.globalEmotesSnapshot()
-        userEmoteSets = await emoteStore.userAvailableEmoteSets()
-        userEmoteIds  = await emoteStore.userEmoteIdSet()
-
-        // セクション構築前にオーナーIDの表示名を事前フェッチして初回レンダリングで即座に表示する
-        await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
-
-        allSections = buildSections(channel: channel, user: user, global: global)
-        applyFilter()
+        await refreshSections()
     }
 
-    /// ピッカー表示中に USERSTATE が届いた場合にエモートの使用可否をリアルタイムで更新する
+    /// ピッカー表示中にエモートセットや USERSTATE が更新された場合にセクションをリアルタイムで再構築する
     ///
     /// View の `.task` モディファイアから呼び出す。View が消えると `.task` が
     /// このメソッドのタスクをキャンセルし、`waitForNextUserEmoteSetsUpdate` が
@@ -102,19 +92,7 @@ final class EmotePickerViewModel {
         while !Task.isCancelled {
             await emoteStore.waitForNextUserEmoteSetsUpdate()
             guard !Task.isCancelled else { break }
-            userEmoteSets = await emoteStore.userAvailableEmoteSets()
-            userEmoteIds  = await emoteStore.userEmoteIdSet()
-            // エモート定義が変わった場合のみセクションを再構築（再フィルタコストを抑える）
-            let channel = await emoteStore.channelEmotesSnapshot()
-            let user    = await emoteStore.userEmotesSnapshot()
-            let global  = await emoteStore.globalEmotesSnapshot()
-            let newSections = buildSections(channel: channel, user: user, global: global)
-            if newSections != allSections {
-                allSections = newSections
-                // 新規セクションの ownerId に対して表示名・アイコンを解決する
-                scheduleOwnerDisplayNameFetch(for: allSections)
-            }
-            applyFilter()
+            await refreshSections()
         }
     }
 
@@ -137,6 +115,22 @@ final class EmotePickerViewModel {
 
     // MARK: - プライベートメソッド
 
+    /// エモートストアのスナップショットを取得し、表示名を事前フェッチしてからセクションを再構築する
+    ///
+    /// `loadEmotes()` と `observeUserEmoteSetsUpdates()` の共通ロジック。
+    /// 表示名フェッチを await することで、セクション構築時点で displayName が確定し
+    /// 初回レンダリングから正しいチャンネル名が表示される。
+    private func refreshSections() async {
+        let channel = await emoteStore.channelEmotesSnapshot()
+        let user    = await emoteStore.userEmotesSnapshot()
+        let global  = await emoteStore.globalEmotesSnapshot()
+        userEmoteSets = await emoteStore.userAvailableEmoteSets()
+        userEmoteIds  = await emoteStore.userEmoteIdSet()
+        await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
+        allSections = buildSections(channel: channel, user: user, global: global)
+        applyFilter()
+    }
+
     /// チャンネル・ユーザーエモートからセクションオーナー ID を収集する
     ///
     /// - Returns: currentBroadcasterId を含む、重複なし・"0" 除外済みの ownerId 配列
@@ -147,24 +141,6 @@ final class EmotePickerViewModel {
             if let ownerId = emote.ownerId, ownerId != "0" { ids.insert(ownerId) }
         }
         return Array(ids)
-    }
-
-    /// セクション内の subscribedChannel / currentChannel の ownerId に対して
-    /// ProfileImageStore の表示名・アイコンフェッチを非同期でスケジュールする
-    ///
-    /// ProfileImageStore は内部でキャッシュ済み ID をスキップするため、
-    /// 重複フェッチは発生しない。
-    private func scheduleOwnerDisplayNameFetch(for sections: [EmotePickerSection]) {
-        let ownerIds = sections.compactMap { section -> String? in
-            switch section.kind {
-            case .subscribedChannel(let ownerId): return ownerId
-            case .currentChannel: return currentBroadcasterId
-            default: return nil
-            }
-        }
-        let uniqueOwnerIds = Array(Set(ownerIds))
-        guard !uniqueOwnerIds.isEmpty else { return }
-        Task { await self.profileImageStore.fetchUsers(userIds: uniqueOwnerIds) }
     }
 
     /// チャンネル / ユーザー / グローバルエモートからセクション配列を構築する

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -86,9 +86,11 @@ final class EmotePickerViewModel {
         userEmoteSets = await emoteStore.userAvailableEmoteSets()
         userEmoteIds  = await emoteStore.userEmoteIdSet()
 
+        // セクション構築前にオーナーIDの表示名を事前フェッチして初回レンダリングで即座に表示する
+        await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
+
         allSections = buildSections(channel: channel, user: user, global: global)
         applyFilter()
-        scheduleOwnerDisplayNameFetch(for: allSections)
     }
 
     /// ピッカー表示中に USERSTATE が届いた場合にエモートの使用可否をリアルタイムで更新する
@@ -134,6 +136,18 @@ final class EmotePickerViewModel {
     }
 
     // MARK: - プライベートメソッド
+
+    /// チャンネル・ユーザーエモートからセクションオーナー ID を収集する
+    ///
+    /// - Returns: currentBroadcasterId を含む、重複なし・"0" 除外済みの ownerId 配列
+    private func collectOwnerIds(channel: [HelixEmote], user: [HelixEmote]) -> [String] {
+        var ids = Set<String>()
+        if let id = currentBroadcasterId { ids.insert(id) }
+        for emote in channel + user {
+            if let ownerId = emote.ownerId, ownerId != "0" { ids.insert(ownerId) }
+        }
+        return Array(ids)
+    }
 
     /// セクション内の subscribedChannel / currentChannel の ownerId に対して
     /// ProfileImageStore の表示名・アイコンフェッチを非同期でスケジュールする

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -166,7 +166,9 @@ final class EmotePickerViewModel {
         global: [HelixEmote]
     ) -> [EmotePickerSection] {
         var seen = Set<String>()
-        let classified = classifyEmotes(channel: channel, user: user, seen: &seen)
+        // グローバルエンドポイントに存在する ID セットを事前に作成してユーザーエモートの振り分けに使用する
+        let globalIdSet = Set(global.map(\.id))
+        let classified = classifyEmotes(channel: channel, user: user, globalIdSet: globalIdSet, seen: &seen)
         return assembleSections(classified: classified, global: global, seen: &seen)
     }
 
@@ -174,18 +176,17 @@ final class EmotePickerViewModel {
     ///
     /// 分類ルール（優先順位）:
     /// 1. `emoteType == "hypetrain"` → `hypeTrain` セクション
-    /// 2. `emoteType == "globals"` → global セクションに送る（ownerId があっても優先）
+    /// 2. グローバル判定（`emoteType == "globals"` または `globalIdSet` に含まれる ID）→ global セクション
     /// 3. `ownerId == currentBroadcasterId` → `currentChannel` セクション（channelEmotes 含む）
     /// 4. `ownerId != nil && ownerId != "0"` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
-    /// 5. それ以外（`ownerId == nil` または `ownerId == "0"` かつ hypetrain 以外）→ global セクションに送る
+    /// 5. それ以外（`ownerId == nil` または `ownerId == "0"`）→ global セクションに送る
     ///
-    /// - Note: `/helix/chat/emotes/user` は Kappa 等の globals タイプエモートを
-    ///   ownerId 付きで返すことがある。emoteType で先に判定して global に振り分ける。
-    /// - Note: `owner_id: "0"` は Twitch 自身が所有するグローバル系エモートを示すため、
-    ///   表示名を解決できないチャンネルセクションを作らず global にまとめる。
+    /// - Note: `/helix/chat/emotes/user` はグローバルエモート（smilies 等）を ownerId 付きで返すため、
+    ///   emoteType だけでなくグローバルエンドポイントの ID セットとも照合して振り分ける。
     private func classifyEmotes(
         channel: [HelixEmote],
         user: [HelixEmote],
+        globalIdSet: Set<String>,
         seen: inout Set<String>
     ) -> (currentChannel: [HelixEmote], hype: [HelixEmote],
           subscribedOwnerIds: [String], subscribedByOwnerId: [String: [HelixEmote]],
@@ -203,8 +204,9 @@ final class EmotePickerViewModel {
         for emote in user where seen.insert(emote.id).inserted {
             if emote.emoteType == "hypetrain" {
                 hypeEmotes.append(emote)
-            } else if emote.emoteType == "globals" {
-                // globals タイプは ownerId があっても global セクションへ送る
+            } else if emote.emoteType == "globals" || globalIdSet.contains(emote.id) {
+                // globals タイプまたはグローバルエンドポイントに存在する ID は global セクションへ送る
+                // seen から除外して assembleSections の global 合算処理で拾う
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -174,10 +174,13 @@ final class EmotePickerViewModel {
     ///
     /// 分類ルール（優先順位）:
     /// 1. `emoteType == "hypetrain"` → `hypeTrain` セクション
-    /// 2. `ownerId == currentBroadcasterId` → `currentChannel` セクション（channelEmotes 含む）
-    /// 3. `ownerId != nil && ownerId != "0"` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
-    /// 4. それ以外（`ownerId == nil` または `ownerId == "0"` かつ hypetrain 以外）→ global セクションに送る
+    /// 2. `emoteType == "globals"` → global セクションに送る（ownerId があっても優先）
+    /// 3. `ownerId == currentBroadcasterId` → `currentChannel` セクション（channelEmotes 含む）
+    /// 4. `ownerId != nil && ownerId != "0"` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
+    /// 5. それ以外（`ownerId == nil` または `ownerId == "0"` かつ hypetrain 以外）→ global セクションに送る
     ///
+    /// - Note: `/helix/chat/emotes/user` は Kappa 等の globals タイプエモートを
+    ///   ownerId 付きで返すことがある。emoteType で先に判定して global に振り分ける。
     /// - Note: `owner_id: "0"` は Twitch 自身が所有するグローバル系エモートを示すため、
     ///   表示名を解決できないチャンネルセクションを作らず global にまとめる。
     private func classifyEmotes(
@@ -200,14 +203,17 @@ final class EmotePickerViewModel {
         for emote in user where seen.insert(emote.id).inserted {
             if emote.emoteType == "hypetrain" {
                 hypeEmotes.append(emote)
+            } else if emote.emoteType == "globals" {
+                // globals タイプは ownerId があっても global セクションへ送る
+                seen.remove(emote.id)
+                otherEmotes.append(emote)
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
                 currentChannelEmotes.append(emote)
             } else if let ownerId = emote.ownerId, ownerId != "0" {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
             } else {
-                // ownerId なしエモートは global セクションで処理するため seen から除外する
-                // （assembleSections で global スナップショットと合算して dedup する）
+                // ownerId なし / "0" エモートは global セクションで処理するため seen から除外する
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
             }

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -88,19 +88,7 @@ final class EmotePickerViewModel {
 
         allSections = buildSections(channel: channel, user: user, global: global)
         applyFilter()
-
-        // ownerId からチャンネル名・アイコンを非同期で解決（ProfileImageStore が @Observable なので自動更新）
-        let ownerIds = allSections.compactMap { section -> String? in
-            switch section.kind {
-            case .subscribedChannel(let ownerId): return ownerId
-            case .currentChannel: return currentBroadcasterId
-            default: return nil
-            }
-        }
-        let uniqueOwnerIds = Array(Set(ownerIds))
-        if !uniqueOwnerIds.isEmpty {
-            Task { await self.profileImageStore.fetchUsers(userIds: uniqueOwnerIds) }
-        }
+        scheduleOwnerDisplayNameFetch(for: allSections)
     }
 
     /// ピッカー表示中に USERSTATE が届いた場合にエモートの使用可否をリアルタイムで更新する
@@ -121,6 +109,8 @@ final class EmotePickerViewModel {
             let newSections = buildSections(channel: channel, user: user, global: global)
             if newSections != allSections {
                 allSections = newSections
+                // 新規セクションの ownerId に対して表示名・アイコンを解決する
+                scheduleOwnerDisplayNameFetch(for: allSections)
             }
             applyFilter()
         }
@@ -145,6 +135,24 @@ final class EmotePickerViewModel {
 
     // MARK: - プライベートメソッド
 
+    /// セクション内の subscribedChannel / currentChannel の ownerId に対して
+    /// ProfileImageStore の表示名・アイコンフェッチを非同期でスケジュールする
+    ///
+    /// ProfileImageStore は内部でキャッシュ済み ID をスキップするため、
+    /// 重複フェッチは発生しない。
+    private func scheduleOwnerDisplayNameFetch(for sections: [EmotePickerSection]) {
+        let ownerIds = sections.compactMap { section -> String? in
+            switch section.kind {
+            case .subscribedChannel(let ownerId): return ownerId
+            case .currentChannel: return currentBroadcasterId
+            default: return nil
+            }
+        }
+        let uniqueOwnerIds = Array(Set(ownerIds))
+        guard !uniqueOwnerIds.isEmpty else { return }
+        Task { await self.profileImageStore.fetchUsers(userIds: uniqueOwnerIds) }
+    }
+
     /// チャンネル / ユーザー / グローバルエモートからセクション配列を構築する
     ///
     /// - Parameters:
@@ -167,8 +175,11 @@ final class EmotePickerViewModel {
     /// 分類ルール（優先順位）:
     /// 1. `emoteType == "hypetrain"` → `hypeTrain` セクション
     /// 2. `ownerId == currentBroadcasterId` → `currentChannel` セクション（channelEmotes 含む）
-    /// 3. `ownerId != nil` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
-    /// 4. `ownerId == nil` かつ hypetrain 以外 → `other` セクション
+    /// 3. `ownerId != nil && ownerId != "0"` → `subscribedChannel(ownerId)` セクション（ビッツエモート含む）
+    /// 4. それ以外（`ownerId == nil` または `ownerId == "0"` かつ hypetrain 以外）→ global セクションに送る
+    ///
+    /// - Note: `owner_id: "0"` は Twitch 自身が所有するグローバル系エモートを示すため、
+    ///   表示名を解決できないチャンネルセクションを作らず global にまとめる。
     private func classifyEmotes(
         channel: [HelixEmote],
         user: [HelixEmote],
@@ -191,7 +202,7 @@ final class EmotePickerViewModel {
                 hypeEmotes.append(emote)
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
                 currentChannelEmotes.append(emote)
-            } else if let ownerId = emote.ownerId {
+            } else if let ownerId = emote.ownerId, ownerId != "0" {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
             } else {

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -13,6 +13,8 @@ import SwiftUI
 struct ChatDetailView: View {
     var viewModel: ChatViewModel
     var authState: AuthState
+    /// プロフィール画像・表示名ストア（エモートピッカーのセクションヘッダー用）
+    var profileImageStore: ProfileImageStore
 
     var body: some View {
         VStack(spacing: 0) {
@@ -30,7 +32,7 @@ struct ChatDetailView: View {
 
             // コメント投稿用入力バー
             Divider()
-            ChatInputBar(viewModel: viewModel, authState: authState)
+            ChatInputBar(viewModel: viewModel, authState: authState, profileImageStore: profileImageStore)
         }
         // タブバーのアクティブタブ色（controlBackgroundColor）と一致させる
         .background(Color(.controlBackgroundColor))

--- a/Sources/TwitchChat/Views/ChatInputBar.swift
+++ b/Sources/TwitchChat/Views/ChatInputBar.swift
@@ -13,6 +13,8 @@ import SwiftUI
 struct ChatInputBar: View {
     var viewModel: ChatViewModel
     var authState: AuthState
+    /// プロフィール画像・表示名ストア（エモートピッカーのセクションヘッダー用）
+    var profileImageStore: ProfileImageStore
 
     /// 入力テキスト（下書き）
     @State private var draft: String = ""
@@ -29,9 +31,10 @@ struct ChatInputBar: View {
     /// / スラッシュコマンド補完の状態管理 ViewModel
     @State private var slashCommandCompletionVM: SlashCommandCompletionViewModel
 
-    init(viewModel: ChatViewModel, authState: AuthState) {
+    init(viewModel: ChatViewModel, authState: AuthState, profileImageStore: ProfileImageStore) {
         self.viewModel = viewModel
         self.authState = authState
+        self.profileImageStore = profileImageStore
         self._mentionCompletionVM = State(
             initialValue: MentionCompletionViewModel(mentionStore: viewModel.mentionStore)
         )
@@ -151,7 +154,11 @@ struct ChatInputBar: View {
             .buttonStyle(.plain)
             .accessibilityLabel("エモートピッカーを開く")
             .popover(isPresented: $showEmotePicker, arrowEdge: .bottom) {
-                EmotePickerView(emoteStore: viewModel.emoteStore) { emoteName in
+                EmotePickerView(
+                    emoteStore: viewModel.emoteStore,
+                    profileImageStore: profileImageStore,
+                    currentBroadcasterId: viewModel.currentRoomId
+                ) { emoteName in
                     insertEmote(emoteName)
                     showEmotePicker = false
                 }

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
                         }
                     )
                 } else if let viewModel = channelManager.selectedViewModel {
-                    ChatDetailView(viewModel: viewModel, authState: authState)
+                    ChatDetailView(viewModel: viewModel, authState: authState, profileImageStore: profileImageStore)
                 } else {
                     // タブ0個の初期状態: チャンネル名入力フォームを直接表示
                     ChannelSearchView(

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -110,7 +110,8 @@ private struct EmoteSectionHeader: View {
                 .clipShape(Circle())
             }
 
-            Text(section.title)
+            // ProfileImageStore から displayName を動的に解決する（@Observable で自動更新）
+            Text(resolvedTitle)
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -120,6 +121,14 @@ private struct EmoteSectionHeader: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color(.windowBackgroundColor))
+    }
+
+    /// iconUserId に対応する displayName を ProfileImageStore から解決する
+    ///
+    /// 未取得の場合は section.title（ownerId または "グローバル" 等）をフォールバックとして使用する。
+    private var resolvedTitle: String {
+        guard let userId = section.iconUserId else { return section.title }
+        return profileImageStore.displayName(for: userId) ?? section.title
     }
 }
 

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -110,8 +110,8 @@ private struct EmoteSectionHeader: View {
                 .clipShape(Circle())
             }
 
-            // ProfileImageStore から displayName を body 内で直接参照して @Observable 追跡を確実にする
-            Text(section.iconUserId.flatMap { profileImageStore.displayName(for: $0) } ?? section.title)
+            // displayName → login → section.title の順でヘッダーテキストを決定する（@Observable で自動更新）
+            Text(section.iconUserId.flatMap { profileImageStore.displayName(for: $0) ?? profileImageStore.login(for: $0) } ?? section.title)
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -1,14 +1,15 @@
 // EmotePickerView.swift
 // エモートピッカービュー
-// グリッド表示と検索フィルタでエモートを選択し、入力フォームに挿入できるビュー
+// グリッド表示・チャンネルごとのセクション・検索フィルタでエモートを選択し入力フォームに挿入できるビュー
 
 import AppKit
 import SwiftUI
 
 /// エモートピッカービュー
 ///
+/// - セクション表示: チャンネルごとにエモートをグループ化し、ヘッダーにアイコン＋名前を表示する
 /// - グリッド表示: `LazyVGrid` でエモートサムネイルを並べる
-/// - 検索フィルタ: テキストフィールドで名前を絞り込む（大文字小文字非区別）
+/// - 検索フィルタ: テキストフィールドで名前を絞り込む（大文字小文字非区別・全セクション横断）
 /// - エモートを選択すると `onSelect` コールバックでエモート名を呼び出し元に通知する
 struct EmotePickerView: View {
 
@@ -16,9 +17,22 @@ struct EmotePickerView: View {
 
     @State private var viewModel: EmotePickerViewModel
 
-    init(emoteStore: EmoteStore, onSelect: @escaping (String) -> Void) {
+    /// プロフィール画像・表示名ストア（セクションヘッダーのアイコン表示に使用）
+    var profileImageStore: ProfileImageStore
+
+    init(
+        emoteStore: EmoteStore,
+        profileImageStore: ProfileImageStore,
+        currentBroadcasterId: String?,
+        onSelect: @escaping (String) -> Void
+    ) {
         self.onSelect = onSelect
-        self._viewModel = State(initialValue: EmotePickerViewModel(emoteStore: emoteStore))
+        self.profileImageStore = profileImageStore
+        self._viewModel = State(initialValue: EmotePickerViewModel(
+            emoteStore: emoteStore,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: currentBroadcasterId
+        ))
     }
 
     var body: some View {
@@ -30,8 +44,8 @@ struct EmotePickerView: View {
 
             Divider()
 
-            // エモートグリッド
-            if viewModel.filteredEmotes.isEmpty {
+            // エモートグリッド（セクション分け）
+            if viewModel.filteredSections.isEmpty {
                 Spacer()
                 Text("エモートが見つかりません")
                     .font(.caption)
@@ -39,28 +53,73 @@ struct EmotePickerView: View {
                 Spacer()
             } else {
                 ScrollView {
-                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 40))], spacing: 4) {
-                        ForEach(viewModel.filteredEmotes) { emote in
-                            let available = viewModel.isAvailable(emote)
-                            Button {
-                                onSelect(emote.name)
-                            } label: {
-                                EmoteCellView(emoteId: emote.id, emoteName: emote.name, isAvailable: available)
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 40))], spacing: 4, pinnedViews: [.sectionHeaders]) {
+                        ForEach(viewModel.filteredSections) { section in
+                            Section {
+                                ForEach(section.emotes) { emote in
+                                    let available = viewModel.isAvailable(emote)
+                                    Button {
+                                        onSelect(emote.name)
+                                    } label: {
+                                        EmoteCellView(emoteId: emote.id, emoteName: emote.name, isAvailable: available)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .disabled(!available)
+                                    .accessibilityLabel(Text(emote.name))
+                                    .accessibilityValue(available ? "" : "使用不可")
+                                }
+                            } header: {
+                                EmoteSectionHeader(section: section, profileImageStore: profileImageStore)
                             }
-                            .buttonStyle(.plain)
-                            .disabled(!available)
-                            .accessibilityLabel(Text(emote.name))
-                            .accessibilityValue(available ? "" : "使用不可")
                         }
                     }
-                    .padding(8)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 8)
                 }
             }
         }
-        .frame(width: 320, height: 300)
+        .frame(width: 320, height: 380)
         .task { await viewModel.loadEmotes() }
         // ピッカー表示中に USERSTATE が届いた場合の使用可否リアルタイム更新
         .task { await viewModel.observeUserEmoteSetsUpdates() }
+    }
+}
+
+/// エモートセクションヘッダービュー
+///
+/// チャンネルアイコン（ProfileImageStore から取得）とセクション名を横並びに表示する。
+/// グローバル・HYPE・その他セクションはアイコンなし。
+private struct EmoteSectionHeader: View {
+
+    let section: EmotePickerSection
+    let profileImageStore: ProfileImageStore
+
+    var body: some View {
+        HStack(spacing: 4) {
+            // チャンネルアイコン（currentChannel / subscribedChannel のみ表示）
+            if let userId = section.iconUserId,
+               let iconUrl = profileImageStore.profileImageUrl(for: userId) {
+                AsyncImage(url: iconUrl) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Color.clear
+                }
+                .frame(width: 14, height: 14)
+                .clipShape(Circle())
+            }
+
+            Text(section.title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Color(.windowBackgroundColor))
     }
 }
 

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -110,8 +110,8 @@ private struct EmoteSectionHeader: View {
                 .clipShape(Circle())
             }
 
-            // ProfileImageStore から displayName を動的に解決する（@Observable で自動更新）
-            Text(resolvedTitle)
+            // ProfileImageStore から displayName を body 内で直接参照して @Observable 追跡を確実にする
+            Text(section.iconUserId.flatMap { profileImageStore.displayName(for: $0) } ?? section.title)
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
@@ -121,14 +121,6 @@ private struct EmoteSectionHeader: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color(.windowBackgroundColor))
-    }
-
-    /// iconUserId に対応する displayName を ProfileImageStore から解決する
-    ///
-    /// 未取得の場合は section.title（ownerId または "グローバル" 等）をフォールバックとして使用する。
-    private var resolvedTitle: String {
-        guard let userId = section.iconUserId else { return section.title }
-        return profileImageStore.displayName(for: userId) ?? section.title
     }
 }
 

--- a/Sources/TwitchChat/Views/EmotePickerView.swift
+++ b/Sources/TwitchChat/Views/EmotePickerView.swift
@@ -121,6 +121,12 @@ private struct EmoteSectionHeader: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color(.windowBackgroundColor))
+        // ヘッダー表示時にも displayName を確実に取得する（タイミング次第でキャッシュ未到達の場合に対応）
+        .task(id: section.iconUserId) {
+            if let userId = section.iconUserId {
+                await profileImageStore.fetchUsers(userIds: [userId])
+            }
+        }
     }
 }
 

--- a/Tests/TwitchChatTests/ChannelManagerTests.swift
+++ b/Tests/TwitchChatTests/ChannelManagerTests.swift
@@ -430,6 +430,57 @@ struct ChannelManagerTests {
         #expect(userEmoteIdSet.isEmpty)
     }
 
+    @Test("preloadEmoteOwnerDisplayNames でプリロード済みエモートの ownerId の表示名が ProfileImageStore にキャッシュされる")
+    func testPreloadEmoteOwnerDisplayNamesFetchesDisplayNames() async {
+        // 前提: ownerId "99999" を持つユーザーエモートがプリロードストアに設定済み
+        let preloadStore = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await preloadStore.setUserEmotes([
+            HelixEmote(
+                id: "emote_sub_99999", name: "サブチャンネルエモート", format: ["static"],
+                emoteType: "subscriptions", emoteSetId: "set_99999", ownerId: "99999"
+            )
+        ])
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            preloadEmoteStore: preloadStore
+        )
+        // モック API が ownerId "99999" に対して "サブチャンネル配信者" を返す
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            HelixUserData(id: "99999", login: "sub_channel", displayName: "サブチャンネル配信者", profileImageUrl: nil)
+        ])
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+
+        // 操作: ownerId の表示名をプリロードする
+        await manager.preloadEmoteOwnerDisplayNames(using: profileImageStore)
+
+        // 検証: ProfileImageStore に ownerId の displayName がキャッシュされている
+        #expect(profileImageStore.displayName(for: "99999") == "サブチャンネル配信者")
+    }
+
+    @Test("ownerId が nil またはゼロのエモートのみの場合 preloadEmoteOwnerDisplayNames は API を呼ばない")
+    func testPreloadEmoteOwnerDisplayNamesSkipsNilAndZeroOwnerIds() async {
+        // 前提: ownerId が nil / "0" のエモートのみ
+        let preloadStore = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await preloadStore.setUserEmotes([
+            HelixEmote(id: "global1", name: "GlobalEmote", format: ["static"], emoteType: "globals", ownerId: nil),
+            HelixEmote(id: "global2", name: "TurboEmote", format: ["static"], emoteType: "turbo", ownerId: "0")
+        ])
+        let manager = ChannelManager(
+            authState: AuthState(),
+            makeIRCClient: { MockTwitchIRCClient() },
+            preloadEmoteStore: preloadStore
+        )
+        let mockClient = MockProfileImageAPIClient()
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+
+        await manager.preloadEmoteOwnerDisplayNames(using: profileImageStore)
+
+        // 検証: API が呼ばれていないこと（callCount == 0）
+        #expect(await mockClient.callCount == 0)
+    }
+
     @Test("roomId 確定時に ChatViewModel の onRoomIdConfirmed コールバックがセットされている")
     func testRoomIdConfirmedCallbackIsConfigured() async throws {
         // 前提: MockTwitchIRCClient と MockTwitchEventSubClient を使う

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -177,10 +177,10 @@ struct EmotePickerViewModelTests {
         #expect(subSections.allSatisfy { !$0.emotes.contains(where: { $0.id == hypeEmote.id }) })
     }
 
-    @Test("ownerId が nil かつ hypetrain でないエモートは other セクションに分類される")
+    @Test("ownerId が nil かつ hypetrain でないエモートは global セクションにまとめられる")
     @MainActor
-    func testEmotesWithNilOwnerIdGoToOtherSection() async {
-        // 前提: ownerId なしのエモート
+    func testEmotesWithNilOwnerIdGoToGlobalSection() async {
+        // 前提: ownerId なしのエモート（リワード等）
         let rewardEmote = HelixEmote(
             id: "reward_1",
             name: "チャンネルポイントエモート",
@@ -192,13 +192,14 @@ struct EmotePickerViewModelTests {
 
         await viewModel.loadEmotes()
 
-        // 検証: other セクションにエモートが入る
-        let otherSection = viewModel.filteredSections.first(where: { $0.kind == .other })
-        #expect(otherSection != nil)
-        #expect(otherSection?.emotes.contains(where: { $0.id == rewardEmote.id }) == true)
+        // 検証: global セクションに ownerId なしエモートがまとめられる（other セクションは生成されない）
+        let globalSection = viewModel.filteredSections.first(where: { $0.kind == .global })
+        #expect(globalSection != nil)
+        #expect(globalSection?.emotes.contains(where: { $0.id == rewardEmote.id }) == true)
+        #expect(viewModel.filteredSections.count == 1)
     }
 
-    @Test("セクションの並び順は currentChannel → subscribedChannel → hypeTrain → other → global")
+    @Test("セクションの並び順は currentChannel → subscribedChannel → hypeTrain → global")
     @MainActor
     func testSectionOrdering() async {
         // 前提: 全種類のセクションが生成される組み合わせ
@@ -215,10 +216,11 @@ struct EmotePickerViewModelTests {
 
         await viewModel.loadEmotes()
 
-        // 検証: セクションが正しい順序で並ぶ（currentChannel → subscribedChannel → hypeTrain → other → global）
+        // 検証: セクションが正しい順序で並ぶ（currentChannel → subscribedChannel → hypeTrain → global）
+        // ownerId なしエモートは global セクションにまとめられる
         let kinds = viewModel.filteredSections.map(\.kind)
-        guard kinds.count == 5 else {
-            Issue.record("セクション数が期待値と異なります（期待: 5, 実際: \(kinds.count)）")
+        guard kinds.count == 4 else {
+            Issue.record("セクション数が期待値と異なります（期待: 4, 実際: \(kinds.count)）")
             return
         }
         #expect(kinds[0] == .currentChannel)
@@ -226,8 +228,7 @@ struct EmotePickerViewModelTests {
             Issue.record("2番目のセクションが subscribedChannel ではありません: \(kinds[1])")
         }
         #expect(kinds[2] == .hypeTrain)
-        #expect(kinds[3] == .other)
-        #expect(kinds[4] == .global)
+        #expect(kinds[3] == .global)
     }
 
     @Test("同じ ID のエモートはセクション間で重複しない")

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -752,14 +752,13 @@ struct EmotePickerViewModelTests {
         #expect(globalSection?.emotes.contains(where: { $0.id == emptyOwnerEmote.id }) == true)
     }
 
-    @Test("API にユーザーが存在しない ownerId のエモートは global セクションに分類される（数字 ID のセクションを作らない）")
+    @Test("API がユーザーを返さない ownerId のエモートは subscribedChannel セクションに分類され ownerId が仮タイトルになる")
     @MainActor
-    func testUnresolvableOwnerIdGoesToGlobalSection() async {
+    func testUnresolvableOwnerIdCreatesSubscribedSectionWithOwnerIdTitle() async {
         // 前提: ownerId "784555479" を持つエモート、モック API がユーザーを返さない
         let mockClient = MockProfileImageAPIClient()
-        await mockClient.setUsers([]) // API はユーザーを返さない（存在しない broadcaster ID）
+        await mockClient.setUsers([]) // API はユーザーを返さない
 
-        // stubbedEmotes: [] でグローバルエモートエンドポイントが空配列を返すように設定
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setUserEmotes([
             HelixEmote(
@@ -780,15 +779,19 @@ struct EmotePickerViewModelTests {
 
         await viewModel.loadEmotes()
 
-        // 検証: subscribedChannel セクションが作成されないこと
+        // 検証: subscribedChannel セクションが作成されること（API が返さなくても誤分類しない）
         let subscribedSection = viewModel.filteredSections.first {
-            if case .subscribedChannel = $0.kind { return true }
+            if case .subscribedChannel(let id) = $0.kind { return id == "784555479" }
             return false
         }
-        #expect(subscribedSection == nil)
+        #expect(subscribedSection != nil)
 
-        // 検証: emote が global セクションに含まれること（数字 ID のセクションに隔離されない）
+        // 検証: タイトルが ownerId にフォールバックしていること（displayName / login 未取得のため）
+        #expect(subscribedSection?.title == "784555479")
+        #expect(subscribedSection?.emotes.contains(where: { $0.id == "emote_unknown_owner" }) == true)
+
+        // 検証: global セクションにはそのエモートが含まれていないこと
         let globalSection = viewModel.filteredSections.first(where: { $0.kind == .global })
-        #expect(globalSection?.emotes.contains(where: { $0.id == "emote_unknown_owner" }) == true)
+        #expect(globalSection?.emotes.contains(where: { $0.id == "emote_unknown_owner" }) != true)
     }
 }

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -99,6 +99,105 @@ struct EmotePickerViewModelTests {
         #expect(subscribedSection?.title == "更新チャンネル")
     }
 
+    @Test("USERSTATE のみ更新されてもセクションは再構築されない（エモートデータが変わっていない場合）")
+    @MainActor
+    func testUserStateOnlyUpdateDoesNotRebuildSections() async throws {
+        // 前提: subscribedChannel セクションが 1 つある状態
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+        await store.setUserEmotes([
+            HelixEmote(id: "sub1", name: "Sub1", format: ["static"], emoteType: "subscriptions", emoteSetId: "111", ownerId: "11111")
+        ])
+        await viewModel.loadEmotes()
+        let initialSectionCount = viewModel.filteredSections.count
+
+        // observer 起動して待機状態にする
+        let observeTask = Task { await viewModel.observeUserEmoteSetsUpdates() }
+        for _ in 0..<5 { await Task.yield() }
+
+        // USERSTATE のみ更新（エモートデータは変えずに userEmoteSets を更新）
+        await store.updateUserEmoteSets(Set(["111"]))
+        try await Task.sleep(for: .milliseconds(50))
+        observeTask.cancel()
+
+        // 検証: セクション数に変化なし（再構築されていない）、可用性判定には反映されている
+        #expect(viewModel.filteredSections.count == initialSectionCount)
+    }
+
+    @Test("ユーザーエモートが増えた場合はセクションが再構築されて displayName が反映される")
+    @MainActor
+    func testUserEmoteIncreaseRebuildsSectionsWithDisplayName() async throws {
+        // 前提: 初回は空
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            HelixUserData(id: "22222", login: "new_ch", displayName: "新しいチャンネル", profileImageUrl: nil)
+        ])
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+        await viewModel.loadEmotes()
+        #expect(viewModel.filteredSections.isEmpty)
+
+        // observer 起動
+        let observeTask = Task { await viewModel.observeUserEmoteSetsUpdates() }
+        for _ in 0..<5 { await Task.yield() }
+
+        // ユーザーエモートを追加（count が増える）
+        await store.setUserEmotes([
+            HelixEmote(id: "new1", name: "New1", format: ["static"], emoteType: "subscriptions", emoteSetId: "222", ownerId: "22222")
+        ])
+        await store.notifyUserEmoteSetsUpdatedForTest()
+        try await Task.sleep(for: .milliseconds(100))
+        observeTask.cancel()
+
+        // 検証: セクションが追加され displayName が正しく設定されている
+        let section = viewModel.filteredSections.first { $0.kind == .subscribedChannel(ownerId: "22222") }
+        #expect(section?.title == "新しいチャンネル")
+    }
+
+    @Test("並行する古い refreshSections が新しい refreshSections の結果を上書きしない")
+    @MainActor
+    func testStaleRefreshDoesNotOverwriteNewerResult() async throws {
+        // 前提: 初回は空、その後エモートが追加される
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+
+        // observer タスクを先に起動して待機状態にする
+        let observeTask = Task { await viewModel.observeUserEmoteSetsUpdates() }
+        for _ in 0..<5 { await Task.yield() }
+
+        // ユーザーエモートを追加して通知（observer が新しいスナップショットで sections を構築）
+        await store.setUserEmotes([
+            HelixEmote(id: "race_emote", name: "raceEmote", format: ["static"], emoteType: "subscriptions", emoteSetId: "777", ownerId: "77777")
+        ])
+        await store.notifyUserEmoteSetsUpdatedForTest()
+
+        // loadEmotes も並行して呼ぶ（古いスナップショットで sections を上書きしようとする）
+        await viewModel.loadEmotes()
+
+        // 更新が落ち着くまで待つ
+        try await Task.sleep(for: .milliseconds(100))
+        observeTask.cancel()
+
+        // 検証: subscribedChannel セクションが消えていない（古いスナップショットで上書きされていない）
+        let hasSubscribedSection = viewModel.filteredSections.contains { $0.kind == .subscribedChannel(ownerId: "77777") }
+        #expect(hasSubscribedSection)
+    }
+
     @Test("グローバルエモートのみのとき global セクションだけが返る")
     @MainActor
     func testLoadEmotesGlobalOnly() async {

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -1,5 +1,5 @@
 // EmotePickerViewModelTests.swift
-// EmotePickerViewModel のフィルタリングロジックテスト
+// EmotePickerViewModel のセクション構築・フィルタリングロジックテスト
 
 import Foundation
 import Testing
@@ -8,122 +8,358 @@ import Testing
 @Suite("EmotePickerViewModelTests")
 struct EmotePickerViewModelTests {
 
-    // MARK: - テスト用エモートデータ
+    // MARK: - テストヘルパー
 
-    /// テスト用エモートセット（3件）
-    private func makeTestEmotes() -> [HelixEmote] {
-        [
-            HelixEmote(id: "1", name: "LUL",        format: ["static", "animated"], emoteType: "globals"),
-            HelixEmote(id: "2", name: "PogChamp",    format: ["static"],             emoteType: "globals"),
-            HelixEmote(id: "3", name: "配信者エモート", format: ["static"],             emoteType: "subscriptions")
-        ]
+    /// テスト用エモートストアと ProfileImageStore を含む環境を生成する
+    @MainActor
+    private func makeEnvironment(
+        channelEmotes: [HelixEmote] = [],
+        userEmotes: [HelixEmote] = [],
+        globalEmotes: [HelixEmote] = [],
+        currentBroadcasterId: String? = nil
+    ) async -> (store: EmoteStore, profileImageStore: ProfileImageStore, viewModel: EmotePickerViewModel) {
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        await store.setChannelEmotes(channelEmotes)
+        await store.setUserEmotes(userEmotes)
+        await store.setGlobalEmotes(globalEmotes)
+
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: currentBroadcasterId
+        )
+        return (store, profileImageStore, viewModel)
     }
 
-    // MARK: - loadEmotes
+    // MARK: - loadEmotes / セクション構築
 
-    @Test("loadEmotes を呼ぶと全件が filteredEmotes に反映される")
+    @Test("グローバルエモートのみのとき global セクションだけが返る")
     @MainActor
-    func testLoadEmotesSetsAllEmotes() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
+    func testLoadEmotesGlobalOnly() async {
+        // 前提: グローバルエモートが 2 件のみ
+        let (_, _, viewModel) = await makeEnvironment(
+            globalEmotes: [.グローバルエモートLUL, .グローバルエモートPogChamp]
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        #expect(viewModel.filteredEmotes.count == 3)
+        // 検証: global セクション 1 つ、エモート 2 件
+        #expect(viewModel.filteredSections.count == 1)
+        #expect(viewModel.filteredSections.first?.kind == .global)
+        #expect(viewModel.filteredSections.first?.emotes.count == 2)
     }
 
-    @Test("エモートが空の場合は filteredEmotes も空になる")
+    @Test("エモートが空の場合は filteredSections も空になる")
     @MainActor
     func testLoadEmotesEmpty() async {
-        // 前提: API がエモートを 0 件返す状態（stubbedEmotes: []）
-        // loadEmotes() 内で fetchGlobalEmotes() を await するため stubbedEmotes を設定する
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
-        let viewModel = EmotePickerViewModel(emoteStore: store)
+        // 前提: すべてのエモートが空
+        let (_, _, viewModel) = await makeEnvironment()
+
         await viewModel.loadEmotes()
 
-        // 検証: エモートが存在しない場合 filteredEmotes は空
-        #expect(viewModel.filteredEmotes.isEmpty)
+        // 検証: セクションが空
+        #expect(viewModel.filteredSections.isEmpty)
+    }
+
+    @Test("currentBroadcasterId 指定時にチャンネルエモートが currentChannel セクションに入る")
+    @MainActor
+    func testLoadEmotesChannelEmotesInCurrentChannelSection() async {
+        // 前提: currentBroadcasterId 設定済み・チャンネルエモートあり
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            globalEmotes: [.グローバルエモートLUL],
+            currentBroadcasterId: "123456"
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: currentChannel セクションにチャンネルエモートが入る
+        let currentSection = viewModel.filteredSections.first(where: { $0.kind == .currentChannel })
+        #expect(currentSection != nil)
+        #expect(currentSection?.emotes.contains(where: { $0.id == HelixEmote.チャンネルエモートHype.id }) == true)
+    }
+
+    @Test("ownerId が currentBroadcasterId と一致するユーザーエモートは currentChannel セクションに合流する")
+    @MainActor
+    func testUserEmotesWithMatchingOwnerIdMergeIntoCurrentChannel() async {
+        // 前提: ユーザーエモートの ownerId が現在のチャンネルと同じ
+        let currentBroadcasterId = "777777"
+        let channelUserEmote = HelixEmote(
+            id: "user_ch_emote",
+            name: "チャンネルユーザーエモート",
+            format: ["static"],
+            emoteType: "subscriptions",
+            emoteSetId: "77777",
+            ownerId: currentBroadcasterId
+        )
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            userEmotes: [channelUserEmote],
+            currentBroadcasterId: currentBroadcasterId
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: currentChannel セクションに両方のエモートが含まれ、他にチャンネルセクションはない
+        let currentSection = viewModel.filteredSections.first(where: { $0.kind == .currentChannel })
+        #expect(currentSection?.emotes.contains(where: { $0.id == HelixEmote.チャンネルエモートHype.id }) == true)
+        #expect(currentSection?.emotes.contains(where: { $0.id == channelUserEmote.id }) == true)
+
+        // subscribedChannel セクションは生成されないこと
+        let subChannelSections = viewModel.filteredSections.filter {
+            if case .subscribedChannel = $0.kind { return true }
+            return false
+        }
+        #expect(subChannelSections.isEmpty)
+    }
+
+    @Test("異なる ownerId の複数ユーザーエモートはそれぞれ subscribedChannel セクションに分類される")
+    @MainActor
+    func testUserEmotesGroupedByOwnerId() async {
+        // 前提: 3 つの異なるチャンネルのユーザーエモート
+        let emoteA1 = HelixEmote(id: "a1", name: "チャンネルAエモート1", format: ["static"], emoteType: "subscriptions", emoteSetId: "1", ownerId: "aaaa")
+        let emoteA2 = HelixEmote(id: "a2", name: "チャンネルAエモート2", format: ["static"], emoteType: "subscriptions", emoteSetId: "1", ownerId: "aaaa")
+        let emoteB1 = HelixEmote(id: "b1", name: "チャンネルBエモート1", format: ["static"], emoteType: "subscriptions", emoteSetId: "2", ownerId: "bbbb")
+        let (_, _, viewModel) = await makeEnvironment(
+            userEmotes: [emoteA1, emoteA2, emoteB1]
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: チャンネル A と B で 2 つの subscribedChannel セクションが生成される
+        let subChannelSections = viewModel.filteredSections.filter {
+            if case .subscribedChannel = $0.kind { return true }
+            return false
+        }
+        #expect(subChannelSections.count == 2)
+
+        let sectionA = subChannelSections.first(where: {
+            if case .subscribedChannel(let id) = $0.kind { return id == "aaaa" }
+            return false
+        })
+        #expect(sectionA?.emotes.count == 2)
+
+        let sectionB = subChannelSections.first(where: {
+            if case .subscribedChannel(let id) = $0.kind { return id == "bbbb" }
+            return false
+        })
+        #expect(sectionB?.emotes.count == 1)
+    }
+
+    @Test("emoteType が hypetrain のエモートは hypeTrain セクションに分類される")
+    @MainActor
+    func testHypeTrainEmotesGoToHypeTrainSection() async {
+        // 前提: ハイプトレインエモートが含まれる
+        let hypeEmote = HelixEmote(
+            id: "hype_1",
+            name: "ハイプトレインエモート",
+            format: ["static"],
+            emoteType: "hypetrain",
+            ownerId: "some_channel"
+        )
+        let (_, _, viewModel) = await makeEnvironment(
+            userEmotes: [hypeEmote, .ユーザーエモート別チャンネルSub]
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: hypeTrain セクションにハイプトレインエモートが入る
+        let hypeSection = viewModel.filteredSections.first(where: { $0.kind == .hypeTrain })
+        #expect(hypeSection != nil)
+        #expect(hypeSection?.emotes.contains(where: { $0.id == hypeEmote.id }) == true)
+
+        // subscribedChannel セクションにハイプトレインエモートは含まれない
+        let subSections = viewModel.filteredSections.filter {
+            if case .subscribedChannel = $0.kind { return true }
+            return false
+        }
+        #expect(subSections.allSatisfy { !$0.emotes.contains(where: { $0.id == hypeEmote.id }) })
+    }
+
+    @Test("ownerId が nil かつ hypetrain でないエモートは other セクションに分類される")
+    @MainActor
+    func testEmotesWithNilOwnerIdGoToOtherSection() async {
+        // 前提: ownerId なしのエモート
+        let rewardEmote = HelixEmote(
+            id: "reward_1",
+            name: "チャンネルポイントエモート",
+            format: ["static"],
+            emoteType: "rewards",
+            ownerId: nil
+        )
+        let (_, _, viewModel) = await makeEnvironment(userEmotes: [rewardEmote])
+
+        await viewModel.loadEmotes()
+
+        // 検証: other セクションにエモートが入る
+        let otherSection = viewModel.filteredSections.first(where: { $0.kind == .other })
+        #expect(otherSection != nil)
+        #expect(otherSection?.emotes.contains(where: { $0.id == rewardEmote.id }) == true)
+    }
+
+    @Test("セクションの並び順は currentChannel → subscribedChannel → hypeTrain → other → global")
+    @MainActor
+    func testSectionOrdering() async {
+        // 前提: 全種類のセクションが生成される組み合わせ
+        let currentBroadcasterId = "111"
+        let hypeEmote = HelixEmote(id: "hype_1", name: "ハイプ1", format: ["static"], emoteType: "hypetrain", ownerId: "hype_ch")
+        let rewardEmote = HelixEmote(id: "reward_1", name: "リワード1", format: ["static"], emoteType: "rewards", ownerId: nil)
+        let subEmote = HelixEmote(id: "sub_1", name: "サブ1", format: ["static"], emoteType: "subscriptions", emoteSetId: "s1", ownerId: "222")
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            userEmotes: [hypeEmote, rewardEmote, subEmote],
+            globalEmotes: [.グローバルエモートLUL],
+            currentBroadcasterId: currentBroadcasterId
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: セクションが正しい順序で並ぶ（currentChannel → subscribedChannel → hypeTrain → other → global）
+        let kinds = viewModel.filteredSections.map(\.kind)
+        guard kinds.count == 5 else {
+            Issue.record("セクション数が期待値と異なります（期待: 5, 実際: \(kinds.count)）")
+            return
+        }
+        #expect(kinds[0] == .currentChannel)
+        if case .subscribedChannel = kinds[1] { } else {
+            Issue.record("2番目のセクションが subscribedChannel ではありません: \(kinds[1])")
+        }
+        #expect(kinds[2] == .hypeTrain)
+        #expect(kinds[3] == .other)
+        #expect(kinds[4] == .global)
+    }
+
+    @Test("同じ ID のエモートはセクション間で重複しない")
+    @MainActor
+    func testNoDuplicatesAcrossSections() async {
+        // 前提: channelEmotes と userEmotes に同じ ID のエモートが含まれる
+        let duplicateEmote = HelixEmote(
+            id: "dup_emote",
+            name: "重複エモート",
+            format: ["static"],
+            emoteType: "subscriptions",
+            emoteSetId: "1234",
+            ownerId: "other_channel"
+        )
+        let channelDuplicate = HelixEmote(
+            id: "dup_emote",  // 同じ ID
+            name: "重複エモート",
+            format: ["static"],
+            emoteType: "subscriptions"
+        )
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [channelDuplicate],
+            userEmotes: [duplicateEmote],
+            currentBroadcasterId: "999"
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: 全セクションを通じてエモートIDが重複しない
+        let allEmoteIds = viewModel.filteredSections.flatMap(\.emotes).map(\.id)
+        let uniqueIds = Set(allEmoteIds)
+        #expect(allEmoteIds.count == uniqueIds.count)
     }
 
     // MARK: - searchQuery フィルタリング
 
-    @Test("searchQuery を設定すると名前で絞り込まれる")
+    @Test("searchQuery を設定するとすべてのセクションを横断的に絞り込める")
     @MainActor
-    func testSearchQueryFiltersEmotes() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
-
-        let viewModel = EmotePickerViewModel(emoteStore: store)
+    func testSearchQueryFiltersAcrossSections() async {
+        // 前提: チャンネルエモートとグローバルエモートが混在
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            globalEmotes: [.グローバルエモートLUL, .グローバルエモートPogChamp],
+            currentBroadcasterId: "111"
+        )
         await viewModel.loadEmotes()
 
-        // "Pog" で検索すると PogChamp のみ返る
-        viewModel.searchQuery = "Pog"
+        // "LUL" で検索するとグローバルセクションのみ残る
+        viewModel.searchQuery = "LUL"
 
-        #expect(viewModel.filteredEmotes.count == 1)
-        #expect(viewModel.filteredEmotes.first?.name == "PogChamp")
+        #expect(viewModel.filteredSections.count == 1)
+        #expect(viewModel.filteredSections.first?.kind == .global)
+        #expect(viewModel.filteredSections.first?.emotes.count == 1)
     }
 
     @Test("searchQuery が大文字小文字を区別しない")
     @MainActor
     func testSearchQueryCaseInsensitive() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
-
-        let viewModel = EmotePickerViewModel(emoteStore: store)
+        let (_, _, viewModel) = await makeEnvironment(
+            globalEmotes: [.グローバルエモートLUL]
+        )
         await viewModel.loadEmotes()
 
         // 小文字の "lul" でも "LUL" がヒットする
         viewModel.searchQuery = "lul"
 
-        #expect(viewModel.filteredEmotes.count == 1)
-        #expect(viewModel.filteredEmotes.first?.name == "LUL")
+        #expect(viewModel.filteredSections.count == 1)
+        #expect(viewModel.filteredSections.first?.emotes.first?.name == "LUL")
     }
 
-    @Test("searchQuery を空文字にすると全件に戻る")
+    @Test("searchQuery を空文字にすると全セクションに戻る")
     @MainActor
-    func testClearSearchQueryReturnsAllEmotes() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
-
-        let viewModel = EmotePickerViewModel(emoteStore: store)
+    func testClearSearchQueryReturnsAllSections() async {
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            globalEmotes: [.グローバルエモートLUL],
+            currentBroadcasterId: "111"
+        )
         await viewModel.loadEmotes()
 
-        // 絞り込んだあと空にすると全件に戻る
         viewModel.searchQuery = "LUL"
-        #expect(viewModel.filteredEmotes.count == 1)
+        #expect(viewModel.filteredSections.count == 1)
 
         viewModel.searchQuery = ""
-        #expect(viewModel.filteredEmotes.count == 3)
+        #expect(viewModel.filteredSections.count == 2)
+    }
+
+    @Test("マッチしない searchQuery では filteredSections が空になる")
+    @MainActor
+    func testSearchQueryNoMatch() async {
+        let (_, _, viewModel) = await makeEnvironment(
+            globalEmotes: [.グローバルエモートLUL]
+        )
+        await viewModel.loadEmotes()
+
+        viewModel.searchQuery = "存在しないエモート名"
+
+        #expect(viewModel.filteredSections.isEmpty)
+    }
+
+    @Test("searchQuery でヒットしたエモートがないセクションは除外される")
+    @MainActor
+    func testEmptySectionsAreExcludedFromFilter() async {
+        // 前提: チャンネルセクションと global セクション
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            globalEmotes: [.グローバルエモートLUL],
+            currentBroadcasterId: "111"
+        )
+        await viewModel.loadEmotes()
+
+        // "配信者" で検索するとチャンネルエモートのみヒット
+        viewModel.searchQuery = "配信者"
+
+        // 検証: global セクションは除外される
+        #expect(viewModel.filteredSections.count == 1)
+        #expect(viewModel.filteredSections.first?.kind == .currentChannel)
     }
 
     @Test("日本語のエモート名でも検索できる")
     @MainActor
     func testSearchQueryWithJapanese() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
-
-        let viewModel = EmotePickerViewModel(emoteStore: store)
+        let (_, _, viewModel) = await makeEnvironment(
+            channelEmotes: [.チャンネルエモートHype],
+            currentBroadcasterId: "111"
+        )
         await viewModel.loadEmotes()
 
         viewModel.searchQuery = "配信者"
 
-        #expect(viewModel.filteredEmotes.count == 1)
-        #expect(viewModel.filteredEmotes.first?.name == "配信者エモート")
-    }
-
-    @Test("マッチしない searchQuery では filteredEmotes が空になる")
-    @MainActor
-    func testSearchQueryNoMatch() async {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-        await store.setGlobalEmotes(makeTestEmotes())
-
-        let viewModel = EmotePickerViewModel(emoteStore: store)
-        await viewModel.loadEmotes()
-
-        viewModel.searchQuery = "存在しないエモート名"
-
-        #expect(viewModel.filteredEmotes.isEmpty)
+        #expect(viewModel.filteredSections.count == 1)
+        #expect(viewModel.filteredSections.first?.emotes.first?.name == HelixEmote.チャンネルエモートHype.name)
     }
 
     // MARK: - isAvailable エモート使用可否判定
@@ -131,140 +367,172 @@ struct EmotePickerViewModelTests {
     @Test("userEmoteSets が nil の場合（USERSTATE 未受信）は全エモートが使用可能")
     @MainActor
     func testIsAvailableWhenUserEmoteSetsNil() async {
-        // 前提: USERSTATE を受信していない状態（updateUserEmoteSets を一度も呼んでいない）
-        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: USERSTATE を受信していない状態
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setGlobalEmotes([
             HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0"),
             HelixEmote(id: "2", name: "サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: USERSTATE 未受信（userEmoteSets が nil）のため全エモートが使用可能
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[1]) == true)
+        // 検証: USERSTATE 未受信のため全エモートが使用可能
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
+        #expect(allEmotes.allSatisfy { viewModel.isAvailable($0) })
     }
 
     @Test("グローバルエモート（emoteSetId: '0'）は使用可能セットに含まれる場合 true を返す")
     @MainActor
     func testIsAvailableGlobalEmote() async {
-        // 前提: USERSTATE を受信しグローバルセット "0" が含まれている
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: USERSTATE でグローバルセット "0" が含まれている
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setUserEmoteSets(Set(["0"]))
         await store.setGlobalEmotes([
             HelixEmote(id: "1", name: "LUL", format: ["static"], emoteType: "globals", emoteSetId: "0")
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: グローバルエモートは使用可能
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+        let globalSection = viewModel.filteredSections.first(where: { $0.kind == .global })
+        let lul = globalSection?.emotes.first
+        #expect(lul.map { viewModel.isAvailable($0) } == true)
     }
 
     @Test("サブスクエモートのセットIDがユーザーのセットに含まれない場合は false を返す")
     @MainActor
     func testIsAvailableSubscriptionEmoteNotSubscribed() async {
-        // 前提: グローバルセット "0" のみ保持している（未サブスク視聴者）
-        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: グローバルセット "0" のみ保持（未サブスク視聴者）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0"]))
         await store.setChannelEmotes([
             HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: サブスクしていないチャンネルのエモートは使用不可
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == false)
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
+        let subEmote = allEmotes.first(where: { $0.name == "配信者サブスクエモート" })
+        #expect(subEmote.map { viewModel.isAvailable($0) } == false)
     }
 
     @Test("サブスクエモートのセットIDがユーザーのセットに含まれる場合は true を返す")
     @MainActor
     func testIsAvailableSubscriptionEmoteSubscribed() async {
-        // 前提: チャンネルのエモートセット "12345" を保持している（サブスク済み視聴者）
-        // setGlobalEmotes を先に呼んで isGlobalLoaded=true にし、API 呼び出しをスキップする
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: チャンネルのエモートセット "12345" を保持（サブスク済み視聴者）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0", "12345"]))
         await store.setChannelEmotes([
             HelixEmote(id: "2", name: "配信者サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "12345")
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: サブスクしているチャンネルのエモートは使用可能
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
+        let subEmote = allEmotes.first(where: { $0.name == "配信者サブスクエモート" })
+        #expect(subEmote.map { viewModel.isAvailable($0) } == true)
     }
 
     @Test("emoteSetId が nil のエモートは常に使用可能を返す")
     @MainActor
     func testIsAvailableEmoteWithNilEmoteSetId() async {
-        // 前提: emoteSetId が nil のエモート（API レスポンスに emote_set_id が含まれない場合）
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setUserEmoteSets(Set(["0"]))
         await store.setGlobalEmotes([
             HelixEmote(id: "3", name: "emoteSetIdなし", format: ["static"], emoteType: nil, emoteSetId: nil)
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: emoteSetId 不明なエモートは安全側に倒して使用可能
-        #expect(viewModel.isAvailable(viewModel.filteredEmotes[0]) == true)
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
+        let emote = allEmotes.first(where: { $0.name == "emoteSetIdなし" })
+        #expect(emote.map { viewModel.isAvailable($0) } == true)
     }
-
-    // MARK: - ユーザーエモート使用可否判定
 
     @Test("ユーザーエモートは emoteSetId が userEmoteSets に含まれなくても常に使用可能")
     @MainActor
     func testUserEmoteIsAlwaysAvailable() async throws {
-        // 前提: USERSTATE はグローバルセット "0" のみ（別チャンネルのセットは未保有）
-        // しかし /helix/chat/emotes/user から取得したエモートはサブスク済みのため使用可能
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: USERSTATE はグローバルセット "0" のみ、/helix/chat/emotes/user から取得済み
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0"]))
         await store.setUserEmotes([
-            HelixEmote(id: "user_sub_1", name: "別チャンネルSub", format: ["static"], emoteType: "subscriptions", emoteSetId: "999999")
+            HelixEmote(id: "user_sub_1", name: "別チャンネルSub", format: ["static"], emoteType: "subscriptions", emoteSetId: "999999", ownerId: "other")
         ])
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: ユーザーエモートは userEmoteSets に関係なく使用可能
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
         let targetEmote = try #require(
-            viewModel.filteredEmotes.first(where: { $0.name == "別チャンネルSub" }),
-            "テスト対象エモートが filteredEmotes に見つかりません"
+            allEmotes.first(where: { $0.name == "別チャンネルSub" }),
+            "テスト対象エモートが filteredSections に見つかりません"
         )
+        // 検証: userEmoteIds に含まれるため使用可能
         #expect(viewModel.isAvailable(targetEmote) == true)
     }
 
     @Test("ユーザーエモートでないチャンネルエモートは従来通り emoteSetId で判定する")
     @MainActor
     func testNonUserEmoteUsesEmoteSetIdCheck() async throws {
-        // 前提: チャンネルエモートだが userEmotes には含まれていない（未サブスク）
-        // グローバルセット "0" のみ保持
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        // 前提: チャンネルエモートだが userEmotes に含まれていない（未サブスク）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setGlobalEmotes([])
         await store.setUserEmoteSets(Set(["0"]))
         await store.setChannelEmotes([
             HelixEmote(id: "ch_unsub", name: "未サブスクエモート", format: ["static"], emoteType: "subscriptions", emoteSetId: "55555")
         ])
-        // ユーザーエモートは空（このチャンネルにはサブスクしていない）
+        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil,
+        )
 
-        let viewModel = EmotePickerViewModel(emoteStore: store)
         await viewModel.loadEmotes()
 
-        // 検証: ユーザーエモートでないエモートは emoteSetId チェックが適用される
+        let allEmotes = viewModel.filteredSections.flatMap(\.emotes)
         let targetEmote = try #require(
-            viewModel.filteredEmotes.first(where: { $0.name == "未サブスクエモート" }),
-            "テスト対象エモートが filteredEmotes に見つかりません"
+            allEmotes.first(where: { $0.name == "未サブスクエモート" }),
+            "テスト対象エモートが filteredSections に見つかりません"
         )
+        // 検証: ユーザーエモートでないためemoteSetId チェックが適用される
         #expect(viewModel.isAvailable(targetEmote) == false)
     }
 }

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -60,6 +60,45 @@ struct EmotePickerViewModelTests {
         #expect(subscribedSection?.title == "テストチャンネル")
     }
 
+    @Test("エモートセット更新後にセクションタイトルが displayName に更新される")
+    @MainActor
+    func testRefreshSectionsUpdatesDisplayNamesOnEmoteSetUpdate() async throws {
+        // 前提: ownerId "99999" を持つユーザーエモート、モック API が displayName "更新チャンネル" を返す
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            HelixUserData(id: "99999", login: "update_ch", displayName: "更新チャンネル", profileImageUrl: nil)
+        ])
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+
+        // 初回ロード（ユーザーエモートなし）
+        await viewModel.loadEmotes()
+        #expect(viewModel.filteredSections.isEmpty)
+
+        // observer タスクを開始し、waitForNextUserEmoteSetsUpdate() に到達するまで yield する
+        let observeTask = Task { await viewModel.observeUserEmoteSetsUpdates() }
+        for _ in 0..<5 { await Task.yield() }
+
+        // エモートセット更新をシミュレート（新たにユーザーエモートが追加される）
+        await store.setUserEmotes([
+            HelixEmote(id: "new_emote", name: "newEmote", format: ["static"], emoteType: "subscriptions", emoteSetId: "888", ownerId: "99999")
+        ])
+        await store.notifyUserEmoteSetsUpdatedForTest()
+
+        // 更新処理（refreshSections + displayName fetch）が完了するまで待つ
+        try await Task.sleep(for: .milliseconds(100))
+        observeTask.cancel()
+
+        // 検証: 新しい subscribedChannel セクションが displayName で表示される
+        let subscribedSection = viewModel.filteredSections.first { $0.kind == .subscribedChannel(ownerId: "99999") }
+        #expect(subscribedSection?.title == "更新チャンネル")
+    }
+
     @Test("グローバルエモートのみのとき global セクションだけが返る")
     @MainActor
     func testLoadEmotesGlobalOnly() async {

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -34,6 +34,32 @@ struct EmotePickerViewModelTests {
 
     // MARK: - loadEmotes / セクション構築
 
+    @Test("loadEmotes はセクション構築前にオーナーIDの表示名をフェッチしてセクションタイトルに反映する")
+    @MainActor
+    func testLoadEmotesPrefetchesDisplayNames() async {
+        // 前提: ownerId "12345" を持つユーザーエモート、モック API が displayName "テストチャンネル" を返す
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            HelixUserData(id: "12345", login: "test_ch", displayName: "テストチャンネル", profileImageUrl: nil)
+        ])
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        await store.setUserEmotes([
+            HelixEmote(id: "emote1", name: "testEmote", format: ["static"], emoteType: "subscriptions", emoteSetId: "999", ownerId: "12345")
+        ])
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: subscribedChannel セクションのタイトルが ownerId でなく displayName になっている
+        let subscribedSection = viewModel.filteredSections.first { $0.kind == .subscribedChannel(ownerId: "12345") }
+        #expect(subscribedSection?.title == "テストチャンネル")
+    }
+
     @Test("グローバルエモートのみのとき global セクションだけが返る")
     @MainActor
     func testLoadEmotesGlobalOnly() async {

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -11,19 +11,24 @@ struct EmotePickerViewModelTests {
     // MARK: - テストヘルパー
 
     /// テスト用エモートストアと ProfileImageStore を含む環境を生成する
+    ///
+    /// - Parameter profileImageUsers: ProfileImageStore モックが返すユーザーデータ（subscribedChannel セクションに displayName が必要な場合に指定）
     @MainActor
     private func makeEnvironment(
         channelEmotes: [HelixEmote] = [],
         userEmotes: [HelixEmote] = [],
         globalEmotes: [HelixEmote] = [],
-        currentBroadcasterId: String? = nil
+        currentBroadcasterId: String? = nil,
+        profileImageUsers: [HelixUserData] = []
     ) async -> (store: EmoteStore, profileImageStore: ProfileImageStore, viewModel: EmotePickerViewModel) {
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
         await store.setChannelEmotes(channelEmotes)
         await store.setUserEmotes(userEmotes)
         await store.setGlobalEmotes(globalEmotes)
 
-        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers(profileImageUsers)
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
@@ -102,9 +107,13 @@ struct EmotePickerViewModelTests {
     @Test("USERSTATE のみ更新されてもセクションは再構築されない（エモートデータが変わっていない場合）")
     @MainActor
     func testUserStateOnlyUpdateDoesNotRebuildSections() async throws {
-        // 前提: subscribedChannel セクションが 1 つある状態
+        // 前提: subscribedChannel セクションが 1 つある状態（ownerId "11111" の displayName を設定）
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            HelixUserData(id: "11111", login: "sub_ch", displayName: "サブチャンネル11111", profileImageUrl: nil)
+        ])
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
-        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
@@ -169,7 +178,12 @@ struct EmotePickerViewModelTests {
     func testStaleRefreshDoesNotOverwriteNewerResult() async throws {
         // 前提: 初回は空、その後エモートが追加される
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
-        let profileImageStore = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+        let mockClient = MockProfileImageAPIClient()
+        // ownerId "77777" の displayName を設定して subscribedChannel セクションが作られるようにする
+        await mockClient.setUsers([
+            HelixUserData(id: "77777", login: "レースチャンネル", displayName: "レースチャンネル", profileImageUrl: nil)
+        ])
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
@@ -286,7 +300,11 @@ struct EmotePickerViewModelTests {
         let emoteA2 = HelixEmote(id: "a2", name: "チャンネルAエモート2", format: ["static"], emoteType: "subscriptions", emoteSetId: "1", ownerId: "aaaa")
         let emoteB1 = HelixEmote(id: "b1", name: "チャンネルBエモート1", format: ["static"], emoteType: "subscriptions", emoteSetId: "2", ownerId: "bbbb")
         let (_, _, viewModel) = await makeEnvironment(
-            userEmotes: [emoteA1, emoteA2, emoteB1]
+            userEmotes: [emoteA1, emoteA2, emoteB1],
+            profileImageUsers: [
+                HelixUserData(id: "aaaa", login: "channel_a", displayName: "チャンネルA", profileImageUrl: nil),
+                HelixUserData(id: "bbbb", login: "channel_b", displayName: "チャンネルB", profileImageUrl: nil)
+            ]
         )
 
         await viewModel.loadEmotes()
@@ -375,7 +393,10 @@ struct EmotePickerViewModelTests {
             channelEmotes: [.チャンネルエモートHype],
             userEmotes: [hypeEmote, rewardEmote, subEmote],
             globalEmotes: [.グローバルエモートLUL],
-            currentBroadcasterId: currentBroadcasterId
+            currentBroadcasterId: currentBroadcasterId,
+            profileImageUsers: [
+                HelixUserData(id: "222", login: "sub_channel", displayName: "サブチャンネル", profileImageUrl: nil)
+            ]
         )
 
         await viewModel.loadEmotes()
@@ -699,5 +720,75 @@ struct EmotePickerViewModelTests {
         )
         // 検証: ユーザーエモートでないためemoteSetId チェックが適用される
         #expect(viewModel.isAvailable(targetEmote) == false)
+    }
+
+    // MARK: - ownerId の異常値ハンドリング
+
+    @Test("ownerId が空文字のユーザーエモートは global セクションに分類され subscribedChannel セクションは作成されない")
+    @MainActor
+    func testEmptyOwnerIdEmoteGoesToGlobalSection() async {
+        // 前提: ownerId が空文字（Twitch API が "" を返す場合）のエモート
+        let emptyOwnerEmote = HelixEmote(
+            id: "emote_empty_owner",
+            name: "空オーナーエモート",
+            format: ["static"],
+            emoteType: "subscriptions",
+            emoteSetId: "999",
+            ownerId: ""
+        )
+        let (_, _, viewModel) = await makeEnvironment(userEmotes: [emptyOwnerEmote])
+
+        await viewModel.loadEmotes()
+
+        // 検証: subscribedChannel セクションが作成されないこと（空文字 ownerId で named section を作らない）
+        let subscribedSection = viewModel.filteredSections.first {
+            if case .subscribedChannel = $0.kind { return true }
+            return false
+        }
+        #expect(subscribedSection == nil)
+
+        // 検証: emote が global セクションに含まれること
+        let globalSection = viewModel.filteredSections.first(where: { $0.kind == .global })
+        #expect(globalSection?.emotes.contains(where: { $0.id == emptyOwnerEmote.id }) == true)
+    }
+
+    @Test("API にユーザーが存在しない ownerId のエモートは global セクションに分類される（数字 ID のセクションを作らない）")
+    @MainActor
+    func testUnresolvableOwnerIdGoesToGlobalSection() async {
+        // 前提: ownerId "784555479" を持つエモート、モック API がユーザーを返さない
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([]) // API はユーザーを返さない（存在しない broadcaster ID）
+
+        // stubbedEmotes: [] でグローバルエモートエンドポイントが空配列を返すように設定
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+        await store.setUserEmotes([
+            HelixEmote(
+                id: "emote_unknown_owner",
+                name: "不明オーナーエモート",
+                format: ["static"],
+                emoteType: "subscriptions",
+                emoteSetId: "777",
+                ownerId: "784555479"
+            )
+        ])
+        let profileImageStore = ProfileImageStore(apiClient: mockClient)
+        let viewModel = EmotePickerViewModel(
+            emoteStore: store,
+            profileImageStore: profileImageStore,
+            currentBroadcasterId: nil
+        )
+
+        await viewModel.loadEmotes()
+
+        // 検証: subscribedChannel セクションが作成されないこと
+        let subscribedSection = viewModel.filteredSections.first {
+            if case .subscribedChannel = $0.kind { return true }
+            return false
+        }
+        #expect(subscribedSection == nil)
+
+        // 検証: emote が global セクションに含まれること（数字 ID のセクションに隔離されない）
+        let globalSection = viewModel.filteredSections.first(where: { $0.kind == .global })
+        #expect(globalSection?.emotes.contains(where: { $0.id == "emote_unknown_owner" }) == true)
     }
 }

--- a/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
+++ b/Tests/TwitchChatTests/EmotePickerViewModelTests.swift
@@ -5,39 +5,35 @@ import Foundation
 import Testing
 @testable import TwitchChat
 
-@Suite("EmotePickerViewModelTests")
-struct EmotePickerViewModelTests {
+/// テスト用エモートストアと ProfileImageStore を含む環境を生成する
+@MainActor
+private func makeEnvironment(
+    channelEmotes: [HelixEmote] = [],
+    userEmotes: [HelixEmote] = [],
+    globalEmotes: [HelixEmote] = [],
+    currentBroadcasterId: String? = nil,
+    profileImageUsers: [HelixUserData] = []
+) async -> (store: EmoteStore, profileImageStore: ProfileImageStore, viewModel: EmotePickerViewModel) {
+    let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
+    await store.setChannelEmotes(channelEmotes)
+    await store.setUserEmotes(userEmotes)
+    await store.setGlobalEmotes(globalEmotes)
 
-    // MARK: - テストヘルパー
+    let mockClient = MockProfileImageAPIClient()
+    await mockClient.setUsers(profileImageUsers)
+    let profileImageStore = ProfileImageStore(apiClient: mockClient)
+    let viewModel = EmotePickerViewModel(
+        emoteStore: store,
+        profileImageStore: profileImageStore,
+        currentBroadcasterId: currentBroadcasterId
+    )
+    return (store, profileImageStore, viewModel)
+}
 
-    /// テスト用エモートストアと ProfileImageStore を含む環境を生成する
-    ///
-    /// - Parameter profileImageUsers: ProfileImageStore モックが返すユーザーデータ（subscribedChannel セクションに displayName が必要な場合に指定）
-    @MainActor
-    private func makeEnvironment(
-        channelEmotes: [HelixEmote] = [],
-        userEmotes: [HelixEmote] = [],
-        globalEmotes: [HelixEmote] = [],
-        currentBroadcasterId: String? = nil,
-        profileImageUsers: [HelixUserData] = []
-    ) async -> (store: EmoteStore, profileImageStore: ProfileImageStore, viewModel: EmotePickerViewModel) {
-        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote(stubbedEmotes: []))
-        await store.setChannelEmotes(channelEmotes)
-        await store.setUserEmotes(userEmotes)
-        await store.setGlobalEmotes(globalEmotes)
+// MARK: - セクション構築テスト
 
-        let mockClient = MockProfileImageAPIClient()
-        await mockClient.setUsers(profileImageUsers)
-        let profileImageStore = ProfileImageStore(apiClient: mockClient)
-        let viewModel = EmotePickerViewModel(
-            emoteStore: store,
-            profileImageStore: profileImageStore,
-            currentBroadcasterId: currentBroadcasterId
-        )
-        return (store, profileImageStore, viewModel)
-    }
-
-    // MARK: - loadEmotes / セクション構築
+@Suite("EmotePickerViewModel - セクション構築")
+struct EmotePickerViewModelSectionTests {
 
     @Test("loadEmotes はセクション構築前にオーナーIDの表示名をフェッチしてセクションタイトルに反映する")
     @MainActor
@@ -447,8 +443,12 @@ struct EmotePickerViewModelTests {
         let uniqueIds = Set(allEmoteIds)
         #expect(allEmoteIds.count == uniqueIds.count)
     }
+}
 
-    // MARK: - searchQuery フィルタリング
+// MARK: - 検索フィルタリングテスト
+
+@Suite("EmotePickerViewModel - 検索フィルタリング")
+struct EmotePickerViewModelFilterTests {
 
     @Test("searchQuery を設定するとすべてのセクションを横断的に絞り込める")
     @MainActor
@@ -547,8 +547,12 @@ struct EmotePickerViewModelTests {
         #expect(viewModel.filteredSections.count == 1)
         #expect(viewModel.filteredSections.first?.emotes.first?.name == HelixEmote.チャンネルエモートHype.name)
     }
+}
 
-    // MARK: - isAvailable エモート使用可否判定
+// MARK: - エモート使用可否判定・異常値ハンドリングテスト
+
+@Suite("EmotePickerViewModel - エモート使用可否判定")
+struct EmotePickerViewModelAvailabilityTests {
 
     @Test("userEmoteSets が nil の場合（USERSTATE 未受信）は全エモートが使用可能")
     @MainActor
@@ -563,7 +567,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -586,7 +590,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -610,7 +614,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -634,7 +638,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -656,7 +660,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -680,7 +684,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -708,7 +712,7 @@ struct EmotePickerViewModelTests {
         let viewModel = EmotePickerViewModel(
             emoteStore: store,
             profileImageStore: profileImageStore,
-            currentBroadcasterId: nil,
+            currentBroadcasterId: nil
         )
 
         await viewModel.loadEmotes()
@@ -721,8 +725,6 @@ struct EmotePickerViewModelTests {
         // 検証: ユーザーエモートでないためemoteSetId チェックが適用される
         #expect(viewModel.isAvailable(targetEmote) == false)
     }
-
-    // MARK: - ownerId の異常値ハンドリング
 
     @Test("ownerId が空文字のユーザーエモートは global セクションに分類され subscribedChannel セクションは作成されない")
     @MainActor

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -666,4 +666,70 @@ struct EmoteStoreTests {
         // 検証: リセット後はスナップショットが空
         #expect(snapshot.isEmpty)
     }
+
+    // MARK: - channelEmotesSnapshot
+
+    @Test("channelEmotesSnapshot は設定済みチャンネルエモートを返す")
+    func testChannelEmotesSnapshotReturnsCurrentEmotes() async {
+        // 前提: チャンネルエモートを直接設定済み
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setChannelEmotes([.チャンネルエモートHype])
+
+        let snapshot = await store.channelEmotesSnapshot()
+
+        // 検証: 設定したチャンネルエモートが全件返る
+        #expect(snapshot.count == 1)
+        #expect(snapshot.first?.id == HelixEmote.チャンネルエモートHype.id)
+    }
+
+    @Test("channelEmotesSnapshot はチャンネルエモートが未設定の場合に空配列を返す")
+    func testChannelEmotesSnapshotEmpty() async {
+        // 前提: チャンネルエモートが設定されていない
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        let snapshot = await store.channelEmotesSnapshot()
+
+        // 検証: チャンネルエモート未設定のため空配列
+        #expect(snapshot.isEmpty)
+    }
+
+    @Test("channelEmotesSnapshot は resetChannelEmotes 後に空配列を返す")
+    func testChannelEmotesSnapshotAfterReset() async {
+        // 前提: チャンネルエモートを設定してからリセット
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setChannelEmotes([.チャンネルエモートHype])
+        await store.resetChannelEmotes()
+
+        let snapshot = await store.channelEmotesSnapshot()
+
+        // 検証: リセット後はスナップショットが空
+        #expect(snapshot.isEmpty)
+    }
+
+    // MARK: - globalEmotesSnapshot
+
+    @Test("globalEmotesSnapshot は設定済みグローバルエモートを返す")
+    func testGlobalEmotesSnapshotReturnsCurrentEmotes() async {
+        // 前提: グローバルエモートを直接設定済み
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+        await store.setGlobalEmotes([.グローバルエモートLUL, .グローバルエモートPogChamp])
+
+        let snapshot = await store.globalEmotesSnapshot()
+
+        // 検証: 設定したグローバルエモートが全件返る
+        #expect(snapshot.count == 2)
+        #expect(snapshot.contains(where: { $0.id == HelixEmote.グローバルエモートLUL.id }))
+        #expect(snapshot.contains(where: { $0.id == HelixEmote.グローバルエモートPogChamp.id }))
+    }
+
+    @Test("globalEmotesSnapshot はグローバルエモートが未設定の場合に空配列を返す")
+    func testGlobalEmotesSnapshotEmpty() async {
+        // 前提: グローバルエモートが設定されていない
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        let snapshot = await store.globalEmotesSnapshot()
+
+        // 検証: グローバルエモート未設定のため空配列
+        #expect(snapshot.isEmpty)
+    }
 }

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -63,6 +63,53 @@ actor MockProfileImageAPIClient: HelixAPIClientProtocol {
     }
 }
 
+/// フェッチを一時停止・再開できる Helix API クライアントモック（インフライト待機テスト専用）
+private actor ControllableMockAPIClient: HelixAPIClientProtocol {
+    var usersToReturn: [HelixUserData] = []
+    private var fetchContinuation: CheckedContinuation<Void, Never>?
+    /// get() が API を呼び出してブロック中の場合 true
+    private(set) var isFetching = false
+
+    func setUsers(_ users: [HelixUserData]) { usersToReturn = users }
+
+    /// ブロックしている get() 呼び出しを再開する
+    func resume() {
+        fetchContinuation?.resume()
+        fetchContinuation = nil
+    }
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        // 最初の呼び出しは resume() が来るまでブロックする
+        isFetching = true
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            fetchContinuation = cont
+        }
+        isFetching = false
+        let requestedIds = queryItems?.filter { $0.name == "id" }.compactMap(\.value) ?? []
+        let filtered = usersToReturn.filter { requestedIds.contains($0.id) }
+        guard let result = HelixUsersResponse(data: filtered) as? T else {
+            throw URLError(.badServerResponse)
+        }
+        return result
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T { throw URLError(.badServerResponse) }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws { throw URLError(.badServerResponse) }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws { throw URLError(.badServerResponse) }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        throw URLError(.badServerResponse)
+    }
+}
+
 // MARK: - テストデータファクトリ
 
 /// テスト用ユーザーデータを生成する
@@ -444,5 +491,39 @@ struct ProfileImageStoreTests {
         store.clear()
 
         #expect(store.login(for: "111111") == nil)
+    }
+
+    // MARK: - インフライト ID の待機
+
+    @Test("フェッチ中の ID を再要求すると完了まで待機して displayName を取得できる")
+    func testFetchUsersWaitsForInflightAndReturnsDisplayName() async {
+        // 前提: モックは最初の get() 呼び出しを resume() されるまでブロックする
+        let mockClient = ControllableMockAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "784555479", login: "yoshiox_ch", displayName: "よしおっくす")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        // バックグラウンドでフェッチ開始（モックがブロックするので API 呼び出しで停止する）
+        let backgroundTask = Task { await store.fetchUsers(userIds: ["784555479"]) }
+
+        // バックグラウンドタスクが API を呼ぶ（= inFlightUserIds に追加される）まで待つ
+        while !(await mockClient.isFetching) { await Task.yield() }
+
+        // モックを解放するタスク（デッドロック防止のため並行実行）
+        let resumeTask = Task {
+            await Task.yield()
+            await mockClient.resume()
+        }
+
+        // 同じ ID を再要求する
+        // 現行実装: インフライト ID をスキップして即座に返る（displayName は nil）
+        // 修正後: インフライト完了を待ってから返る（displayName は "よしおっくす"）
+        await store.fetchUsers(userIds: ["784555479"])
+
+        // この時点で displayName が確実に取得できていること
+        #expect(store.displayName(for: "784555479") == "よしおっくす")
+
+        _ = await (backgroundTask.value, resumeTask.value)
     }
 }

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -336,4 +336,60 @@ struct ProfileImageStoreTests {
         #expect(store.profileImageUrl(forLogin: "yoshiox") == nil)
         #expect(store.userId(forLogin: "yoshiox") == nil)
     }
+
+    // MARK: - displayName キャッシュ
+
+    @Test("fetchUsers 後に displayName(for:) がユーザーの表示名を返す")
+    func testDisplayNameIsStoredAfterFetch() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", login: "shroud", displayName: "Shroud")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["111111"])
+
+        // 検証: フェッチ後に displayName が取得できる
+        #expect(store.displayName(for: "111111") == "Shroud")
+    }
+
+    @Test("fetchUsers(logins:) 後にも displayName(for:) が表示名を返す")
+    func testDisplayNameIsStoredAfterFetchByLogin() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "222222", login: "pokimane", displayName: "Pokimane")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(logins: ["pokimane"])
+
+        // 検証: ログイン名でフェッチした場合も displayName が取得できる
+        #expect(store.displayName(for: "222222") == "Pokimane")
+    }
+
+    @Test("displayName(for:) は未フェッチのユーザーID に対して nil を返す")
+    func testDisplayNameReturnsNilForUnknownUser() {
+        let mockClient = MockProfileImageAPIClient()
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        // 検証: 未取得ユーザーは nil
+        #expect(store.displayName(for: "999999") == nil)
+    }
+
+    @Test("clear() 後は displayName も nil になる")
+    func testDisplayNameClearedAfterClear() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", login: "shroud", displayName: "Shroud")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["111111"])
+        #expect(store.displayName(for: "111111") == "Shroud")
+
+        store.clear()
+
+        // 検証: クリア後は displayName も nil
+        #expect(store.displayName(for: "111111") == nil)
+    }
 }

--- a/Tests/TwitchChatTests/ProfileImageStoreTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStoreTests.swift
@@ -392,4 +392,57 @@ struct ProfileImageStoreTests {
         // 検証: クリア後は displayName も nil
         #expect(store.displayName(for: "111111") == nil)
     }
+
+    // MARK: - login(for:) - userId からログイン名取得
+
+    @Test("fetchUsers(userIds:) 後に login(for:) でログイン名を取得できる")
+    func testLoginForUserIdAfterFetch() async {
+        // 前提: userId "784555479" のユーザーを API が返す
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "784555479", login: "yoshiox_ch", displayName: "よしおっくす", profileImageUrl: nil)
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(userIds: ["784555479"])
+
+        // 検証: userId → login が取得できる
+        #expect(store.login(for: "784555479") == "yoshiox_ch")
+    }
+
+    @Test("未フェッチの userId に対して login(for:) は nil を返す")
+    func testLoginForUserIdReturnsNilWhenNotFetched() {
+        let store = ProfileImageStore(apiClient: MockProfileImageAPIClient())
+
+        #expect(store.login(for: "784555479") == nil)
+    }
+
+    @Test("fetchUsers(logins:) 後も login(for:) でログイン名を取得できる")
+    func testLoginForUserIdAfterLoginFetch() async {
+        // login でフェッチした場合も userId → login マッピングが作られること
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "537206155", login: "another_ch", displayName: "AnotherChannel", profileImageUrl: nil)
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+
+        await store.fetchUsers(logins: ["another_ch"])
+
+        #expect(store.login(for: "537206155") == "another_ch")
+    }
+
+    @Test("clear() 後は login(for:) も nil になる")
+    func testLoginClearedAfterClear() async {
+        let mockClient = MockProfileImageAPIClient()
+        await mockClient.setUsers([
+            makeHelixUser(id: "111111", login: "shroud", displayName: "Shroud")
+        ])
+        let store = ProfileImageStore(apiClient: mockClient)
+        await store.fetchUsers(userIds: ["111111"])
+        #expect(store.login(for: "111111") == "shroud")
+
+        store.clear()
+
+        #expect(store.login(for: "111111") == nil)
+    }
 }


### PR DESCRIPTION
## Summary

- `EmotePickerSection` モデルを新規追加し、`currentChannel` / `subscribedChannel` / `hypeTrain` / `other` / `global` の 5 種別でエモートをセクション分類する
- `EmotePickerViewModel` をセクション対応に全面改修し、`buildSections` / `classifyEmotes` / `assembleSections` の 3 メソッドに分離してロジックを整理する
- `EmotePickerView` を `LazyVGrid + pinnedViews sectionHeaders` によるセクション表示 UI に変更し、チャンネルアイコン付きヘッダーを追加する
- `EmoteStore` に `channelEmotesSnapshot` / `globalEmotesSnapshot` を追加する
- `ProfileImageStore` に `displayName` キャッシュを追加し、セクションヘッダーのチャンネル表示名取得に使用する
- `ProfileImageStore` を `ContentView → ChatDetailView → ChatInputBar` の依存チェーンで `EmotePickerView` まで受け渡す

## セクション表示順

1. **このチャンネル** — チャンネルエモート + `ownerId == currentBroadcasterId` のユーザーエモート
2. **購読中の他チャンネル** — `ownerId != nil` のユーザーエモートを `ownerId` でグルーピング（API 取得順）
3. **HYPE** — `emoteType == "hypetrain"` のエモート（存在する場合）
4. **その他** — `ownerId == nil` かつ hypetrain 以外（存在する場合）
5. **グローバル** — グローバルエモート

## Test plan

- [ ] `swift build` でコンパイルエラーなし
- [ ] `swift test` で全テスト (85件) パス
- [ ] `swiftlint --strict` で lint 違反 0 件
- [ ] 複数チャンネルを購読しているアカウントでエモートピッカーを開き、セクション分けされて表示されることを確認
- [ ] 検索ボックスで全セクションを横断的に絞り込めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エモートピッカーがセクション表示に刷新（チャンネル／購読／HYPE／グローバル等）、見出しごとに絞り込み・空セクション除外が可能に。
  * セクション見出しにプロフィール画像と表示名を表示。グリッドレイアウトと高さ・ヘッダー固定を調整。

* **バグ修正**
  * バッジ取得中のキャンセルを正常扱いに。

* **テスト**
  * セクション構築、スナップショット、表示名キャッシュに関するテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->