### PR TITLE
feat: SwiftData スキーマ（SchemaV1）+ PersistenceActor 実装（永続化基盤 PR-2）

### DIFF
--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -220,6 +220,48 @@ struct ChatMessage: Sendable, Identifiable {
         self.isSystemNotice = original.isSystemNotice
     }
 
+    /// 永続化層からの復元用イニシャライザ（PersistedChatMessage.toDomain() から呼ぶ）
+    ///
+    /// segments は text と emotePositions から再生成する。
+    ///
+    /// - Note: このイニシャライザは Persistence 層の DTO 変換にのみ使用する
+    init(
+        id: String,
+        username: String,
+        displayName: String,
+        text: String,
+        colorHex: String?,
+        badges: [Badge],
+        emotes: [EmotePosition],
+        roomId: String?,
+        isAction: Bool,
+        receivedAt: Date,
+        replyParentMsgId: String?,
+        isOptimistic: Bool,
+        replyParentUserLogin: String?,
+        replyParentDisplayName: String?,
+        replyParentMsgBody: String?,
+        isSystemNotice: Bool
+    ) {
+        self.id = id
+        self.username = username
+        self.displayName = displayName
+        self.text = text
+        self.colorHex = colorHex
+        self.badges = badges
+        self.emotes = emotes
+        self.segments = MessageSegment.segments(from: text, emotePositions: emotes)
+        self.roomId = roomId
+        self.isAction = isAction
+        self.receivedAt = receivedAt
+        self.replyParentMsgId = replyParentMsgId
+        self.isOptimistic = isOptimistic
+        self.replyParentUserLogin = replyParentUserLogin
+        self.replyParentDisplayName = replyParentDisplayName
+        self.replyParentMsgBody = replyParentMsgBody
+        self.isSystemNotice = isSystemNotice
+    }
+
     /// システム通知メッセージを生成する
     ///
     /// モデレーションコマンドの成功・失敗等、アプリが生成する情報メッセージに使用する。

--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -232,7 +232,7 @@ struct ChatMessage: Sendable, Identifiable {
         text: String,
         colorHex: String?,
         badges: [Badge],
-        emotes: [EmotePosition],
+        emotePositions: [EmotePosition],
         roomId: String?,
         isAction: Bool,
         receivedAt: Date,
@@ -249,8 +249,8 @@ struct ChatMessage: Sendable, Identifiable {
         self.text = text
         self.colorHex = colorHex
         self.badges = badges
-        self.emotes = emotes
-        self.segments = MessageSegment.segments(from: text, emotePositions: emotes)
+        self.emotes = emotePositions
+        self.segments = MessageSegment.segments(from: text, emotePositions: emotePositions)
         self.roomId = roomId
         self.isAction = isAction
         self.receivedAt = receivedAt

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -1,0 +1,561 @@
+// PersistenceActor.swift
+// SwiftData を使った永続化処理の actor 実装
+// @ModelActor により ModelContext へのアクセスを actor 境界に閉じ、Swift 6 strict concurrency を保証する
+
+import Foundation
+import SwiftData
+
+// MARK: - PersistenceActor
+
+/// SwiftData の永続化処理を担う actor
+///
+/// `@ModelActor` マクロが `init(modelContainer:)` / `modelContext` / `modelExecutor` を自動生成する。
+/// `@Model` / `ModelContext` は actor 外部に絶対に漏らさない。戻り値は常に Sendable DTO。
+@ModelActor
+actor PersistenceActor {
+
+    // MARK: - エモート
+
+    /// 指定ユーザーのエモートを取得する
+    func loadUserEmotes(userId: String) -> [HelixEmote] {
+        let scopeRaw = EmoteScope.user(userId: userId).rawValue
+        return fetchEmotes(scopeRaw: scopeRaw)
+    }
+
+    /// 指定ユーザーのエモートを保存する（全件 upsert）
+    func saveUserEmotes(_ emotes: [HelixEmote], userId: String) throws {
+        try upsertEmotes(emotes, scope: .user(userId: userId))
+    }
+
+    /// グローバルエモートを取得する
+    func loadGlobalEmotes() -> [HelixEmote] {
+        fetchEmotes(scopeRaw: EmoteScope.global.rawValue)
+    }
+
+    /// グローバルエモートを保存する（全件 upsert）
+    func saveGlobalEmotes(_ emotes: [HelixEmote]) throws {
+        try upsertEmotes(emotes, scope: .global)
+    }
+
+    /// 指定チャンネルのエモートを取得する
+    func loadChannelEmotes(broadcasterId: String) -> [HelixEmote] {
+        let scopeRaw = EmoteScope.channel(broadcasterId: broadcasterId).rawValue
+        return fetchEmotes(scopeRaw: scopeRaw)
+    }
+
+    /// 指定チャンネルのエモートを保存する（全件 upsert）
+    func saveChannelEmotes(_ emotes: [HelixEmote], broadcasterId: String) throws {
+        try upsertEmotes(emotes, scope: .channel(broadcasterId: broadcasterId))
+    }
+
+    // MARK: - バッジ
+
+    /// 指定スコープのバッジを取得する
+    func loadBadges(scope: BadgeScope) -> [BadgeVersionSnapshot] {
+        let scopeRaw = badgeScopeRaw(scope)
+        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.map { $0.toDomain() }
+    }
+
+    /// 指定スコープのバッジを保存する（全件 upsert）
+    func saveBadges(_ badges: [BadgeVersionSnapshot], scope: BadgeScope) throws {
+        try upsertBadges(badges, scope: scope)
+    }
+
+    // MARK: - プロフィール
+
+    /// 指定ユーザーIDのプロフィールを一括取得する
+    func loadUserProfiles(userIds: [String]) -> [UserProfileSnapshot] {
+        let descriptor = FetchDescriptor<PersistedUser>(
+            predicate: #Predicate { userIds.contains($0.userId) }
+        )
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.map { $0.toDomain() }
+    }
+
+    /// ユーザープロフィールを保存する（upsert）
+    func saveUserProfiles(_ profiles: [UserProfileSnapshot]) throws {
+        for profile in profiles {
+            let userId = profile.userId
+            let descriptor = FetchDescriptor<PersistedUser>(
+                predicate: #Predicate { $0.userId == userId }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                existing.login = profile.login
+                existing.displayName = profile.displayName
+                existing.profileImageUrl = profile.profileImageUrl
+                existing.updatedAt = Date()
+            } else {
+                modelContext.insert(PersistedUser(from: profile))
+            }
+        }
+        try modelContext.save()
+    }
+
+    // MARK: - チャット履歴
+
+    /// 指定 roomId の直近メッセージを受信日時降順で取得する
+    func loadRecentMessages(roomId: String, limit: Int, before: Date?) -> [ChatMessage] {
+        let safeLimit = max(0, limit)
+        var descriptor: FetchDescriptor<PersistedChatMessage>
+        if let before {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.roomId == roomId && $0.receivedAt < before },
+                sortBy: [SortDescriptor(\.receivedAt, order: .reverse)]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.roomId == roomId },
+                sortBy: [SortDescriptor(\.receivedAt, order: .reverse)]
+            )
+        }
+        descriptor.fetchLimit = safeLimit
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toDomain() }
+    }
+
+    /// チャットメッセージを追加する（重複 id は skip、uniqueness は @Attribute(.unique) が保証）
+    func appendMessages(_ messages: [ChatMessage]) throws {
+        for message in messages {
+            let msgId = message.id
+            let descriptor = FetchDescriptor<PersistedChatMessage>(
+                predicate: #Predicate { $0.id == msgId }
+            )
+            // 既存レコードがない場合のみ insert（upsert ではなく append）
+            if (try? modelContext.fetch(descriptor).first) == nil {
+                modelContext.insert(PersistedChatMessage(from: message))
+            }
+        }
+        try modelContext.save()
+    }
+
+    /// テキスト内容でメッセージを検索する
+    func searchMessages(query: String, roomId: String?, limit: Int) -> [ChatMessage] {
+        let safeLimit = max(0, limit)
+        var descriptor: FetchDescriptor<PersistedChatMessage>
+        if let roomId {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.roomId == roomId && $0.text.localizedStandardContains(query) },
+                sortBy: [SortDescriptor(\.receivedAt, order: .reverse)]
+            )
+        } else {
+            descriptor = FetchDescriptor(
+                predicate: #Predicate { $0.text.localizedStandardContains(query) },
+                sortBy: [SortDescriptor(\.receivedAt, order: .reverse)]
+            )
+        }
+        descriptor.fetchLimit = safeLimit
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.compactMap { $0.toDomain() }
+    }
+
+    // MARK: - 画像バイナリ
+
+    /// キャッシュキーで画像バイナリを取得する
+    func loadImageData(key: ImageCacheKey) -> Data? {
+        let cacheKeyStr = imageCacheKeyRaw(key)
+        let descriptor = FetchDescriptor<PersistedImageAsset>(
+            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
+        )
+        guard let asset = try? modelContext.fetch(descriptor).first else { return nil }
+        // LRU 更新（失敗しても無視）
+        asset.lastAccessedAt = Date()
+        try? modelContext.save()
+        return asset.data
+    }
+
+    /// 画像バイナリを保存する（upsert）
+    func saveImageData(_ data: Data, key: ImageCacheKey, mime: String) throws {
+        let cacheKeyStr = imageCacheKeyRaw(key)
+        let descriptor = FetchDescriptor<PersistedImageAsset>(
+            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
+        )
+        let now = Date()
+        if let existing = try? modelContext.fetch(descriptor).first {
+            existing.data = data
+            existing.mime = mime
+            existing.lastAccessedAt = now
+        } else {
+            modelContext.insert(PersistedImageAsset(
+                cacheKey: cacheKeyStr,
+                kind: key.kind.rawValue,
+                identifier: key.identifier,
+                data: data,
+                mime: mime,
+                lastAccessedAt: now,
+                createdAt: now
+            ))
+        }
+        try modelContext.save()
+    }
+
+    // MARK: - ライフサイクル
+
+    /// ユーザー固有データを削除する（グローバル/チャンネル/バッジ/履歴/画像は保持）
+    func clearUserScoped(userId: String) {
+        let userScopeRaw = EmoteScope.user(userId: userId).rawValue
+        let emoteDescriptor = FetchDescriptor<PersistedEmote>(
+            predicate: #Predicate { $0.scope == userScopeRaw }
+        )
+        if let rows = try? modelContext.fetch(emoteDescriptor) {
+            for row in rows { modelContext.delete(row) }
+        }
+        let userDescriptor = FetchDescriptor<PersistedUser>(
+            predicate: #Predicate { $0.userId == userId }
+        )
+        if let rows = try? modelContext.fetch(userDescriptor) {
+            for row in rows { modelContext.delete(row) }
+        }
+        try? modelContext.save()
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension PersistenceActor {
+
+    /// スコープ別エモートを fetch して HelixEmote 配列に変換する
+    func fetchEmotes(scopeRaw: String) -> [HelixEmote] {
+        let descriptor = FetchDescriptor<PersistedEmote>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        return rows.map { $0.toDomain() }
+    }
+
+    /// エモートをスコープ単位で upsert する（既存を全件差し替え）
+    func upsertEmotes(_ emotes: [HelixEmote], scope: EmoteScope) throws {
+        let scopeRaw = scope.rawValue
+        let descriptor = FetchDescriptor<PersistedEmote>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let existing = (try? modelContext.fetch(descriptor)) ?? []
+        let newIds = Set(emotes.map { $0.id })
+        // 新セットに含まれない既存行を削除
+        for row in existing where !newIds.contains(row.emoteId) {
+            modelContext.delete(row)
+        }
+        let existingById = Dictionary(uniqueKeysWithValues: existing.map { ($0.emoteId, $0) })
+        let now = Date()
+        for emote in emotes {
+            let key = scope.makeKey(emoteId: emote.id)
+            if let row = existingById[emote.id] {
+                row.name = emote.name
+                row.formatRaw = emote.format.joined(separator: ",")
+                row.emoteType = emote.emoteType
+                row.emoteSetId = emote.emoteSetId
+                row.ownerId = emote.ownerId
+                row.updatedAt = now
+            } else {
+                modelContext.insert(PersistedEmote(
+                    key: key,
+                    scope: scopeRaw,
+                    emoteId: emote.id,
+                    name: emote.name,
+                    formatRaw: emote.format.joined(separator: ","),
+                    emoteType: emote.emoteType,
+                    emoteSetId: emote.emoteSetId,
+                    ownerId: emote.ownerId,
+                    updatedAt: now
+                ))
+            }
+        }
+        try modelContext.save()
+    }
+
+    /// バッジをスコープ単位で upsert する（既存を全件差し替え）
+    func upsertBadges(_ badges: [BadgeVersionSnapshot], scope: BadgeScope) throws {
+        let scopeRaw = badgeScopeRaw(scope)
+        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let existing = (try? modelContext.fetch(descriptor)) ?? []
+        let newKeys = Set(badges.map { "\(scopeRaw)|\($0.setId)|\($0.version)" })
+        for row in existing where !newKeys.contains(row.compositeKey) {
+            modelContext.delete(row)
+        }
+        let existingByKey = Dictionary(uniqueKeysWithValues: existing.map { ($0.compositeKey, $0) })
+        let now = Date()
+        for badge in badges {
+            let compositeKey = "\(scopeRaw)|\(badge.setId)|\(badge.version)"
+            if let row = existingByKey[compositeKey] {
+                row.imageUrl1x = badge.imageUrl1x
+                row.imageUrl2x = badge.imageUrl2x
+                row.imageUrl4x = badge.imageUrl4x
+                row.title = badge.title
+                row.badgeDescription = badge.description
+                row.updatedAt = now
+            } else {
+                modelContext.insert(PersistedBadgeVersion(
+                    compositeKey: compositeKey,
+                    scope: scopeRaw,
+                    setId: badge.setId,
+                    version: badge.version,
+                    imageUrl1x: badge.imageUrl1x,
+                    imageUrl2x: badge.imageUrl2x,
+                    imageUrl4x: badge.imageUrl4x,
+                    title: badge.title,
+                    badgeDescription: badge.description,
+                    updatedAt: now
+                ))
+            }
+        }
+        try modelContext.save()
+    }
+
+    /// BadgeScope をスコープ文字列に変換する
+    func badgeScopeRaw(_ scope: BadgeScope) -> String {
+        switch scope {
+        case .global:
+            return "global"
+        case .channel(let broadcasterId):
+            return "channel:\(broadcasterId)"
+        }
+    }
+
+    /// ImageCacheKey をキャッシュキー文字列に変換する
+    func imageCacheKeyRaw(_ key: ImageCacheKey) -> String {
+        "\(key.kind.rawValue):\(key.identifier)"
+    }
+}
+
+// MARK: - EmoteScope
+
+/// エモートのスコープを表す列挙型（PersistenceActor 内部で使用）
+enum EmoteScope {
+    case global
+    case channel(broadcasterId: String)
+    case user(userId: String)
+
+    /// スコープの文字列表現
+    var rawValue: String {
+        switch self {
+        case .global:
+            return "global"
+        case .channel(let broadcasterId):
+            return "channel:\(broadcasterId)"
+        case .user(let userId):
+            return "user:\(userId)"
+        }
+    }
+
+    /// スコープとエモートIDを結合した主キーを生成する
+    func makeKey(emoteId: String) -> String {
+        "\(rawValue):\(emoteId)"
+    }
+}
+
+// MARK: - ImageCacheKey.Kind Extension
+
+extension ImageCacheKey.Kind {
+    /// SwiftData 保存用の文字列表現
+    var rawValue: String {
+        switch self {
+        case .emote: return "emote"
+        case .badge: return "badge"
+        case .profile: return "profile"
+        }
+    }
+}
+
+// MARK: - DTO 変換: PersistedEmote
+
+extension PersistedEmote {
+    /// HelixEmote とスコープから PersistedEmote を生成する
+    convenience init(key: String, scope: String, from emote: HelixEmote, updatedAt: Date) {
+        self.init(
+            key: key,
+            scope: scope,
+            emoteId: emote.id,
+            name: emote.name,
+            formatRaw: emote.format.joined(separator: ","),
+            emoteType: emote.emoteType,
+            emoteSetId: emote.emoteSetId,
+            ownerId: emote.ownerId,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// HelixEmote に変換する
+    func toDomain() -> HelixEmote {
+        let format = formatRaw.isEmpty ? [] : formatRaw.split(separator: ",").map(String.init)
+        return HelixEmote(
+            id: emoteId,
+            name: name,
+            format: format,
+            emoteType: emoteType,
+            emoteSetId: emoteSetId,
+            ownerId: ownerId
+        )
+    }
+}
+
+// MARK: - DTO 変換: PersistedBadgeVersion
+
+extension PersistedBadgeVersion {
+    /// BadgeVersionSnapshot から PersistedBadgeVersion を生成する
+    convenience init(compositeKey: String, scope: String, from badge: BadgeVersionSnapshot, updatedAt: Date) {
+        self.init(
+            compositeKey: compositeKey,
+            scope: scope,
+            setId: badge.setId,
+            version: badge.version,
+            imageUrl1x: badge.imageUrl1x,
+            imageUrl2x: badge.imageUrl2x,
+            imageUrl4x: badge.imageUrl4x,
+            title: badge.title,
+            badgeDescription: badge.description,
+            updatedAt: updatedAt
+        )
+    }
+
+    /// BadgeVersionSnapshot に変換する
+    func toDomain() -> BadgeVersionSnapshot {
+        BadgeVersionSnapshot(
+            setId: setId,
+            version: version,
+            imageUrl1x: imageUrl1x,
+            imageUrl2x: imageUrl2x,
+            imageUrl4x: imageUrl4x,
+            title: title,
+            description: badgeDescription
+        )
+    }
+}
+
+// MARK: - DTO 変換: PersistedUser
+
+extension PersistedUser {
+    /// UserProfileSnapshot から PersistedUser を生成する
+    convenience init(from profile: UserProfileSnapshot) {
+        self.init(
+            userId: profile.userId,
+            login: profile.login,
+            displayName: profile.displayName,
+            profileImageUrl: profile.profileImageUrl,
+            updatedAt: Date()
+        )
+    }
+
+    /// UserProfileSnapshot に変換する
+    func toDomain() -> UserProfileSnapshot {
+        UserProfileSnapshot(
+            userId: userId,
+            login: login,
+            displayName: displayName,
+            profileImageUrl: profileImageUrl
+        )
+    }
+}
+
+// MARK: - DTO 変換: PersistedChatMessage
+
+// Badge と EmotePosition への Codable 適合（永続化層限定）
+// ドメイン層には漏らさない
+extension Badge: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        version = try container.decode(String.self, forKey: .version)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(version, forKey: .version)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case version
+    }
+}
+
+extension EmotePosition: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        emoteId = try container.decode(String.self, forKey: .emoteId)
+        startIndex = try container.decode(Int.self, forKey: .startIndex)
+        endIndex = try container.decode(Int.self, forKey: .endIndex)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(emoteId, forKey: .emoteId)
+        try container.encode(startIndex, forKey: .startIndex)
+        try container.encode(endIndex, forKey: .endIndex)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case emoteId
+        case startIndex
+        case endIndex
+    }
+}
+
+private let jsonEncoder = JSONEncoder()
+private let jsonDecoder = JSONDecoder()
+
+extension PersistedChatMessage {
+    /// ChatMessage から PersistedChatMessage を生成する
+    convenience init(from message: ChatMessage) {
+        let badgesRaw = (try? String(data: jsonEncoder.encode(message.badges), encoding: .utf8)) ?? "[]"
+        let emotesRaw = (try? String(data: jsonEncoder.encode(message.emotes), encoding: .utf8)) ?? "[]"
+        self.init(
+            id: message.id,
+            username: message.username,
+            displayName: message.displayName,
+            text: message.text,
+            colorHex: message.colorHex,
+            badgesRaw: badgesRaw,
+            emotesRaw: emotesRaw,
+            roomId: message.roomId,
+            isAction: message.isAction,
+            receivedAt: message.receivedAt,
+            replyParentMsgId: message.replyParentMsgId,
+            isOptimistic: message.isOptimistic,
+            replyParentUserLogin: message.replyParentUserLogin,
+            replyParentDisplayName: message.replyParentDisplayName,
+            replyParentMsgBody: message.replyParentMsgBody,
+            isSystemNotice: message.isSystemNotice,
+            tmiSentAt: nil,
+            senderUserId: nil
+        )
+    }
+
+    /// ChatMessage に変換する（segments は text と emotes から再生成する）
+    func toDomain() -> ChatMessage? {
+        let badges = (try? jsonDecoder.decode([Badge].self, from: Data(badgesRaw.utf8))) ?? []
+        let emotes = (try? jsonDecoder.decode([EmotePosition].self, from: Data(emotesRaw.utf8))) ?? []
+        return ChatMessage(
+            id: id,
+            username: username,
+            displayName: displayName,
+            text: text,
+            colorHex: colorHex,
+            badges: badges,
+            emotes: emotes,
+            roomId: roomId,
+            isAction: isAction,
+            receivedAt: receivedAt,
+            replyParentMsgId: replyParentMsgId,
+            isOptimistic: isOptimistic,
+            replyParentUserLogin: replyParentUserLogin,
+            replyParentDisplayName: replyParentDisplayName,
+            replyParentMsgBody: replyParentMsgBody,
+            isSystemNotice: isSystemNotice
+        )
+    }
+}
+
+// MARK: - ChatMessage.toPersistent
+
+extension ChatMessage {
+    /// PersistedChatMessage に変換する（PersistenceActor 内部でのみ使用）
+    func toPersistent() -> PersistedChatMessage {
+        PersistedChatMessage(from: self)
+    }
+}

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -76,18 +76,22 @@ actor PersistenceActor {
         return rows.map { $0.toDomain() }
     }
 
-    /// ユーザープロフィールを保存する（upsert）
+    /// ユーザープロフィールを保存する（一括 upsert）
     func saveUserProfiles(_ profiles: [UserProfileSnapshot]) throws {
+        guard !profiles.isEmpty else { return }
+        let userIds = profiles.map { $0.userId }
+        let descriptor = FetchDescriptor<PersistedUser>(
+            predicate: #Predicate { userIds.contains($0.userId) }
+        )
+        let existing = try modelContext.fetch(descriptor)
+        let existingByUserId = Dictionary(uniqueKeysWithValues: existing.map { ($0.userId, $0) })
+        let now = Date()
         for profile in profiles {
-            let userId = profile.userId
-            let descriptor = FetchDescriptor<PersistedUser>(
-                predicate: #Predicate { $0.userId == userId }
-            )
-            if let existing = try? modelContext.fetch(descriptor).first {
-                existing.login = profile.login
-                existing.displayName = profile.displayName
-                existing.profileImageUrl = profile.profileImageUrl
-                existing.updatedAt = Date()
+            if let row = existingByUserId[profile.userId] {
+                row.login = profile.login
+                row.displayName = profile.displayName
+                row.profileImageUrl = profile.profileImageUrl
+                row.updatedAt = now
             } else {
                 modelContext.insert(PersistedUser(from: profile))
             }
@@ -117,17 +121,17 @@ actor PersistenceActor {
         return rows.compactMap { $0.toDomain() }
     }
 
-    /// チャットメッセージを追加する（重複 id は skip、uniqueness は @Attribute(.unique) が保証）
+    /// チャットメッセージを追加する（既存 id は skip、一括 fetch で N+1 を回避）
     func appendMessages(_ messages: [ChatMessage]) throws {
-        for message in messages {
-            let msgId = message.id
-            let descriptor = FetchDescriptor<PersistedChatMessage>(
-                predicate: #Predicate { $0.id == msgId }
-            )
-            // 既存レコードがない場合のみ insert（upsert ではなく append）
-            if (try? modelContext.fetch(descriptor).first) == nil {
-                modelContext.insert(PersistedChatMessage(from: message))
-            }
+        guard !messages.isEmpty else { return }
+        let newIds = messages.map { $0.id }
+        let descriptor = FetchDescriptor<PersistedChatMessage>(
+            predicate: #Predicate { newIds.contains($0.id) }
+        )
+        let existing = (try? modelContext.fetch(descriptor)) ?? []
+        let existingIds = Set(existing.map { $0.id })
+        for message in messages where !existingIds.contains(message.id) {
+            modelContext.insert(PersistedChatMessage(from: message))
         }
         try modelContext.save()
     }
@@ -200,16 +204,26 @@ actor PersistenceActor {
         let emoteDescriptor = FetchDescriptor<PersistedEmote>(
             predicate: #Predicate { $0.scope == userScopeRaw }
         )
-        if let rows = try? modelContext.fetch(emoteDescriptor) {
+        do {
+            let rows = try modelContext.fetch(emoteDescriptor)
             for row in rows { modelContext.delete(row) }
+        } catch {
+            print("[PersistenceActor] clearUserScoped: ユーザーエモート fetch 失敗 userId=\(userId) error=\(error)")
         }
         let userDescriptor = FetchDescriptor<PersistedUser>(
             predicate: #Predicate { $0.userId == userId }
         )
-        if let rows = try? modelContext.fetch(userDescriptor) {
+        do {
+            let rows = try modelContext.fetch(userDescriptor)
             for row in rows { modelContext.delete(row) }
+        } catch {
+            print("[PersistenceActor] clearUserScoped: ユーザープロフィール fetch 失敗 userId=\(userId) error=\(error)")
         }
-        try? modelContext.save()
+        do {
+            try modelContext.save()
+        } catch {
+            print("[PersistenceActor] clearUserScoped: save 失敗 userId=\(userId) error=\(error)")
+        }
     }
 }
 
@@ -502,8 +516,20 @@ private let jsonDecoder = JSONDecoder()
 extension PersistedChatMessage {
     /// ChatMessage から PersistedChatMessage を生成する
     convenience init(from message: ChatMessage) {
-        let badgesRaw = (try? String(data: jsonEncoder.encode(message.badges), encoding: .utf8)) ?? "[]"
-        let emotesRaw = (try? String(data: jsonEncoder.encode(message.emotes), encoding: .utf8)) ?? "[]"
+        let badgesRaw: String
+        do {
+            badgesRaw = String(data: try jsonEncoder.encode(message.badges), encoding: .utf8) ?? "[]"
+        } catch {
+            print("[PersistenceActor] badges JSON エンコード失敗 id=\(message.id) error=\(error)")
+            badgesRaw = "[]"
+        }
+        let emotesRaw: String
+        do {
+            emotesRaw = String(data: try jsonEncoder.encode(message.emotes), encoding: .utf8) ?? "[]"
+        } catch {
+            print("[PersistenceActor] emotes JSON エンコード失敗 id=\(message.id) error=\(error)")
+            emotesRaw = "[]"
+        }
         self.init(
             id: message.id,
             username: message.username,
@@ -537,7 +563,7 @@ extension PersistedChatMessage {
             text: text,
             colorHex: colorHex,
             badges: badges,
-            emotes: emotes,
+            emotePositions: emotes,
             roomId: roomId,
             isAction: isAction,
             receivedAt: receivedAt,

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -164,7 +164,7 @@ actor PersistenceActor {
         let descriptor = FetchDescriptor<PersistedImageAsset>(
             predicate: #Predicate { $0.cacheKey == cacheKeyStr }
         )
-        guard let asset = try? modelContext.fetch(descriptor).first else { return nil }
+        guard let asset = (try? modelContext.fetch(descriptor))?.first else { return nil }
         // LRU 更新（失敗しても無視）
         asset.lastAccessedAt = Date()
         try? modelContext.save()
@@ -178,7 +178,7 @@ actor PersistenceActor {
             predicate: #Predicate { $0.cacheKey == cacheKeyStr }
         )
         let now = Date()
-        if let existing = try? modelContext.fetch(descriptor).first {
+        if let existing = (try? modelContext.fetch(descriptor))?.first {
             existing.data = data
             existing.mime = mime
             existing.lastAccessedAt = now
@@ -208,7 +208,7 @@ actor PersistenceActor {
             let rows = try modelContext.fetch(emoteDescriptor)
             for row in rows { modelContext.delete(row) }
         } catch {
-            print("[PersistenceActor] clearUserScoped: ユーザーエモート fetch 失敗 userId=\(userId) error=\(error)")
+            print("[PersistenceActor] clearUserScoped: ユーザーエモート fetch 失敗 error=\(error)")
         }
         let userDescriptor = FetchDescriptor<PersistedUser>(
             predicate: #Predicate { $0.userId == userId }
@@ -217,12 +217,12 @@ actor PersistenceActor {
             let rows = try modelContext.fetch(userDescriptor)
             for row in rows { modelContext.delete(row) }
         } catch {
-            print("[PersistenceActor] clearUserScoped: ユーザープロフィール fetch 失敗 userId=\(userId) error=\(error)")
+            print("[PersistenceActor] clearUserScoped: ユーザープロフィール fetch 失敗 error=\(error)")
         }
         do {
             try modelContext.save()
         } catch {
-            print("[PersistenceActor] clearUserScoped: save 失敗 userId=\(userId) error=\(error)")
+            print("[PersistenceActor] clearUserScoped: save 失敗 error=\(error)")
         }
     }
 }
@@ -470,13 +470,13 @@ extension PersistedUser {
 // Badge と EmotePosition への Codable 適合（永続化層限定）
 // ドメイン層には漏らさない
 extension Badge: Codable {
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         name = try container.decode(String.self, forKey: .name)
         version = try container.decode(String.self, forKey: .version)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(version, forKey: .version)
@@ -489,14 +489,14 @@ extension Badge: Codable {
 }
 
 extension EmotePosition: Codable {
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         emoteId = try container.decode(String.self, forKey: .emoteId)
         startIndex = try container.decode(Int.self, forKey: .startIndex)
         endIndex = try container.decode(Int.self, forKey: .endIndex)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(emoteId, forKey: .emoteId)
         try container.encode(startIndex, forKey: .startIndex)
@@ -510,22 +510,20 @@ extension EmotePosition: Codable {
     }
 }
 
-private let jsonEncoder = JSONEncoder()
-private let jsonDecoder = JSONDecoder()
-
 extension PersistedChatMessage {
     /// ChatMessage から PersistedChatMessage を生成する
     convenience init(from message: ChatMessage) {
+        let encoder = JSONEncoder()
         let badgesRaw: String
         do {
-            badgesRaw = String(data: try jsonEncoder.encode(message.badges), encoding: .utf8) ?? "[]"
+            badgesRaw = String(data: try encoder.encode(message.badges), encoding: .utf8) ?? "[]"
         } catch {
             print("[PersistenceActor] badges JSON エンコード失敗 id=\(message.id) error=\(error)")
             badgesRaw = "[]"
         }
         let emotesRaw: String
         do {
-            emotesRaw = String(data: try jsonEncoder.encode(message.emotes), encoding: .utf8) ?? "[]"
+            emotesRaw = String(data: try encoder.encode(message.emotes), encoding: .utf8) ?? "[]"
         } catch {
             print("[PersistenceActor] emotes JSON エンコード失敗 id=\(message.id) error=\(error)")
             emotesRaw = "[]"
@@ -554,8 +552,9 @@ extension PersistedChatMessage {
 
     /// ChatMessage に変換する（segments は text と emotes から再生成する）
     func toDomain() -> ChatMessage? {
-        let badges = (try? jsonDecoder.decode([Badge].self, from: Data(badgesRaw.utf8))) ?? []
-        let emotes = (try? jsonDecoder.decode([EmotePosition].self, from: Data(emotesRaw.utf8))) ?? []
+        let decoder = JSONDecoder()
+        let badges = (try? decoder.decode([Badge].self, from: Data(badgesRaw.utf8))) ?? []
+        let emotes = (try? decoder.decode([EmotePosition].self, from: Data(emotesRaw.utf8))) ?? []
         return ChatMessage(
             id: id,
             username: username,

--- a/Sources/TwitchChat/Persistence/PersistenceContainer.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceContainer.swift
@@ -2,17 +2,54 @@
 // PersistenceService インスタンスを束ねる Sendable ラッパー
 // DI 配線の窓口として TwitchChatApp から各ストアへ service を渡す際に使用する
 
+import Foundation
+import SwiftData
+
 /// PersistenceService インスタンスを保持する Sendable ラッパー
 ///
-/// PR-1 段階では in-memory 実装のみを提供する。
-/// 将来 SwiftData 実装が入る際は `makeOnDisk()` ファクトリを追加し、
+/// ディスク永続化が必要な場合は `makeOnDisk()` を使用し、
 /// `TwitchChatApp` の呼び出しを `(try? .makeOnDisk()) ?? .makeInMemory()` に変更する。
+/// 構築失敗時のフォールバックは呼び出し側で行う。
 struct PersistenceContainer: Sendable {
     /// 永続化サービスの実体
     let service: any PersistenceService
 
-    /// インメモリ実装で初期化する（PR-1 段階）
+    /// インメモリ実装で初期化する（テスト・フォールバック用）
     static func makeInMemory() -> PersistenceContainer {
         PersistenceContainer(service: InMemoryPersistenceService())
+    }
+
+    /// SwiftData ディスク永続化で初期化する
+    ///
+    /// Application Support 配下の SQLite ファイルにデータを保存する。
+    /// 構築に失敗した場合は呼び出し側で `makeInMemory()` にフォールバックすること。
+    ///
+    /// - Throws: ディレクトリ作成または `ModelContainer` の構築に失敗した場合
+    static func makeOnDisk() throws -> PersistenceContainer {
+        let storeURL = try defaultOnDiskStoreURL()
+        let config = ModelConfiguration(url: storeURL)
+        let container = try ModelContainer(
+            for: Schema(versionedSchema: SchemaV1.self),
+            migrationPlan: ChatSchemaMigrationPlan.self,
+            configurations: config
+        )
+        return PersistenceContainer(service: SwiftDataPersistenceService(container: container))
+    }
+
+    /// Application Support 配下の SQLite ファイル URL を返す
+    private static func defaultOnDiskStoreURL() throws -> URL {
+        let fileManager = FileManager.default
+        let base = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let bundleId = Bundle.main.bundleIdentifier ?? "TwitchChat"
+        let dir = base.appending(path: bundleId, directoryHint: .isDirectory)
+        if !fileManager.fileExists(atPath: dir.path(percentEncoded: false)) {
+            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir.appending(path: "TwitchChat.sqlite", directoryHint: .notDirectory)
     }
 }

--- a/Sources/TwitchChat/Persistence/PersistenceContainer.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceContainer.swift
@@ -47,9 +47,7 @@ struct PersistenceContainer: Sendable {
         )
         let bundleId = Bundle.main.bundleIdentifier ?? "TwitchChat"
         let dir = base.appending(path: bundleId, directoryHint: .isDirectory)
-        if !fileManager.fileExists(atPath: dir.path(percentEncoded: false)) {
-            try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
-        }
+        try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appending(path: "TwitchChat.sqlite", directoryHint: .notDirectory)
     }
 }

--- a/Sources/TwitchChat/Persistence/SchemaV1.swift
+++ b/Sources/TwitchChat/Persistence/SchemaV1.swift
@@ -1,0 +1,288 @@
+// SchemaV1.swift
+// SwiftData スキーマバージョン1の @Model クラス定義とマイグレーション計画
+// Twitch チャットアプリのエモート・チャット履歴・バッジ・ユーザー・画像を永続化する
+
+import Foundation
+import SwiftData
+
+// MARK: - PersistedEmote
+
+/// エモートの永続化モデル
+///
+/// key は "<scope>:<emoteId>" 形式で一意性を保証する。
+/// scope は "global" / "channel:<broadcasterId>" / "user:<userId>" のいずれか。
+@Model
+final class PersistedEmote {
+    /// 主キー（"<scope>:<emoteId>"）
+    @Attribute(.unique) var key: String
+    /// スコープ文字列（インデックス対象）
+    var scope: String
+    /// エモートID（Twitch エモートの一意ID）
+    var emoteId: String
+    /// エモート名
+    var name: String
+    /// format 配列をカンマ区切りで保存（例: "static,animated"）
+    var formatRaw: String
+    /// エモートタイプ（"globals", "subscriptions" 等）
+    var emoteType: String?
+    /// エモートセットID
+    var emoteSetId: String?
+    /// エモートオーナーのユーザーID
+    var ownerId: String?
+    /// 最終更新日時
+    var updatedAt: Date
+
+    #Index<PersistedEmote>([\.scope], [\.emoteSetId], [\.ownerId])
+
+    init(
+        key: String,
+        scope: String,
+        emoteId: String,
+        name: String,
+        formatRaw: String,
+        emoteType: String?,
+        emoteSetId: String?,
+        ownerId: String?,
+        updatedAt: Date
+    ) {
+        self.key = key
+        self.scope = scope
+        self.emoteId = emoteId
+        self.name = name
+        self.formatRaw = formatRaw
+        self.emoteType = emoteType
+        self.emoteSetId = emoteSetId
+        self.ownerId = ownerId
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - PersistedChannel
+
+/// チャンネルの永続化モデル（PR-2 では枠確保のみ、PR-3 以降で使用）
+@Model
+final class PersistedChannel {
+    /// 主キー（Twitch の room-id タグ）
+    @Attribute(.unique) var roomId: String
+    /// 最終更新日時
+    var updatedAt: Date
+
+    init(roomId: String, updatedAt: Date) {
+        self.roomId = roomId
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - PersistedChatMessage
+
+/// チャットメッセージの永続化モデル
+///
+/// badges と emotes は JSON 文字列で保存。segments は toDomain() 時に再生成する。
+/// tmiSentAt / senderUserId は V1 枠確保のみ（将来の軽量マイグレーション用）。
+@Model
+final class PersistedChatMessage {
+    /// 主キー（Twitch の message id または UUID）
+    @Attribute(.unique) var id: String
+    var username: String
+    var displayName: String
+    /// メッセージ本文（全文検索インデックス対象）
+    var text: String
+    var colorHex: String?
+    /// [Badge] を JSONEncoder でエンコードした文字列
+    var badgesRaw: String
+    /// [EmotePosition] を JSONEncoder でエンコードした文字列
+    var emotesRaw: String
+    /// チャンネルの room-id（インデックス対象）
+    var roomId: String?
+    var isAction: Bool
+    /// 受信日時（降順ソート・before フィルタ用、インデックス対象）
+    var receivedAt: Date
+    var replyParentMsgId: String?
+    var isOptimistic: Bool
+    var replyParentUserLogin: String?
+    var replyParentDisplayName: String?
+    var replyParentMsgBody: String?
+    var isSystemNotice: Bool
+    /// V1 枠確保（tmi-sent-ts タグのパース後に充填予定）
+    var tmiSentAt: Date?
+    /// V1 枠確保（user-id タグのパース後に充填予定）
+    var senderUserId: String?
+
+    #Index<PersistedChatMessage>([\.roomId], [\.receivedAt], [\.text])
+
+    init(
+        id: String,
+        username: String,
+        displayName: String,
+        text: String,
+        colorHex: String?,
+        badgesRaw: String,
+        emotesRaw: String,
+        roomId: String?,
+        isAction: Bool,
+        receivedAt: Date,
+        replyParentMsgId: String?,
+        isOptimistic: Bool,
+        replyParentUserLogin: String?,
+        replyParentDisplayName: String?,
+        replyParentMsgBody: String?,
+        isSystemNotice: Bool,
+        tmiSentAt: Date?,
+        senderUserId: String?
+    ) {
+        self.id = id
+        self.username = username
+        self.displayName = displayName
+        self.text = text
+        self.colorHex = colorHex
+        self.badgesRaw = badgesRaw
+        self.emotesRaw = emotesRaw
+        self.roomId = roomId
+        self.isAction = isAction
+        self.receivedAt = receivedAt
+        self.replyParentMsgId = replyParentMsgId
+        self.isOptimistic = isOptimistic
+        self.replyParentUserLogin = replyParentUserLogin
+        self.replyParentDisplayName = replyParentDisplayName
+        self.replyParentMsgBody = replyParentMsgBody
+        self.isSystemNotice = isSystemNotice
+        self.tmiSentAt = tmiSentAt
+        self.senderUserId = senderUserId
+    }
+}
+
+// MARK: - PersistedBadgeVersion
+
+/// バッジバージョンの永続化モデル
+///
+/// compositeKey は "<scopeRaw>|<setId>|<version>" 形式。
+/// description はプロトコルメソッドと衝突するため badgeDescription として保存。
+@Model
+final class PersistedBadgeVersion {
+    /// 主キー（"<scopeRaw>|<setId>|<version>"）
+    @Attribute(.unique) var compositeKey: String
+    /// スコープ文字列（"global" / "channel:<broadcasterId>"）（インデックス対象）
+    var scope: String
+    var setId: String
+    var version: String
+    var imageUrl1x: String
+    var imageUrl2x: String
+    var imageUrl4x: String
+    var title: String?
+    /// BadgeVersionSnapshot.description に対応（Swift の description と衝突回避のため命名変更）
+    var badgeDescription: String?
+    var updatedAt: Date
+
+    #Index<PersistedBadgeVersion>([\.scope])
+
+    init(
+        compositeKey: String,
+        scope: String,
+        setId: String,
+        version: String,
+        imageUrl1x: String,
+        imageUrl2x: String,
+        imageUrl4x: String,
+        title: String?,
+        badgeDescription: String?,
+        updatedAt: Date
+    ) {
+        self.compositeKey = compositeKey
+        self.scope = scope
+        self.setId = setId
+        self.version = version
+        self.imageUrl1x = imageUrl1x
+        self.imageUrl2x = imageUrl2x
+        self.imageUrl4x = imageUrl4x
+        self.title = title
+        self.badgeDescription = badgeDescription
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - PersistedUser
+
+/// ユーザープロフィールの永続化モデル
+@Model
+final class PersistedUser {
+    /// 主キー（Twitch の user-id）
+    @Attribute(.unique) var userId: String
+    /// ログイン名（インデックス対象）
+    var login: String
+    var displayName: String
+    var profileImageUrl: String?
+    var updatedAt: Date
+
+    #Index<PersistedUser>([\.login])
+
+    init(userId: String, login: String, displayName: String, profileImageUrl: String?, updatedAt: Date) {
+        self.userId = userId
+        self.login = login
+        self.displayName = displayName
+        self.profileImageUrl = profileImageUrl
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - PersistedImageAsset
+
+/// 画像バイナリの永続化モデル（BLOB は外部ファイルに分離）
+///
+/// cacheKey は "<kindRaw>:<identifier>" 形式。
+/// lastAccessedAt は LRU eviction の軸として使用する。
+@Model
+final class PersistedImageAsset {
+    /// 主キー（"<kindRaw>:<identifier>"）
+    @Attribute(.unique) var cacheKey: String
+    /// 画像種別文字列（"emote" / "badge" / "profile"）（インデックス対象）
+    var kind: String
+    var identifier: String
+    /// 画像バイナリ（外部ファイルに分離して保存）
+    @Attribute(.externalStorage) var data: Data
+    var mime: String
+    /// 最終アクセス日時（LRU eviction 用、インデックス対象）
+    var lastAccessedAt: Date
+    var createdAt: Date
+
+    #Index<PersistedImageAsset>([\.kind], [\.lastAccessedAt])
+
+    init(cacheKey: String, kind: String, identifier: String, data: Data, mime: String, lastAccessedAt: Date, createdAt: Date) {
+        self.cacheKey = cacheKey
+        self.kind = kind
+        self.identifier = identifier
+        self.data = data
+        self.mime = mime
+        self.lastAccessedAt = lastAccessedAt
+        self.createdAt = createdAt
+    }
+}
+
+// MARK: - VersionedSchema
+
+/// SwiftData スキーマバージョン1
+///
+/// 全 @Model クラスを列挙する。将来のマイグレーションで `stages` に追加する。
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier: Schema.Version { Schema.Version(1, 0, 0) }
+
+    static var models: [any PersistentModel.Type] {
+        [
+            PersistedEmote.self,
+            PersistedChannel.self,
+            PersistedChatMessage.self,
+            PersistedBadgeVersion.self,
+            PersistedUser.self,
+            PersistedImageAsset.self
+        ]
+    }
+}
+
+// MARK: - SchemaMigrationPlan
+
+/// チャットスキーマのマイグレーション計画
+///
+/// V1 単独でスタート。V1 → V2 への破壊的変更が発生した際に `stages` に追加する。
+enum ChatSchemaMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] { [SchemaV1.self] }
+    static var stages: [MigrationStage] { [] }
+}

--- a/Sources/TwitchChat/Persistence/SchemaV1.swift
+++ b/Sources/TwitchChat/Persistence/SchemaV1.swift
@@ -85,7 +85,7 @@ final class PersistedChatMessage {
     @Attribute(.unique) var id: String
     var username: String
     var displayName: String
-    /// メッセージ本文（全文検索インデックス対象）
+    /// メッセージ本文（B-tree インデックス対象、全文検索ではない）
     var text: String
     var colorHex: String?
     /// [Badge] を JSONEncoder でエンコードした文字列
@@ -108,7 +108,7 @@ final class PersistedChatMessage {
     /// V1 枠確保（user-id タグのパース後に充填予定）
     var senderUserId: String?
 
-    #Index<PersistedChatMessage>([\.roomId], [\.receivedAt], [\.text])
+    #Index<PersistedChatMessage>([\.roomId, \.receivedAt], [\.text])
 
     init(
         id: String,

--- a/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
@@ -1,0 +1,109 @@
+// SwiftDataPersistenceService.swift
+// PersistenceActor に委譲する薄いラッパー実装
+// PersistenceService プロトコルを満たし、TwitchChatApp からの DI 対象となる
+
+import Foundation
+import SwiftData
+
+/// SwiftData を使用した永続化サービス
+///
+/// `PersistenceActor` に全処理を委譲する薄いラッパー struct。
+/// 構築失敗時は呼び出し側（`PersistenceContainer.makeOnDisk()`）で catch して
+/// `InMemoryPersistenceService` にフォールバックする。
+struct SwiftDataPersistenceService: PersistenceService {
+
+    private let actor: PersistenceActor
+
+    /// 既存の ModelContainer からサービスを生成する
+    init(container: ModelContainer) {
+        self.actor = PersistenceActor(modelContainer: container)
+    }
+
+    /// ModelContainer を新規に構築してサービスを生成する
+    ///
+    /// - Parameter inMemory: `true` の場合はディスクに書き込まない（テスト用）
+    /// - Throws: `ModelContainer` の構築に失敗した場合
+    init(inMemory: Bool = false) throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: inMemory)
+        let container = try ModelContainer(
+            for: Schema(versionedSchema: SchemaV1.self),
+            migrationPlan: ChatSchemaMigrationPlan.self,
+            configurations: config
+        )
+        self.init(container: container)
+    }
+
+    // MARK: - エモート
+
+    func loadUserEmotes(userId: String) async -> [HelixEmote] {
+        await actor.loadUserEmotes(userId: userId)
+    }
+
+    func saveUserEmotes(_ emotes: [HelixEmote], userId: String) async throws {
+        try await actor.saveUserEmotes(emotes, userId: userId)
+    }
+
+    func loadGlobalEmotes() async -> [HelixEmote] {
+        await actor.loadGlobalEmotes()
+    }
+
+    func saveGlobalEmotes(_ emotes: [HelixEmote]) async throws {
+        try await actor.saveGlobalEmotes(emotes)
+    }
+
+    func loadChannelEmotes(broadcasterId: String) async -> [HelixEmote] {
+        await actor.loadChannelEmotes(broadcasterId: broadcasterId)
+    }
+
+    func saveChannelEmotes(_ emotes: [HelixEmote], broadcasterId: String) async throws {
+        try await actor.saveChannelEmotes(emotes, broadcasterId: broadcasterId)
+    }
+
+    // MARK: - バッジ・プロフィール
+
+    func loadBadges(scope: BadgeScope) async -> [BadgeVersionSnapshot] {
+        await actor.loadBadges(scope: scope)
+    }
+
+    func saveBadges(_ badges: [BadgeVersionSnapshot], scope: BadgeScope) async throws {
+        try await actor.saveBadges(badges, scope: scope)
+    }
+
+    func loadUserProfiles(userIds: [String]) async -> [UserProfileSnapshot] {
+        await actor.loadUserProfiles(userIds: userIds)
+    }
+
+    func saveUserProfiles(_ profiles: [UserProfileSnapshot]) async throws {
+        try await actor.saveUserProfiles(profiles)
+    }
+
+    // MARK: - チャット履歴
+
+    func loadRecentMessages(roomId: String, limit: Int, before: Date?) async -> [ChatMessage] {
+        await actor.loadRecentMessages(roomId: roomId, limit: limit, before: before)
+    }
+
+    func appendMessages(_ messages: [ChatMessage]) async throws {
+        try await actor.appendMessages(messages)
+    }
+
+    func searchMessages(query: String, roomId: String?, limit: Int) async -> [ChatMessage] {
+        await actor.searchMessages(query: query, roomId: roomId, limit: limit)
+    }
+
+    // MARK: - 画像バイナリ
+
+    func loadImageData(key: ImageCacheKey) async -> Data? {
+        await actor.loadImageData(key: key)
+    }
+
+    func saveImageData(_ data: Data, key: ImageCacheKey, mime: String) async throws {
+        try await actor.saveImageData(data, key: key, mime: mime)
+    }
+
+    // MARK: - ライフサイクル
+
+    func clearUserScoped(userId: String) async {
+        await actor.clearUserScoped(userId: userId)
+    }
+}

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -564,7 +564,7 @@ struct SwiftDataPersistenceServiceTests {
 // MARK: - テスト用 ChatMessage イニシャライザ
 
 private extension ChatMessage {
-    /// テスト専用: roomId と receivedAt を指定してチャットメッセージを生成する
+    /// テスト専用: id と receivedAt を指定してチャットメッセージを生成する（roomId は固定値）
     init(id: String, text: String, receivedAt: Date) {
         self.init(
             id: id,

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -1,0 +1,572 @@
+// SwiftDataPersistenceServiceTests.swift
+// SwiftDataPersistenceService の統合テスト
+// ModelConfiguration(isStoredInMemoryOnly: true) を使ってスキーマ・DTO 変換・upsert を検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+/// SwiftDataPersistenceService の統合テストスイート
+@Suite("SwiftDataPersistenceService テスト")
+struct SwiftDataPersistenceServiceTests {
+
+    /// テスト用の in-memory SwiftDataPersistenceService を生成する
+    private func makeService() throws -> SwiftDataPersistenceService {
+        try SwiftDataPersistenceService(inMemory: true)
+    }
+
+    // MARK: - エモート
+
+    @Test("ユーザーエモートを保存して取得できる")
+    func ユーザーエモートを保存して取得できる() async throws {
+        // 前提: 空の SwiftDataPersistenceService（in-memory）
+        let service = try makeService()
+        let emotes = [
+            HelixEmote(id: "1", name: "ぴえんエモート", format: ["static"], emoteType: "subscriptions"),
+            HelixEmote(id: "2", name: "草エモート", format: ["static", "animated"], emoteType: "subscriptions")
+        ]
+
+        // 操作: ユーザーID "視聴者ユーザー123" にエモートを保存する
+        try await service.saveUserEmotes(emotes, userId: "視聴者ユーザー123")
+
+        // 検証: 同じユーザーIDで取得できる（順序に依存しない方法で確認）
+        let loaded = await service.loadUserEmotes(userId: "視聴者ユーザー123")
+        #expect(loaded.count == 2)
+        #expect(loaded.map(\.name).contains("ぴえんエモート"))
+        #expect(loaded.map(\.name).contains("草エモート"))
+    }
+
+    @Test("ユーザーエモートはユーザーIDごとに分離される")
+    func ユーザーエモートはユーザーIDごとに分離される() async throws {
+        // 前提: 2ユーザー分のエモートを別々に保存
+        let service = try makeService()
+        let emotesA = [HelixEmote(id: "10", name: "ユーザーAエモート", format: ["static"], emoteType: nil)]
+        let emotesB = [HelixEmote(id: "20", name: "ユーザーBエモート", format: ["static"], emoteType: nil)]
+        try await service.saveUserEmotes(emotesA, userId: "ユーザーA")
+        try await service.saveUserEmotes(emotesB, userId: "ユーザーB")
+
+        // 検証: それぞれのユーザーIDで別々のエモートが取得できる
+        let loadedA = await service.loadUserEmotes(userId: "ユーザーA")
+        let loadedB = await service.loadUserEmotes(userId: "ユーザーB")
+        #expect(loadedA.count == 1)
+        #expect(loadedA.map(\.name).contains("ユーザーAエモート"))
+        #expect(loadedB.count == 1)
+        #expect(loadedB.map(\.name).contains("ユーザーBエモート"))
+    }
+
+    @Test("グローバルエモートを保存して取得できる")
+    func グローバルエモートを保存して取得できる() async throws {
+        // 前提: 空のサービス
+        let service = try makeService()
+        let emotes = [
+            HelixEmote(id: "25", name: "LUL", format: ["static"], emoteType: "globals"),
+            HelixEmote(id: "1902", name: "PogChamp", format: ["static", "animated"], emoteType: "globals")
+        ]
+
+        // 操作: グローバルエモートを保存する
+        try await service.saveGlobalEmotes(emotes)
+
+        // 検証: グローバルエモートが取得できる
+        let loaded = await service.loadGlobalEmotes()
+        #expect(loaded.count == 2)
+        #expect(loaded.map(\.name).contains("LUL"))
+        #expect(loaded.map(\.name).contains("PogChamp"))
+    }
+
+    @Test("チャンネルエモートはチャンネルごとに分離される")
+    func チャンネルエモートはチャンネルごとに分離される() async throws {
+        // 前提: 2チャンネル分のエモートを保存
+        let service = try makeService()
+        let emotesA = [HelixEmote(id: "100", name: "チャンネルAエモート", format: ["static"], emoteType: nil)]
+        let emotesB = [HelixEmote(id: "200", name: "チャンネルBエモート", format: ["static"], emoteType: nil)]
+        try await service.saveChannelEmotes(emotesA, broadcasterId: "チャンネルA配信者ID")
+        try await service.saveChannelEmotes(emotesB, broadcasterId: "チャンネルB配信者ID")
+
+        // 検証: チャンネルごとに分離される
+        let loadedA = await service.loadChannelEmotes(broadcasterId: "チャンネルA配信者ID")
+        let loadedB = await service.loadChannelEmotes(broadcasterId: "チャンネルB配信者ID")
+        #expect(loadedA.count == 1)
+        #expect(loadedA.map(\.name).contains("チャンネルAエモート"))
+        #expect(loadedB.count == 1)
+        #expect(loadedB.map(\.name).contains("チャンネルBエモート"))
+    }
+
+    @Test("同一スコープでエモートを再保存すると重複せず最新内容に置き換わる")
+    func 同一スコープでエモートを再保存すると重複せず最新内容に置き換わる() async throws {
+        // 前提: 最初に2件のグローバルエモートを保存
+        let service = try makeService()
+        let first = [
+            HelixEmote(id: "1", name: "ぴえん", format: ["static"], emoteType: nil),
+            HelixEmote(id: "2", name: "草", format: ["static"], emoteType: nil)
+        ]
+        try await service.saveGlobalEmotes(first)
+
+        // 操作: id=1 を別名で上書き、id=3 を新規追加、id=2 は削除（セット差し替え）
+        let second = [
+            HelixEmote(id: "1", name: "ぴえん改", format: ["animated"], emoteType: nil),
+            HelixEmote(id: "3", name: "祝", format: ["static"], emoteType: nil)
+        ]
+        try await service.saveGlobalEmotes(second)
+
+        // 検証: 2件のみ、id=1 は最新の name と format、id=2 は消えている
+        let loaded = await service.loadGlobalEmotes()
+        #expect(loaded.count == 2)
+        let byId = Dictionary(uniqueKeysWithValues: loaded.map { ($0.id, $0) })
+        #expect(byId["1"]?.name == "ぴえん改")
+        #expect(byId["1"]?.format == ["animated"])
+        #expect(byId["3"]?.name == "祝")
+        #expect(byId["2"] == nil)
+    }
+
+    @Test("ユーザーエモートを保存してもグローバルエモートは影響を受けない")
+    func ユーザーエモートを保存してもグローバルエモートは影響を受けない() async throws {
+        // 前提: グローバルエモート1件を事前保存
+        let service = try makeService()
+        try await service.saveGlobalEmotes([
+            HelixEmote(id: "global1", name: "グローバルエモート", format: ["static"], emoteType: "globals")
+        ])
+
+        // 操作: 別ユーザーエモートを保存
+        try await service.saveUserEmotes([
+            HelixEmote(id: "user1", name: "ユーザーエモート", format: ["static"], emoteType: nil)
+        ], userId: "ユーザーX")
+
+        // 検証: グローバルエモートは変化しない
+        let global = await service.loadGlobalEmotes()
+        #expect(global.count == 1)
+        #expect(global.first?.name == "グローバルエモート")
+    }
+
+    // MARK: - バッジ
+
+    @Test("バッジをスコープごとに保存して取得できる")
+    func バッジをスコープごとに保存して取得できる() async throws {
+        // 前提: 空のサービス
+        let service = try makeService()
+        let globalBadges = [
+            BadgeVersionSnapshot(setId: "broadcaster", version: "1",
+                                 imageUrl1x: "https://example.com/1x",
+                                 imageUrl2x: "https://example.com/2x",
+                                 imageUrl4x: "https://example.com/4x",
+                                 title: "配信者", description: nil)
+        ]
+
+        // 操作: グローバルバッジを保存
+        try await service.saveBadges(globalBadges, scope: .global)
+
+        // 検証: グローバルスコープで取得できる
+        let loaded = await service.loadBadges(scope: .global)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.setId == "broadcaster")
+        #expect(loaded.first?.title == "配信者")
+    }
+
+    @Test("チャンネルバッジはチャンネルごとに分離される")
+    func チャンネルバッジはチャンネルごとに分離される() async throws {
+        // 前提: 2チャンネルのバッジを保存
+        let service = try makeService()
+        let badgesA = [BadgeVersionSnapshot(setId: "subscriber", version: "12",
+                                            imageUrl1x: "https://a.com/1x",
+                                            imageUrl2x: "https://a.com/2x",
+                                            imageUrl4x: "https://a.com/4x",
+                                            title: "12ヶ月サブ", description: nil)]
+        let badgesB = [BadgeVersionSnapshot(setId: "subscriber", version: "6",
+                                            imageUrl1x: "https://b.com/1x",
+                                            imageUrl2x: "https://b.com/2x",
+                                            imageUrl4x: "https://b.com/4x",
+                                            title: "6ヶ月サブ", description: nil)]
+        try await service.saveBadges(badgesA, scope: .channel(broadcasterId: "チャンネルA"))
+        try await service.saveBadges(badgesB, scope: .channel(broadcasterId: "チャンネルB"))
+
+        // 検証: チャンネルごとに分離される
+        let loadedA = await service.loadBadges(scope: .channel(broadcasterId: "チャンネルA"))
+        let loadedB = await service.loadBadges(scope: .channel(broadcasterId: "チャンネルB"))
+        #expect(loadedA.count == 1)
+        #expect(loadedA.first?.title == "12ヶ月サブ")
+        #expect(loadedB.count == 1)
+        #expect(loadedB.first?.title == "6ヶ月サブ")
+    }
+
+    // MARK: - プロフィール
+
+    @Test("ユーザープロフィールを保存して複数ID一括取得できる")
+    func ユーザープロフィールを保存して複数ID一括取得できる() async throws {
+        // 前提: 3ユーザーのプロフィールを保存
+        let service = try makeService()
+        let profiles = [
+            UserProfileSnapshot(userId: "001", login: "yamada_taro", displayName: "山田太郎", profileImageUrl: nil),
+            UserProfileSnapshot(userId: "002", login: "sato_hanako", displayName: "佐藤花子", profileImageUrl: "https://example.com/hanako.png"),
+            UserProfileSnapshot(userId: "003", login: "suzuki_ichiro", displayName: "鈴木一郎", profileImageUrl: nil)
+        ]
+        try await service.saveUserProfiles(profiles)
+
+        // 操作: 001 と 003 を一括取得
+        let loaded = await service.loadUserProfiles(userIds: ["001", "003"])
+
+        // 検証: 2件取得でき、表示名が正しい
+        #expect(loaded.count == 2)
+        #expect(loaded.map(\.displayName).contains("山田太郎"))
+        #expect(loaded.map(\.displayName).contains("鈴木一郎"))
+        #expect(!loaded.map(\.displayName).contains("佐藤花子"))
+    }
+
+    @Test("ユーザープロフィールを再保存すると上書きされる")
+    func ユーザープロフィールを再保存すると上書きされる() async throws {
+        // 前提: 初期プロフィールを保存
+        let service = try makeService()
+        let original = UserProfileSnapshot(userId: "001", login: "yamada_taro", displayName: "山田太郎", profileImageUrl: nil)
+        try await service.saveUserProfiles([original])
+
+        // 操作: 同じユーザーIDで displayName を変更して再保存
+        let updated = UserProfileSnapshot(userId: "001", login: "yamada_taro", displayName: "山田太郎（更新後）", profileImageUrl: "https://example.com/icon.png")
+        try await service.saveUserProfiles([updated])
+
+        // 検証: 1件のみで最新の displayName に更新されている
+        let loaded = await service.loadUserProfiles(userIds: ["001"])
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.displayName == "山田太郎（更新後）")
+        #expect(loaded.first?.profileImageUrl == "https://example.com/icon.png")
+    }
+
+    // MARK: - チャット履歴
+
+    @Test("メッセージを追加してroomIdごとに直近件数を取得できる")
+    func メッセージを追加してroomIdごとに直近件数を取得できる() async throws {
+        // 前提: 2チャンネルのメッセージを追加
+        let service = try makeService()
+        let messagesA = (1...3).map { i in
+            ChatMessage(systemNotice: "チャンネルAのメッセージ\(i)", roomId: "チャンネルA配信者ID")
+        }
+        let messagesB = [ChatMessage(systemNotice: "チャンネルBのメッセージ1", roomId: "チャンネルB配信者ID")]
+        try await service.appendMessages(messagesA)
+        try await service.appendMessages(messagesB)
+
+        // 操作: チャンネルAの直近2件を取得
+        let loaded = await service.loadRecentMessages(roomId: "チャンネルA配信者ID", limit: 2, before: nil)
+
+        // 検証: 2件のみ取得され、チャンネルBのメッセージは混入しない
+        #expect(loaded.count == 2)
+        for msg in loaded {
+            #expect(msg.roomId == "チャンネルA配信者ID")
+        }
+    }
+
+    @Test("メッセージは受信日時降順で返る")
+    func メッセージは受信日時降順で返る() async throws {
+        // 前提: 3件のメッセージを保存（id で識別するため UUID を固定）
+        let service = try makeService()
+        let now = Date()
+        let messages = [
+            ChatMessage(id: "msg_oldest", text: "最古のメッセージ", receivedAt: now.addingTimeInterval(-200)),
+            ChatMessage(id: "msg_middle", text: "中間のメッセージ", receivedAt: now.addingTimeInterval(-100)),
+            ChatMessage(id: "msg_newest", text: "最新のメッセージ", receivedAt: now)
+        ]
+        try await service.appendMessages(messages)
+
+        // 操作: 全件取得
+        let loaded = await service.loadRecentMessages(roomId: "テストチャンネルID", limit: 10, before: nil)
+
+        // 検証: 降順（最新が先頭）で返る
+        #expect(loaded.count == 3)
+        #expect(loaded[0].id == "msg_newest")
+        #expect(loaded[1].id == "msg_middle")
+        #expect(loaded[2].id == "msg_oldest")
+    }
+
+    @Test("beforeパラメータで指定日時より前のメッセージのみ取得できる")
+    func beforeパラメータで指定日時より前のメッセージのみ取得できる() async throws {
+        // 前提: 3件のメッセージを時系列で保存
+        let service = try makeService()
+        let now = Date()
+        let cutoff = now.addingTimeInterval(-100)
+        let messages = [
+            ChatMessage(id: "msg_old", text: "カットオフ前のメッセージ", receivedAt: now.addingTimeInterval(-200)),
+            ChatMessage(id: "msg_cutoff", text: "カットオフ境界のメッセージ", receivedAt: cutoff),
+            ChatMessage(id: "msg_new", text: "カットオフ後のメッセージ", receivedAt: now)
+        ]
+        try await service.appendMessages(messages)
+
+        // 操作: before=cutoff で取得（cutoff 未満のみ）
+        let loaded = await service.loadRecentMessages(roomId: "テストチャンネルID", limit: 10, before: cutoff)
+
+        // 検証: cutoff より前のメッセージのみ（msg_old のみ）
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.id == "msg_old")
+    }
+
+    @Test("メッセージ検索でクエリにマッチするメッセージのみ返る")
+    func メッセージ検索でクエリにマッチするメッセージのみ返る() async throws {
+        // 前提: 3件のメッセージを保存
+        let service = try makeService()
+        let messages = [
+            ChatMessage(id: "msg1", text: "今日は良い天気ですね", receivedAt: Date().addingTimeInterval(-2)),
+            ChatMessage(id: "msg2", text: "明日は雨の予報です", receivedAt: Date().addingTimeInterval(-1)),
+            ChatMessage(id: "msg3", text: "週末は晴れるらしい", receivedAt: Date())
+        ]
+        try await service.appendMessages(messages)
+
+        // 操作: "天気" を含むメッセージを検索
+        let results = await service.searchMessages(query: "天気", roomId: nil, limit: 10)
+
+        // 検証: "今日は良い天気ですね" のみヒット
+        #expect(results.count == 1)
+        #expect(results.first?.id == "msg1")
+    }
+
+    @Test("バッジとエモートを含むメッセージを保存して復元できる")
+    func バッジとエモートを含むメッセージを保存して復元できる() async throws {
+        // 前提: バッジとエモートを持つメッセージを作成
+        let service = try makeService()
+        let emotes = [EmotePosition(emoteId: "25", startIndex: 0, endIndex: 4)]
+        let badges = [Badge(name: "broadcaster", version: "1"), Badge(name: "subscriber", version: "12")]
+        let original = ChatMessage(
+            id: "testmsg_001",
+            username: "yamada_taro",
+            displayName: "山田太郎",
+            text: "LUL こんにちは",
+            colorHex: "#FF4500",
+            badges: badges,
+            emotes: emotes,
+            roomId: "チャンネルA配信者ID",
+            isAction: false,
+            receivedAt: Date(),
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: false
+        )
+
+        // 操作: 保存して取得
+        try await service.appendMessages([original])
+        let loaded = await service.loadRecentMessages(roomId: "チャンネルA配信者ID", limit: 10, before: nil)
+
+        // 検証: 1件取得でき、badges/emotes が復元されている
+        #expect(loaded.count == 1)
+        let restored = loaded[0]
+        #expect(restored.id == original.id)
+        #expect(restored.text == original.text)
+        #expect(restored.username == original.username)
+        #expect(restored.displayName == original.displayName)
+        #expect(restored.colorHex == original.colorHex)
+        #expect(restored.badges == original.badges)
+        #expect(restored.emotes == original.emotes)
+        // segments は text + emotes から再生成されるため等価性を確認
+        #expect(restored.segments == original.segments)
+    }
+
+    @Test("返信情報を含むメッセージを保存して復元できる")
+    func 返信情報を含むメッセージを保存して復元できる() async throws {
+        // 前提: 返信情報を持つメッセージを作成
+        let service = try makeService()
+        let original = ChatMessage(
+            id: "reply_msg_001",
+            username: "sato_hanako",
+            displayName: "佐藤花子",
+            text: "返信テスト",
+            colorHex: nil,
+            badges: [],
+            emotes: [],
+            roomId: "チャンネルA配信者ID",
+            isAction: false,
+            receivedAt: Date(),
+            replyParentMsgId: "parent_msg_999",
+            isOptimistic: false,
+            replyParentUserLogin: "yamada_taro",
+            replyParentDisplayName: "山田太郎",
+            replyParentMsgBody: "元のメッセージ本文",
+            isSystemNotice: false
+        )
+
+        // 操作: 保存して取得
+        try await service.appendMessages([original])
+        let loaded = await service.loadRecentMessages(roomId: "チャンネルA配信者ID", limit: 10, before: nil)
+
+        // 検証: 返信情報が正しく復元される
+        let restored = try #require(loaded.first)
+        #expect(restored.replyParentMsgId == "parent_msg_999")
+        #expect(restored.replyParentUserLogin == "yamada_taro")
+        #expect(restored.replyParentDisplayName == "山田太郎")
+        #expect(restored.replyParentMsgBody == "元のメッセージ本文")
+    }
+
+    @Test("ACTIONメッセージとシステム通知メッセージのフラグが復元される")
+    func ACTIONメッセージとシステム通知メッセージのフラグが復元される() async throws {
+        // 前提: ACTION メッセージとシステム通知メッセージを作成
+        let service = try makeService()
+        let actionMsg = ChatMessage(
+            id: "action_msg_001",
+            username: "suzuki_ichiro",
+            displayName: "鈴木一郎",
+            text: "踊っています",
+            colorHex: nil,
+            badges: [],
+            emotes: [],
+            roomId: "チャンネルA配信者ID",
+            isAction: true,
+            receivedAt: Date().addingTimeInterval(-1),
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: false
+        )
+        let systemMsg = ChatMessage(
+            id: "system_msg_001",
+            username: "",
+            displayName: "",
+            text: "モデレーションコマンド成功",
+            colorHex: nil,
+            badges: [],
+            emotes: [],
+            roomId: "チャンネルA配信者ID",
+            isAction: false,
+            receivedAt: Date(),
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: true
+        )
+
+        // 操作: 保存して取得
+        try await service.appendMessages([actionMsg, systemMsg])
+        let loaded = await service.loadRecentMessages(roomId: "チャンネルA配信者ID", limit: 10, before: nil)
+
+        // 検証: フラグが正しく復元される
+        #expect(loaded.count == 2)
+        let loadedById = Dictionary(uniqueKeysWithValues: loaded.map { ($0.id, $0) })
+        #expect(loadedById["action_msg_001"]?.isAction == true)
+        #expect(loadedById["action_msg_001"]?.isSystemNotice == false)
+        #expect(loadedById["system_msg_001"]?.isSystemNotice == true)
+        #expect(loadedById["system_msg_001"]?.isAction == false)
+    }
+
+    // MARK: - 画像
+
+    @Test("画像バイナリを保存して取得できる")
+    func 画像バイナリを保存して取得できる() async throws {
+        // 前提: テスト用の画像データ
+        let service = try makeService()
+        let imageData = Data("テスト画像バイナリ".utf8)
+        let key = ImageCacheKey(kind: .emote, identifier: "emote_001:2x:static")
+
+        // 操作: 保存して取得
+        try await service.saveImageData(imageData, key: key, mime: "image/png")
+        let loaded = await service.loadImageData(key: key)
+
+        // 検証: 同じデータが取得できる
+        #expect(loaded == imageData)
+    }
+
+    @Test("画像バイナリを再保存すると最新データで上書きされる")
+    func 画像バイナリを再保存すると最新データで上書きされる() async throws {
+        // 前提: 初期データを保存
+        let service = try makeService()
+        let key = ImageCacheKey(kind: .badge, identifier: "broadcaster:1:2x")
+        let originalData = Data("元の画像データ".utf8)
+        try await service.saveImageData(originalData, key: key, mime: "image/png")
+
+        // 操作: 同じキーで別データを保存
+        let updatedData = Data("更新後の画像データ".utf8)
+        try await service.saveImageData(updatedData, key: key, mime: "image/webp")
+
+        // 検証: 最新データが取得できる
+        let loaded = await service.loadImageData(key: key)
+        #expect(loaded == updatedData)
+    }
+
+    @Test("画像種別が異なれば同じidentifierでも分離される")
+    func 画像種別が異なれば同じidentifierでも分離される() async throws {
+        // 前提: 同じ identifier で異なる kind の画像を保存
+        let service = try makeService()
+        let emoteData = Data("エモート画像".utf8)
+        let badgeData = Data("バッジ画像".utf8)
+        let sharedIdentifier = "12345:2x:static"
+        let emoteKey = ImageCacheKey(kind: .emote, identifier: sharedIdentifier)
+        let badgeKey = ImageCacheKey(kind: .badge, identifier: sharedIdentifier)
+        try await service.saveImageData(emoteData, key: emoteKey, mime: "image/png")
+        try await service.saveImageData(badgeData, key: badgeKey, mime: "image/png")
+
+        // 検証: それぞれ別々に取得できる
+        let loadedEmote = await service.loadImageData(key: emoteKey)
+        let loadedBadge = await service.loadImageData(key: badgeKey)
+        #expect(loadedEmote == emoteData)
+        #expect(loadedBadge == badgeData)
+    }
+
+    // MARK: - ライフサイクル
+
+    @Test("clearUserScopedでユーザー固有データのみ削除されグローバル_チャンネル_履歴は保持される")
+    func clearUserScopedでユーザー固有データのみ削除されグローバル_チャンネル_履歴は保持される() async throws {
+        // 前提: 5種類のデータを保存
+        let service = try makeService()
+        let userId = "削除対象ユーザー001"
+        // ユーザーエモート（削除対象）
+        try await service.saveUserEmotes([
+            HelixEmote(id: "user1", name: "ユーザー固有エモート", format: ["static"], emoteType: nil)
+        ], userId: userId)
+        // ユーザープロフィール（削除対象）
+        try await service.saveUserProfiles([
+            UserProfileSnapshot(userId: userId, login: "target_user", displayName: "削除対象ユーザー", profileImageUrl: nil)
+        ])
+        // グローバルエモート（保持対象）
+        try await service.saveGlobalEmotes([
+            HelixEmote(id: "global1", name: "グローバルエモート", format: ["static"], emoteType: "globals")
+        ])
+        // チャンネルエモート（保持対象）
+        try await service.saveChannelEmotes([
+            HelixEmote(id: "ch1", name: "チャンネルエモート", format: ["static"], emoteType: nil)
+        ], broadcasterId: "チャンネルA配信者ID")
+        // チャット履歴（保持対象）
+        try await service.appendMessages([
+            ChatMessage(systemNotice: "残すメッセージ", roomId: "チャンネルA配信者ID")
+        ])
+
+        // 操作: ユーザースコープのみクリア
+        await service.clearUserScoped(userId: userId)
+
+        // 検証: ユーザーエモートとプロフィールのみ削除される
+        let userEmotes = await service.loadUserEmotes(userId: userId)
+        let userProfiles = await service.loadUserProfiles(userIds: [userId])
+        #expect(userEmotes.isEmpty)
+        #expect(userProfiles.isEmpty)
+
+        // グローバル・チャンネル・履歴は保持される
+        let globalEmotes = await service.loadGlobalEmotes()
+        let channelEmotes = await service.loadChannelEmotes(broadcasterId: "チャンネルA配信者ID")
+        let messages = await service.loadRecentMessages(roomId: "チャンネルA配信者ID", limit: 10, before: nil)
+        #expect(globalEmotes.count == 1)
+        #expect(channelEmotes.count == 1)
+        #expect(messages.count == 1)
+    }
+}
+
+// MARK: - テスト用 ChatMessage イニシャライザ
+
+private extension ChatMessage {
+    /// テスト専用: roomId と receivedAt を指定してチャットメッセージを生成する
+    init(id: String, text: String, receivedAt: Date) {
+        self.init(
+            id: id,
+            username: "テストユーザー",
+            displayName: "テストユーザー",
+            text: text,
+            colorHex: nil,
+            badges: [],
+            emotes: [],
+            roomId: "テストチャンネルID",
+            isAction: false,
+            receivedAt: receivedAt,
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: false
+        )
+    }
+}

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -326,7 +326,7 @@ struct SwiftDataPersistenceServiceTests {
             text: "LUL こんにちは",
             colorHex: "#FF4500",
             badges: badges,
-            emotes: emotes,
+            emotePositions: emotes,
             roomId: "チャンネルA配信者ID",
             isAction: false,
             receivedAt: Date(),
@@ -367,7 +367,7 @@ struct SwiftDataPersistenceServiceTests {
             text: "返信テスト",
             colorHex: nil,
             badges: [],
-            emotes: [],
+            emotePositions: [],
             roomId: "チャンネルA配信者ID",
             isAction: false,
             receivedAt: Date(),
@@ -402,7 +402,7 @@ struct SwiftDataPersistenceServiceTests {
             text: "踊っています",
             colorHex: nil,
             badges: [],
-            emotes: [],
+            emotePositions: [],
             roomId: "チャンネルA配信者ID",
             isAction: true,
             receivedAt: Date().addingTimeInterval(-1),
@@ -420,7 +420,7 @@ struct SwiftDataPersistenceServiceTests {
             text: "モデレーションコマンド成功",
             colorHex: nil,
             badges: [],
-            emotes: [],
+            emotePositions: [],
             roomId: "チャンネルA配信者ID",
             isAction: false,
             receivedAt: Date(),
@@ -502,38 +502,54 @@ struct SwiftDataPersistenceServiceTests {
 
     @Test("clearUserScopedでユーザー固有データのみ削除されグローバル_チャンネル_履歴は保持される")
     func clearUserScopedでユーザー固有データのみ削除されグローバル_チャンネル_履歴は保持される() async throws {
-        // 前提: 5種類のデータを保存
+        // 前提: 削除対象ユーザーと別ユーザーのデータを保存
         let service = try makeService()
         let userId = "削除対象ユーザー001"
-        // ユーザーエモート（削除対象）
+        let otherUserId = "別ユーザー002"
+        // 削除対象: ユーザーエモート
         try await service.saveUserEmotes([
             HelixEmote(id: "user1", name: "ユーザー固有エモート", format: ["static"], emoteType: nil)
         ], userId: userId)
-        // ユーザープロフィール（削除対象）
+        // 削除対象: ユーザープロフィール
         try await service.saveUserProfiles([
             UserProfileSnapshot(userId: userId, login: "target_user", displayName: "削除対象ユーザー", profileImageUrl: nil)
         ])
-        // グローバルエモート（保持対象）
+        // 保持対象: 別ユーザーのエモートとプロフィール
+        try await service.saveUserEmotes([
+            HelixEmote(id: "other1", name: "別ユーザーエモート", format: ["static"], emoteType: nil)
+        ], userId: otherUserId)
+        try await service.saveUserProfiles([
+            UserProfileSnapshot(userId: otherUserId, login: "other_user", displayName: "別ユーザー", profileImageUrl: nil)
+        ])
+        // 保持対象: グローバルエモート
         try await service.saveGlobalEmotes([
             HelixEmote(id: "global1", name: "グローバルエモート", format: ["static"], emoteType: "globals")
         ])
-        // チャンネルエモート（保持対象）
+        // 保持対象: チャンネルエモート
         try await service.saveChannelEmotes([
             HelixEmote(id: "ch1", name: "チャンネルエモート", format: ["static"], emoteType: nil)
         ], broadcasterId: "チャンネルA配信者ID")
-        // チャット履歴（保持対象）
+        // 保持対象: チャット履歴
         try await service.appendMessages([
             ChatMessage(systemNotice: "残すメッセージ", roomId: "チャンネルA配信者ID")
         ])
 
-        // 操作: ユーザースコープのみクリア
+        // 操作: 削除対象ユーザーのスコープのみクリア
         await service.clearUserScoped(userId: userId)
 
-        // 検証: ユーザーエモートとプロフィールのみ削除される
+        // 検証: 削除対象ユーザーのエモートとプロフィールのみ削除される
         let userEmotes = await service.loadUserEmotes(userId: userId)
         let userProfiles = await service.loadUserProfiles(userIds: [userId])
         #expect(userEmotes.isEmpty)
         #expect(userProfiles.isEmpty)
+
+        // 別ユーザーのデータは保持される
+        let otherEmotes = await service.loadUserEmotes(userId: otherUserId)
+        let otherProfiles = await service.loadUserProfiles(userIds: [otherUserId])
+        #expect(otherEmotes.count == 1)
+        #expect(otherEmotes.first?.name == "別ユーザーエモート")
+        #expect(otherProfiles.count == 1)
+        #expect(otherProfiles.first?.displayName == "別ユーザー")
 
         // グローバル・チャンネル・履歴は保持される
         let globalEmotes = await service.loadGlobalEmotes()
@@ -557,7 +573,7 @@ private extension ChatMessage {
             text: text,
             colorHex: nil,
             badges: [],
-            emotes: [],
+            emotePositions: [],
             roomId: "テストチャンネルID",
             isAction: false,
             receivedAt: receivedAt,


### PR DESCRIPTION
## Summary

- `Sources/TwitchChat/Persistence/SchemaV1.swift` — 6 つの `@Model` クラス（`PersistedEmote` / `PersistedChannel` / `PersistedChatMessage` / `PersistedBadgeVersion` / `PersistedUser` / `PersistedImageAsset`）と `SchemaV1 VersionedSchema` / `ChatSchemaMigrationPlan` を定義
- `Sources/TwitchChat/Persistence/PersistenceActor.swift` — `@ModelActor` ベースで全 `PersistenceService` メソッドを実装。`Badge` / `EmotePosition` の `Codable` 適合（永続化層 private）、DTO 変換 extension を追加
- `Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift` — `PersistenceActor` に委譲する薄い `struct` ラッパーを追加（`init(container:)` / `init(inMemory:)` の 2 イニシャライザ）
- `Sources/TwitchChat/Persistence/PersistenceContainer.swift` — `makeOnDisk() throws` ファクトリを追加（Application Support 配下に SQLite を生成）
- `Sources/TwitchChat/Models/ChatMessage.swift` — 永続化復元用の `internal init(id:...:emotePositions:...)` を追加（既存 init は無変更）
- `Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift` — `ModelConfiguration(isStoredInMemoryOnly: true)` を使った統合テスト 21 件を追加（upsert / DTO 変換 / scope 分離 / clearUserScoped の非破壊範囲）

## 設計上の決定

- `PersistenceService` protocol への適合は `SwiftDataPersistenceService`（非 actor struct）で行い、`@ModelActor` の `PersistenceActor` には protocol を**適合させない**（マクロと protocol が衝突するリスクを回避）
- 構築失敗時のフォールバックは `PersistenceContainer.makeOnDisk()` が throws → 呼び出し側で `(try? .makeOnDisk()) ?? .makeInMemory()` に変更（PR-3 で実施）
- `badges` / `emotes` は JSON 文字列カラム（`badgesRaw` / `emotesRaw`）で保存（`@Relationship` は回避）
- `segments` は非永続化、`toDomain()` 時に `MessageSegment.segments(from:emotePositions:)` で再生成
- `TwitchChatApp.swift` / 各ストアは**変更しない**（PR-3 以降で実際の呼び出しを追加）

## 既知の IRC タイミング依存テスト失敗

`TwitchIRCClientTests` の 7 件の PING/RECONNECT タイミングテストが CI 環境で断続的に失敗しますが、これは本 PR の変更と無関係な既知の問題です（PR-1 以前から存在）。

## Test plan

- [x] `swift build` — Build complete
- [x] `swift test --filter SwiftDataPersistenceService` — 21 tests passed
- [x] `swift test --filter PersistenceService` — 31 tests passed（InMemory 10 件 + SwiftData 21 件）
- [x] `swiftlint lint --strict` — 0 violations
- [x] 既存テスト — IRC タイミング依存テスト以外すべて GREEN

Refs #53 (PR-2)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャットメッセージのローカル保存に対応しました
  * チャットメッセージの検索機能を追加しました
  * ユーザープロフィール、エモート、バッジをオフラインで利用できるようになりました
  * 画像のキャッシング機能を実装しました

* **テスト**
  * ローカルデータ永続化機能の統合テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->