### PR TITLE
feat: バッジ・プロフィール画像メタの永続化配線（永続化基盤 PR-3）

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -2,6 +2,7 @@
 // アプリケーションのエントリポイント
 // SwiftUI の App プロトコルに準拠し、メインウィンドウを定義する
 
+import os.log
 import SwiftUI
 
 /// Twitch IRC チャットビューアーのアプリ定義
@@ -69,7 +70,14 @@ struct TwitchChatApp: App {
                 ProgressView("起動中...")
                     .onAppear {
                         let helixClient = HelixAPIClient(tokenProvider: authState)
-                        let persistenceContainer = PersistenceContainer.makeInMemory()
+                        let persistenceContainer: PersistenceContainer
+                        do {
+                            persistenceContainer = try PersistenceContainer.makeOnDisk()
+                        } catch {
+                            Logger(subsystem: "dev.mtane.TwitchChat", category: "Persistence")
+                                .error("makeOnDisk 失敗、InMemory にフォールバック: \(error.localizedDescription)")
+                            persistenceContainer = .makeInMemory()
+                        }
                         channelManager = ChannelManager(
                             authState: authState,
                             persistenceService: persistenceContainer.service

--- a/Sources/TwitchChat/Persistence/InMemoryPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/InMemoryPersistenceService.swift
@@ -20,7 +20,8 @@ actor InMemoryPersistenceService: PersistenceService {
     private var userEmotes: [String: [HelixEmote]] = [:]
     private var globalEmotes: [HelixEmote] = []
     private var channelEmotes: [String: [HelixEmote]] = [:]
-    private var badges: [BadgeScope: [BadgeVersionSnapshot]] = [:]
+    /// バッジデータとその保存時刻を保持する（TTL 判定に使用）
+    private var badges: [BadgeScope: (snapshots: [BadgeVersionSnapshot], savedAt: Date)] = [:]
     private var userProfiles: [String: UserProfileSnapshot] = [:]
     /// roomId をキーにメッセージを格納。roomId が nil のメッセージは `noRoomKey` に格納する
     private var messages: [String: [ChatMessage]] = [:]
@@ -55,11 +56,16 @@ actor InMemoryPersistenceService: PersistenceService {
     }
 
     func loadBadges(scope: BadgeScope) async -> [BadgeVersionSnapshot] {
-        badges[scope] ?? []
+        badges[scope]?.snapshots ?? []
     }
 
     func saveBadges(_ badgeList: [BadgeVersionSnapshot], scope: BadgeScope) async throws {
-        badges[scope] = badgeList
+        badges[scope] = (snapshots: badgeList, savedAt: Date())
+    }
+
+    func loadBadgesWithTimestamp(scope: BadgeScope) async -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?) {
+        guard let entry = badges[scope] else { return (snapshots: [], fetchedAt: nil) }
+        return (snapshots: entry.snapshots, fetchedAt: entry.savedAt)
     }
 
     func loadUserProfiles(userIds: [String]) async -> [UserProfileSnapshot] {
@@ -122,4 +128,11 @@ actor InMemoryPersistenceService: PersistenceService {
         userEmotes.removeValue(forKey: userId)
         userProfiles.removeValue(forKey: userId)
     }
+
+#if DEBUG
+    /// テスト用: バッジを任意の保存日時で登録する（TTL 検証用）
+    func saveBadgesWithDate(_ badgeList: [BadgeVersionSnapshot], scope: BadgeScope, savedAt: Date) async {
+        badges[scope] = (snapshots: badgeList, savedAt: savedAt)
+    }
+#endif
 }

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -52,12 +52,7 @@ actor PersistenceActor {
 
     /// 指定スコープのバッジを取得する
     func loadBadges(scope: BadgeScope) -> [BadgeVersionSnapshot] {
-        let scopeRaw = badgeScopeRaw(scope)
-        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
-            predicate: #Predicate { $0.scope == scopeRaw }
-        )
-        let rows = (try? modelContext.fetch(descriptor)) ?? []
-        return rows.map { $0.toDomain() }
+        fetchBadgeRows(scope: scope).map { $0.toDomain() }
     }
 
     /// 指定スコープのバッジを保存する（全件 upsert）
@@ -69,11 +64,7 @@ actor PersistenceActor {
     ///
     /// `updatedAt` の最大値を `fetchedAt` として返す。未保存の場合は `fetchedAt` が nil。
     func loadBadgesWithTimestamp(scope: BadgeScope) -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?) {
-        let scopeRaw = badgeScopeRaw(scope)
-        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
-            predicate: #Predicate { $0.scope == scopeRaw }
-        )
-        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        let rows = fetchBadgeRows(scope: scope)
         guard !rows.isEmpty else { return (snapshots: [], fetchedAt: nil) }
         let snapshots = rows.map { $0.toDomain() }
         let fetchedAt = rows.map(\.updatedAt).max()
@@ -293,6 +284,15 @@ private extension PersistenceActor {
             }
         }
         try modelContext.save()
+    }
+
+    /// 指定スコープの PersistedBadgeVersion 行を取得する共通ヘルパー
+    func fetchBadgeRows(scope: BadgeScope) -> [PersistedBadgeVersion] {
+        let scopeRaw = badgeScopeRaw(scope)
+        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
     }
 
     /// バッジをスコープ単位で upsert する（既存を全件差し替え）

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -65,6 +65,21 @@ actor PersistenceActor {
         try upsertBadges(badges, scope: scope)
     }
 
+    /// 指定スコープのバッジをタイムスタンプ付きで取得する
+    ///
+    /// `updatedAt` の最大値を `fetchedAt` として返す。未保存の場合は `fetchedAt` が nil。
+    func loadBadgesWithTimestamp(scope: BadgeScope) -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?) {
+        let scopeRaw = badgeScopeRaw(scope)
+        let descriptor = FetchDescriptor<PersistedBadgeVersion>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        guard !rows.isEmpty else { return (snapshots: [], fetchedAt: nil) }
+        let snapshots = rows.map { $0.toDomain() }
+        let fetchedAt = rows.map(\.updatedAt).max()
+        return (snapshots: snapshots, fetchedAt: fetchedAt)
+    }
+
     // MARK: - プロフィール
 
     /// 指定ユーザーIDのプロフィールを一括取得する

--- a/Sources/TwitchChat/Persistence/PersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceService.swift
@@ -50,6 +50,12 @@ protocol PersistenceService: Sendable {
     /// - Throws: ディスクまたはデータベース書き込みに失敗した場合
     func saveBadges(_ badges: [BadgeVersionSnapshot], scope: BadgeScope) async throws
 
+    /// 指定スコープのバッジ一覧をタイムスタンプ付きでロードする
+    ///
+    /// TTL 判定（24h stale-while-revalidate）に使用する。
+    /// 該当スコープのバッジが未保存の場合は `fetchedAt` に nil を返す。
+    func loadBadgesWithTimestamp(scope: BadgeScope) async -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?)
+
     /// 指定ユーザーID 一覧のプロフィールをロードする
     ///
     /// 取得できたプロフィールのみを返す。指定した ID が存在しない場合はその要素を省略する。

--- a/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
@@ -69,6 +69,10 @@ struct SwiftDataPersistenceService: PersistenceService {
         try await actor.saveBadges(badges, scope: scope)
     }
 
+    func loadBadgesWithTimestamp(scope: BadgeScope) async -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?) {
+        await actor.loadBadgesWithTimestamp(scope: scope)
+    }
+
     func loadUserProfiles(userIds: [String]) async -> [UserProfileSnapshot] {
         await actor.loadUserProfiles(userIds: userIds)
     }

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -129,6 +129,18 @@ actor BadgeStore {
     func fetchChannelBadges(channelId: String) async {
         // Twitch の room-id は数字のみで構成される（URLパラメータインジェクション対策）
         guard !channelId.isEmpty, channelId.allSatisfy(\.isNumber) else { return }
+        let scope: BadgeScope = .channel(broadcasterId: channelId)
+        // 永続化キャッシュから先読みしてオフライン時の即時表示と API 呼び出し抑止を実現する
+        if let persistence = persistenceService {
+            let cached = await persistence.loadBadgesWithTimestamp(scope: scope)
+            if !cached.snapshots.isEmpty {
+                channelBadges = Self.buildMapping(from: cached.snapshots)
+                if let fetchedAt = cached.fetchedAt,
+                   Date().timeIntervalSince(fetchedAt) < Self.badgeTTL {
+                    return
+                }
+            }
+        }
         do {
             let response: HelixBadgesResponse = try await apiClient.get(
                 url: Self.helixChannelBadgesURL,
@@ -136,7 +148,7 @@ actor BadgeStore {
             )
             channelBadges = Self.buildMapping(from: response.data)
             // write-back: 永続化サービスが存在すればチャンネルスコープで非同期保存する
-            writeBackBadges(response.data, scope: .channel(broadcasterId: channelId))
+            writeBackBadges(response.data, scope: scope)
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
         } catch HelixAPIError.unauthorized {

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -25,8 +25,6 @@ actor BadgeStore {
     /// Helix チャンネルバッジエンドポイント
     private static let helixChannelBadgesURL = URL(string: "https://api.twitch.tv/helix/chat/badges")!
 
-    // MARK: - 定数
-
     /// グローバルバッジの TTL（24 時間）
     private static let badgeTTL: TimeInterval = 86400
 
@@ -71,6 +69,8 @@ actor BadgeStore {
     /// TTL 超過時は古いデータでキャッシュを充填した上で `isGlobalLoaded = false` のままにし、
     /// 後続の `fetchGlobalBadges()` で再フェッチさせる。
     func seedFromPersistence() async {
+        // 既に API フェッチ済みならインメモリデータを上書きしない
+        guard !isGlobalLoaded else { return }
         guard let persistence = persistenceService else { return }
         let result = await persistence.loadBadgesWithTimestamp(scope: .global)
         guard !result.snapshots.isEmpty else { return }
@@ -102,12 +102,7 @@ actor BadgeStore {
                 self.globalBadges = Self.buildMapping(from: response.data)
                 self.isGlobalLoaded = true
                 // write-back: 永続化サービスが存在すればバッジを非同期保存する
-                if let persistence = self.persistenceService {
-                    let snapshots = response.data.map { Self.badgeVersionSnapshot(from: $0) }.flatMap { $0 }
-                    Task { [persistence] in
-                        try? await persistence.saveBadges(snapshots, scope: .global)
-                    }
-                }
+                self.writeBackBadges(response.data, scope: .global)
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
             } catch let error as URLError where error.code == .cancelled {
@@ -141,12 +136,7 @@ actor BadgeStore {
             )
             channelBadges = Self.buildMapping(from: response.data)
             // write-back: 永続化サービスが存在すればチャンネルスコープで非同期保存する
-            if let persistence = persistenceService {
-                let snapshots = response.data.map { Self.badgeVersionSnapshot(from: $0) }.flatMap { $0 }
-                Task { [persistence] in
-                    try? await persistence.saveBadges(snapshots, scope: .channel(broadcasterId: channelId))
-                }
-            }
+            writeBackBadges(response.data, scope: .channel(broadcasterId: channelId))
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
         } catch HelixAPIError.unauthorized {
@@ -200,6 +190,23 @@ actor BadgeStore {
         channelBadges = mapping
     }
 #endif
+
+    // MARK: - プライベートメソッド
+
+    /// バッジを永続化サービスに非同期保存する（fire-and-forget）
+    private func writeBackBadges(_ badgeSets: [HelixBadgeSet], scope: BadgeScope) {
+        guard let persistence = persistenceService else { return }
+        let snapshots = badgeSets.flatMap { Self.badgeVersionSnapshot(from: $0) }
+        Task { [persistence] in
+            do {
+                try await persistence.saveBadges(snapshots, scope: scope)
+            } catch {
+                #if DEBUG
+                print("[BadgeStore] write-back 失敗 scope=\(scope) error=\(error)")
+                #endif
+            }
+        }
+    }
 
     // MARK: - 静的ユーティリティ
 

--- a/Sources/TwitchChat/Services/BadgeStore.swift
+++ b/Sources/TwitchChat/Services/BadgeStore.swift
@@ -25,6 +25,11 @@ actor BadgeStore {
     /// Helix チャンネルバッジエンドポイント
     private static let helixChannelBadgesURL = URL(string: "https://api.twitch.tv/helix/chat/badges")!
 
+    // MARK: - 定数
+
+    /// グローバルバッジの TTL（24 時間）
+    private static let badgeTTL: TimeInterval = 86400
+
     // MARK: - 状態
 
     /// グローバルバッジのURLマッピング
@@ -42,16 +47,39 @@ actor BadgeStore {
     /// Helix API クライアント
     private let apiClient: any HelixAPIClientProtocol
 
+    /// 永続化サービス（seed / write-back に使用）
+    private let persistenceService: (any PersistenceService)?
+
     // MARK: - 初期化
 
     /// BadgeStore を初期化する
     ///
-    /// - Parameter apiClient: Helix API クライアント（テスト時はモックを注入）
-    init(apiClient: any HelixAPIClientProtocol) {
+    /// - Parameters:
+    ///   - apiClient: Helix API クライアント（テスト時はモックを注入）
+    ///   - persistenceService: 永続化サービス（nil の場合は永続化なし）
+    init(apiClient: any HelixAPIClientProtocol, persistenceService: (any PersistenceService)? = nil) {
         self.apiClient = apiClient
+        self.persistenceService = persistenceService
     }
 
     // MARK: - 公開メソッド
+
+    /// 永続化済みグローバルバッジを読み込んでキャッシュを事前充填する
+    ///
+    /// チャンネル接続時に呼び出す。TTL（24h）以内のデータなら `isGlobalLoaded = true`
+    /// にして後続の `fetchGlobalBadges()` による API 呼び出しを抑止する（stale-while-revalidate）。
+    /// TTL 超過時は古いデータでキャッシュを充填した上で `isGlobalLoaded = false` のままにし、
+    /// 後続の `fetchGlobalBadges()` で再フェッチさせる。
+    func seedFromPersistence() async {
+        guard let persistence = persistenceService else { return }
+        let result = await persistence.loadBadgesWithTimestamp(scope: .global)
+        guard !result.snapshots.isEmpty else { return }
+        globalBadges = Self.buildMapping(from: result.snapshots)
+        if let fetchedAt = result.fetchedAt,
+           Date().timeIntervalSince(fetchedAt) < Self.badgeTTL {
+            isGlobalLoaded = true
+        }
+    }
 
     /// グローバルバッジ定義をフェッチする
     ///
@@ -73,6 +101,13 @@ actor BadgeStore {
                 )
                 self.globalBadges = Self.buildMapping(from: response.data)
                 self.isGlobalLoaded = true
+                // write-back: 永続化サービスが存在すればバッジを非同期保存する
+                if let persistence = self.persistenceService {
+                    let snapshots = response.data.map { Self.badgeVersionSnapshot(from: $0) }.flatMap { $0 }
+                    Task { [persistence] in
+                        try? await persistence.saveBadges(snapshots, scope: .global)
+                    }
+                }
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
             } catch let error as URLError where error.code == .cancelled {
@@ -105,6 +140,13 @@ actor BadgeStore {
                 queryItems: [URLQueryItem(name: "broadcaster_id", value: channelId)]
             )
             channelBadges = Self.buildMapping(from: response.data)
+            // write-back: 永続化サービスが存在すればチャンネルスコープで非同期保存する
+            if let persistence = persistenceService {
+                let snapshots = response.data.map { Self.badgeVersionSnapshot(from: $0) }.flatMap { $0 }
+                Task { [persistence] in
+                    try? await persistence.saveBadges(snapshots, scope: .channel(broadcasterId: channelId))
+                }
+            }
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             // 未ログイン時はスキップ
         } catch HelixAPIError.unauthorized {
@@ -178,5 +220,34 @@ actor BadgeStore {
             mapping[set.setId] = versions
         }
         return mapping
+    }
+
+    /// BadgeVersionSnapshot の配列から URLマッピングを構築する
+    ///
+    /// 永続化キャッシュから復元する際に使用する。2x URL を採用する。
+    ///
+    /// - Parameter snapshots: 永続化済みバッジスナップショットの配列
+    /// - Returns: [バッジ名: [バージョン: URLString]] のマッピング
+    static func buildMapping(from snapshots: [BadgeVersionSnapshot]) -> BadgeURLMapping {
+        var mapping: BadgeURLMapping = [:]
+        for snapshot in snapshots {
+            mapping[snapshot.setId, default: [:]][snapshot.version] = snapshot.imageUrl2x
+        }
+        return mapping
+    }
+
+    /// HelixBadgeSet を BadgeVersionSnapshot の配列に変換する（write-back 用）
+    private static func badgeVersionSnapshot(from badgeSet: HelixBadgeSet) -> [BadgeVersionSnapshot] {
+        badgeSet.versions.map { version in
+            BadgeVersionSnapshot(
+                setId: badgeSet.setId,
+                version: version.id,
+                imageUrl1x: version.imageUrl1x,
+                imageUrl2x: version.imageUrl2x,
+                imageUrl4x: version.imageUrl4x,
+                title: version.title,
+                description: version.description
+            )
+        }
     }
 }

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -220,7 +220,11 @@ final class ProfileImageStore {
             )
         }
         Task { [persistence] in
-            try? await persistence.saveUserProfiles(snapshots)
+            do {
+                try await persistence.saveUserProfiles(snapshots)
+            } catch {
+                logger.debug("プロフィール永続化失敗: \(error.localizedDescription)")
+            }
         }
     }
 
@@ -229,6 +233,15 @@ final class ProfileImageStore {
     /// fetchUsers の先読みで使用する。`fetchedUserIds` にも登録することで
     /// 同一ユーザーへの重複 API 呼び出しを防ぐ。
     private func applyCachedSnapshot(_ snapshot: UserProfileSnapshot) {
+        // キャッシュ上限超過時は全消去してメモリ増大を防ぐ（fetchAndStore と同じ方針）
+        if profileImageUrls.count >= Self.maxCacheEntries {
+            profileImageUrls.removeAll()
+            displayNames.removeAll()
+            userLogins.removeAll()
+            fetchedUserIds.removeAll()
+            fetchedLogins.removeAll()
+            loginToUserId.removeAll()
+        }
         fetchedUserIds.insert(snapshot.userId)
         fetchedLogins.insert(snapshot.login)
         loginToUserId[snapshot.login] = snapshot.userId

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -131,26 +131,29 @@ final class ProfileImageStore {
         // @MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ
         var newUserIds = userIds.filter { !fetchedUserIds.contains($0) && !inFlightUserIds.contains($0) }
 
-        // 永続化キャッシュから先読みして API 呼び出しを最小化する
-        if !newUserIds.isEmpty, let persistence = persistenceService {
-            let cached = await persistence.loadUserProfiles(userIds: newUserIds)
-            for snapshot in cached {
-                applyCachedSnapshot(snapshot)
-            }
-            // キャッシュで解決済みの ID は API から取得しない
-            let cachedIds = Set(cached.map(\.userId))
-            newUserIds = newUserIds.filter { !cachedIds.contains($0) }
-        }
-
         if !newUserIds.isEmpty {
-            // フェッチ中フラグを設定し、完了後に必ず解除する
-            inFlightUserIds.formUnion(newUserIds)
-            defer { inFlightUserIds.subtract(newUserIds) }
+            // 永続化 await の前に ID を予約して、await サスペンション中の再入による重複リクエストを防ぐ
+            let reservedUserIds = Set(newUserIds)
+            inFlightUserIds.formUnion(reservedUserIds)
+            defer { inFlightUserIds.subtract(reservedUserIds) }
+
+            // 永続化キャッシュから先読みして API 呼び出しを最小化する
+            if let persistence = persistenceService {
+                let cached = await persistence.loadUserProfiles(userIds: newUserIds)
+                for snapshot in cached {
+                    applyCachedSnapshot(snapshot)
+                }
+                // キャッシュで解決済みの ID は API から取得しない
+                let cachedIds = Set(cached.map(\.userId))
+                newUserIds = newUserIds.filter { !cachedIds.contains($0) }
+            }
 
             // Helix API の100件制限に合わせてチャンク分割してリクエスト
-            let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
-            for chunk in chunks {
-                await fetchChunk(userIds: chunk)
+            if !newUserIds.isEmpty {
+                let chunks = newUserIds.chunked(into: Self.maxIdsPerRequest)
+                for chunk in chunks {
+                    await fetchChunk(userIds: chunk)
+                }
             }
         }
 

--- a/Sources/TwitchChat/Services/ProfileImageStore.swift
+++ b/Sources/TwitchChat/Services/ProfileImageStore.swift
@@ -129,7 +129,18 @@ final class ProfileImageStore {
         // 未取得かつフェッチ中でないユーザーのみ対象にする
         // fetchedUserIds でフェッチ済み（URL が nil のユーザーを含む）を除外し、
         // @MainActor の await サスペンション中に別タスクが同じ ID を重複リクエストする問題を防ぐ
-        let newUserIds = userIds.filter { !fetchedUserIds.contains($0) && !inFlightUserIds.contains($0) }
+        var newUserIds = userIds.filter { !fetchedUserIds.contains($0) && !inFlightUserIds.contains($0) }
+
+        // 永続化キャッシュから先読みして API 呼び出しを最小化する
+        if !newUserIds.isEmpty, let persistence = persistenceService {
+            let cached = await persistence.loadUserProfiles(userIds: newUserIds)
+            for snapshot in cached {
+                applyCachedSnapshot(snapshot)
+            }
+            // キャッシュで解決済みの ID は API から取得しない
+            let cachedIds = Set(cached.map(\.userId))
+            newUserIds = newUserIds.filter { !cachedIds.contains($0) }
+        }
 
         if !newUserIds.isEmpty {
             // フェッチ中フラグを設定し、完了後に必ず解除する
@@ -197,6 +208,37 @@ final class ProfileImageStore {
         await fetchAndStore(queryItems: queryItems, fallbackIds: logins, mode: .login)
     }
 
+    /// API 取得結果を永続化サービスに非同期保存する（fire-and-forget）
+    private func persistUserProfilesAsync(from users: [HelixUserData]) {
+        guard let persistence = persistenceService, !users.isEmpty else { return }
+        let snapshots = users.map { userData in
+            UserProfileSnapshot(
+                userId: userData.id,
+                login: userData.login.lowercased(),
+                displayName: userData.displayName,
+                profileImageUrl: userData.profileImageUrl?.absoluteString
+            )
+        }
+        Task { [persistence] in
+            try? await persistence.saveUserProfiles(snapshots)
+        }
+    }
+
+    /// 永続化スナップショットをインメモリキャッシュに適用する
+    ///
+    /// fetchUsers の先読みで使用する。`fetchedUserIds` にも登録することで
+    /// 同一ユーザーへの重複 API 呼び出しを防ぐ。
+    private func applyCachedSnapshot(_ snapshot: UserProfileSnapshot) {
+        fetchedUserIds.insert(snapshot.userId)
+        fetchedLogins.insert(snapshot.login)
+        loginToUserId[snapshot.login] = snapshot.userId
+        userLogins[snapshot.userId] = snapshot.login
+        displayNames[snapshot.userId] = snapshot.displayName
+        if let urlString = snapshot.profileImageUrl, let url = URL(string: urlString) {
+            profileImageUrls[snapshot.userId] = url
+        }
+    }
+
     /// Helix API を呼び出してレスポンスをキャッシュに保存する共通処理
     ///
     /// - Parameters:
@@ -239,6 +281,7 @@ final class ProfileImageStore {
                 let returnedLogins = Set(response.data.map { $0.login.lowercased() })
                 fetchedLogins.formUnion(Set(fallbackIds).subtracting(returnedLogins))
             }
+            persistUserProfilesAsync(from: response.data)
         } catch let error as URLError where error.code == .userAuthenticationRequired {
             #if DEBUG
             logger.debug("プロフィール画像取得スキップ: 未認証 queryItems=\(queryItems)")

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -156,7 +156,12 @@ final class ChannelManager {
 
         // 新規接続
         let ircClient = makeIRCClient()
-        let viewModel = ChatViewModel(ircClient: ircClient, authState: authState, apiClient: apiClient)
+        let viewModel = ChatViewModel(
+            ircClient: ircClient,
+            authState: authState,
+            apiClient: apiClient,
+            persistenceService: persistenceService
+        )
 
         // プリロード済みユーザーエモートをシードして初回ピッカー表示を高速化する
         // connect() より前にシードすることで、USERSTATE 到着前からエモートが利用可能になる

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -158,16 +158,18 @@ final class ChatViewModel {
     ///   - authState: 認証状態（ログイン済みなら認証接続に使用）
     ///   - apiClient: Helix API クライアント（テスト時はモックを注入）
     ///   - moderationService: モデレーションサービス（テスト時はモックを注入）
+    ///   - persistenceService: 永続化サービス（nil の場合は永続化なし）
     init(
         ircClient: any TwitchIRCClientProtocol = TwitchIRCClient(),
         authState: AuthState = AuthState(),
         apiClient: (any HelixAPIClientProtocol)? = nil,
-        moderationService: (any ModerationServiceProtocol)? = nil
+        moderationService: (any ModerationServiceProtocol)? = nil,
+        persistenceService: (any PersistenceService)? = nil
     ) {
         self.ircClient = ircClient
         self.authState = authState
         let helixClient = apiClient ?? HelixAPIClient(tokenProvider: authState)
-        self.badgeStore = BadgeStore(apiClient: helixClient)
+        self.badgeStore = BadgeStore(apiClient: helixClient, persistenceService: persistenceService)
         self.emoteStore = EmoteStore(apiClient: helixClient)
         self.moderationService = moderationService ?? ModerationService(apiClient: helixClient)
     }
@@ -192,7 +194,11 @@ final class ChatViewModel {
         await emoteStore.resetChannelEmotes()
 
         // グローバルバッジ・エモート定義を並行フェッチ（切断時にキャンセルできるよう保持）
-        globalBadgeFetchTask = Task { await badgeStore.fetchGlobalBadges() }
+        // seedFromPersistence でキャッシュを先読みしてから fetchGlobalBadges を実行する（stale-while-revalidate）
+        globalBadgeFetchTask = Task {
+            await badgeStore.seedFromPersistence()
+            await badgeStore.fetchGlobalBadges()
+        }
         globalEmoteFetchTask = Task { await emoteStore.fetchGlobalEmotes() }
 
         // ユーザーエモートを並行フェッチ（user:read:emotes スコープがある場合のみ）

--- a/Tests/TwitchChatTests/BadgeStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/BadgeStorePersistenceTests.swift
@@ -1,0 +1,262 @@
+// BadgeStorePersistenceTests.swift
+// BadgeStore の永続化配線テスト（seed / write-back / TTL / scope 分離）
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// API 呼び出し回数を記録する BadgeAPI クライアント
+///
+/// fetchGlobalBadges の TTL テストで「API が呼ばれたか」を確認するために使用する
+actor MockCountingBadgeAPIClient: HelixAPIClientProtocol {
+
+    /// 成功レスポンスとして返すバッジ定義 JSON（nil の場合はサーバーエラーを返す）
+    let badgeJSON: String?
+
+    /// `get` が呼ばれた回数
+    private(set) var getCallCount = 0
+
+    init(badgeJSON: String? = nil) {
+        self.badgeJSON = badgeJSON
+    }
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        getCallCount += 1
+        if let json = badgeJSON, let data = json.data(using: .utf8) {
+            return try JSONDecoder().decode(T.self, from: data)
+        }
+        // 成功 JSON 未設定の場合は未認証エラーとして返す（assertionFailure を避けるため）
+        throw HelixAPIError.unauthorized
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T {
+        throw URLError(.badServerResponse)
+    }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        throw URLError(.badServerResponse)
+    }
+}
+
+// MARK: - テストスイート
+
+/// BadgeStore の永続化配線（seed / write-back / TTL / scope 分離）テスト
+@Suite("BadgeStorePersistenceTests")
+struct BadgeStorePersistenceTests {
+
+    // MARK: - ヘルパー
+
+    /// テスト用グローバルバッジスナップショット
+    private func makeBroadcasterBadge() -> BadgeVersionSnapshot {
+        BadgeVersionSnapshot(
+            setId: "broadcaster",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/broadcaster/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/broadcaster/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/broadcaster/1/4x.png",
+            title: "配信者",
+            description: nil
+        )
+    }
+
+    /// バッジ成功レスポンス JSON（broadcaster バッジ1件）
+    private func broadcasterBadgeJSON() -> String {
+        let version = """
+            {"id":"1","image_url_1x":"https://cdn.example.com/broadcaster/1/1x.png",\
+            "image_url_2x":"https://cdn.example.com/broadcaster/1/2x.png",\
+            "image_url_4x":"https://cdn.example.com/broadcaster/1/4x.png",\
+            "title":"配信者","description":"配信者バッジ"}
+            """
+        return """
+            {"data":[{"set_id":"broadcaster","versions":[\(version)]}]}
+            """
+    }
+
+    // MARK: - seed 正常系
+
+    @Test("永続化済みグローバルバッジからseedすると画像URLを解決できる")
+    func 永続化済みグローバルバッジからseedすると画像URLを解決できる() async {
+        // 前提: InMemoryPersistenceService にグローバルバッジを事前保存する
+        let persistence = InMemoryPersistenceService()
+        let badge = makeBroadcasterBadge()
+        try? await persistence.saveBadges([badge], scope: .global)
+
+        // 操作: 永続化サービスを持つ BadgeStore を作成して seed する
+        let store = BadgeStore(apiClient: MockHelixAPIClient(), persistenceService: persistence)
+        await store.seedFromPersistence()
+
+        // 検証: seed 後にバッジ画像 URL が解決できる（2x URL を使用）
+        let ircBadge = Badge(name: "broadcaster", version: "1")
+        let url = await store.imageURL(for: ircBadge)
+        #expect(url?.absoluteString == "https://cdn.example.com/broadcaster/1/2x.png")
+    }
+
+    @Test("persistenceServiceなしのBadgeStoreはseedFromPersistenceを呼んでも安全")
+    func persistenceServiceなしのBadgeStoreはseedFromPersistenceを呼んでも安全() async {
+        // 前提: persistenceService なしの BadgeStore（既存コードとの後方互換確認）
+        let store = BadgeStore(apiClient: MockHelixAPIClient())
+
+        // 操作: seedFromPersistence を呼んでもクラッシュしない
+        await store.seedFromPersistence()
+
+        // 検証: バッジが設定されていない（URL 解決は nil）
+        let url = await store.imageURL(for: Badge(name: "broadcaster", version: "1"))
+        #expect(url == nil)
+    }
+
+    // MARK: - write-back
+
+    @Test("fetchGlobalBadges成功後に永続化サービスにバッジが保存される")
+    func fetchGlobalBadges成功後に永続化サービスにバッジが保存される() async {
+        // 前提: バッジレスポンスを返す API クライアントと InMemoryPersistenceService
+        let apiClient = MockCountingBadgeAPIClient(badgeJSON: broadcasterBadgeJSON())
+        let persistence = InMemoryPersistenceService()
+        let store = BadgeStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: グローバルバッジをフェッチする
+        await store.fetchGlobalBadges()
+
+        // 検証: 永続化サービスにバッジが保存されている
+        // write-back は Task で非同期に行うため少し待機する
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let saved = await persistence.loadBadges(scope: .global)
+        #expect(saved.contains { $0.setId == "broadcaster" })
+    }
+
+    @Test("fetchChannelBadges成功後にチャンネルスコープで永続化される")
+    func fetchChannelBadges成功後にチャンネルスコープで永続化される() async {
+        // 前提: チャンネルバッジ（subscriber）を返す API クライアント
+        let subVersion = """
+            {"id":"6","image_url_1x":"https://cdn.example.com/sub/6/1x.png",\
+            "image_url_2x":"https://cdn.example.com/sub/6/2x.png",\
+            "image_url_4x":"https://cdn.example.com/sub/6/4x.png",\
+            "title":"6ヶ月サブスク","description":"6ヶ月サブスクバッジ"}
+            """
+        let subscriberJSON = """
+            {"data":[{"set_id":"subscriber","versions":[\(subVersion)]}]}
+            """
+        let apiClient = MockCountingBadgeAPIClient(badgeJSON: subscriberJSON)
+        let persistence = InMemoryPersistenceService()
+        // channelId は Twitch room-id 形式（数字のみ）を使用する
+        let channelId = "12345678"
+        let store = BadgeStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: チャンネルバッジをフェッチする
+        await store.fetchChannelBadges(channelId: channelId)
+
+        // 検証: チャンネルスコープで永続化されている
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let saved = await persistence.loadBadges(scope: .channel(broadcasterId: channelId))
+        #expect(saved.contains { $0.setId == "subscriber" })
+    }
+
+    // MARK: - TTL（stale-while-revalidate）
+
+    @Test("TTL24時間以内のseedではisGlobalLoadedがtrueになりAPI呼び出しを抑止する")
+    func TTL24時間以内のseedではisGlobalLoadedがtrueになりAPI呼び出しを抑止する() async {
+        // 前提: 23h 前に保存したグローバルバッジ（TTL 24h 以内）
+        let persistence = InMemoryPersistenceService()
+        let badge = makeBroadcasterBadge()
+        let twentyThreeHoursAgo = Date().addingTimeInterval(-23 * 3600)
+        await persistence.saveBadgesWithDate([badge], scope: .global, savedAt: twentyThreeHoursAgo)
+
+        let apiClient = MockCountingBadgeAPIClient()
+        let store = BadgeStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchGlobalBadges を呼ぶ
+        await store.seedFromPersistence()
+        await store.fetchGlobalBadges()
+
+        // 検証: TTL 以内なので API は呼ばれない（isGlobalLoaded = true で guard を通過しない）
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 0)
+    }
+
+    @Test("TTL24時間超のseedではAPIを再フェッチする（stale-while-revalidate）")
+    func TTL24時間超のseedではAPIを再フェッチする() async {
+        // 前提: 25h 前に保存したグローバルバッジ（TTL 24h 超）
+        let persistence = InMemoryPersistenceService()
+        let badge = makeBroadcasterBadge()
+        let twentyFiveHoursAgo = Date().addingTimeInterval(-25 * 3600)
+        await persistence.saveBadgesWithDate([badge], scope: .global, savedAt: twentyFiveHoursAgo)
+
+        // API は失敗させて（ネットワーク未接続想定）API が呼ばれたかどうかだけ確認する
+        let apiClient = MockCountingBadgeAPIClient()
+        let store = BadgeStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchGlobalBadges を呼ぶ
+        await store.seedFromPersistence()
+        await store.fetchGlobalBadges()
+
+        // 検証: TTL 超過のため isGlobalLoaded = false のまま → API が呼ばれる
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 1)
+    }
+
+    // MARK: - scope 分離
+
+    @Test("グローバルバッジとチャンネルバッジは別スコープで独立して永続化される")
+    func グローバルバッジとチャンネルバッジは別スコープで独立して永続化される() async {
+        // 前提: グローバルとチャンネルで異なるバッジを事前保存
+        let persistence = InMemoryPersistenceService()
+        let globalBadge = BadgeVersionSnapshot(
+            setId: "broadcaster",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/broadcaster/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/broadcaster/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/broadcaster/1/4x.png",
+            title: "配信者",
+            description: nil
+        )
+        let channelBadge = BadgeVersionSnapshot(
+            setId: "subscriber",
+            version: "6",
+            imageUrl1x: "https://cdn.example.com/sub/6/1x.png",
+            imageUrl2x: "https://cdn.example.com/sub/6/2x.png",
+            imageUrl4x: "https://cdn.example.com/sub/6/4x.png",
+            title: "6ヶ月サブスク",
+            description: nil
+        )
+        try? await persistence.saveBadges([globalBadge], scope: .global)
+        try? await persistence.saveBadges([channelBadge], scope: .channel(broadcasterId: "テストチャンネルID"))
+
+        // 操作: それぞれのスコープでタイムスタンプ付きバッジを取得
+        let globalResult = await persistence.loadBadgesWithTimestamp(scope: .global)
+        let channelResult = await persistence.loadBadgesWithTimestamp(
+            scope: .channel(broadcasterId: "テストチャンネルID")
+        )
+        let unknownResult = await persistence.loadBadgesWithTimestamp(
+            scope: .channel(broadcasterId: "未登録チャンネルID")
+        )
+
+        // 検証: グローバルスコープには broadcaster バッジのみ
+        #expect(globalResult.snapshots.count == 1)
+        #expect(globalResult.snapshots.first?.setId == "broadcaster")
+        #expect(globalResult.fetchedAt != nil)
+
+        // 検証: チャンネルスコープには subscriber バッジのみ
+        #expect(channelResult.snapshots.count == 1)
+        #expect(channelResult.snapshots.first?.setId == "subscriber")
+        #expect(channelResult.fetchedAt != nil)
+
+        // 検証: 未登録チャンネルは空かつ fetchedAt は nil
+        #expect(unknownResult.snapshots.isEmpty)
+        #expect(unknownResult.fetchedAt == nil)
+    }
+}

--- a/Tests/TwitchChatTests/BadgeStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/BadgeStorePersistenceTests.swift
@@ -75,6 +75,21 @@ struct BadgeStorePersistenceTests {
         )
     }
 
+    /// 永続化サービスにバッジが保存されるまでポーリング待機する
+    private func waitForSavedBadges(
+        in persistence: InMemoryPersistenceService,
+        scope: BadgeScope,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> [BadgeVersionSnapshot] {
+        let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            let saved = await persistence.loadBadges(scope: scope)
+            if !saved.isEmpty { return saved }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await persistence.loadBadges(scope: scope)
+    }
+
     /// バッジ成功レスポンス JSON（broadcaster バッジ1件）
     private func broadcasterBadgeJSON() -> String {
         let version = """
@@ -91,11 +106,11 @@ struct BadgeStorePersistenceTests {
     // MARK: - seed 正常系
 
     @Test("永続化済みグローバルバッジからseedすると画像URLを解決できる")
-    func 永続化済みグローバルバッジからseedすると画像URLを解決できる() async {
+    func 永続化済みグローバルバッジからseedすると画像URLを解決できる() async throws {
         // 前提: InMemoryPersistenceService にグローバルバッジを事前保存する
         let persistence = InMemoryPersistenceService()
         let badge = makeBroadcasterBadge()
-        try? await persistence.saveBadges([badge], scope: .global)
+        try await persistence.saveBadges([badge], scope: .global)
 
         // 操作: 永続化サービスを持つ BadgeStore を作成して seed する
         let store = BadgeStore(apiClient: MockHelixAPIClient(), persistenceService: persistence)
@@ -132,10 +147,8 @@ struct BadgeStorePersistenceTests {
         // 操作: グローバルバッジをフェッチする
         await store.fetchGlobalBadges()
 
-        // 検証: 永続化サービスにバッジが保存されている
-        // write-back は Task で非同期に行うため少し待機する
-        try? await Task.sleep(nanoseconds: 100_000_000)
-        let saved = await persistence.loadBadges(scope: .global)
+        // 検証: 永続化サービスにバッジが保存されている（write-back の完了を bounded poll で待機）
+        let saved = await waitForSavedBadges(in: persistence, scope: .global)
         #expect(saved.contains { $0.setId == "broadcaster" })
     }
 
@@ -160,9 +173,11 @@ struct BadgeStorePersistenceTests {
         // 操作: チャンネルバッジをフェッチする
         await store.fetchChannelBadges(channelId: channelId)
 
-        // 検証: チャンネルスコープで永続化されている
-        try? await Task.sleep(nanoseconds: 100_000_000)
-        let saved = await persistence.loadBadges(scope: .channel(broadcasterId: channelId))
+        // 検証: チャンネルスコープで永続化されている（write-back の完了を bounded poll で待機）
+        let saved = await waitForSavedBadges(
+            in: persistence,
+            scope: .channel(broadcasterId: channelId)
+        )
         #expect(saved.contains { $0.setId == "subscriber" })
     }
 
@@ -212,7 +227,7 @@ struct BadgeStorePersistenceTests {
     // MARK: - scope 分離
 
     @Test("グローバルバッジとチャンネルバッジは別スコープで独立して永続化される")
-    func グローバルバッジとチャンネルバッジは別スコープで独立して永続化される() async {
+    func グローバルバッジとチャンネルバッジは別スコープで独立して永続化される() async throws {
         // 前提: グローバルとチャンネルで異なるバッジを事前保存
         let persistence = InMemoryPersistenceService()
         let globalBadge = BadgeVersionSnapshot(
@@ -233,8 +248,8 @@ struct BadgeStorePersistenceTests {
             title: "6ヶ月サブスク",
             description: nil
         )
-        try? await persistence.saveBadges([globalBadge], scope: .global)
-        try? await persistence.saveBadges([channelBadge], scope: .channel(broadcasterId: "テストチャンネルID"))
+        try await persistence.saveBadges([globalBadge], scope: .global)
+        try await persistence.saveBadges([channelBadge], scope: .channel(broadcasterId: "テストチャンネルID"))
 
         // 操作: それぞれのスコープでタイムスタンプ付きバッジを取得
         let globalResult = await persistence.loadBadgesWithTimestamp(scope: .global)

--- a/Tests/TwitchChatTests/BadgeStoreTests.swift
+++ b/Tests/TwitchChatTests/BadgeStoreTests.swift
@@ -180,7 +180,7 @@ struct BadgeStoreTests {
 
     @Test("空のバッジセット配列からは空マッピングを構築する")
     func testBuildMappingFromEmptyBadgeSets() {
-        let mapping = BadgeStore.buildMapping(from: [])
+        let mapping = BadgeStore.buildMapping(from: [] as [HelixBadgeSet])
         #expect(mapping.isEmpty)
     }
 

--- a/Tests/TwitchChatTests/PersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/PersistenceServiceTests.swift
@@ -234,6 +234,83 @@ struct PersistenceServiceTests {
         #expect(missing == nil)
     }
 
+    // MARK: - バッジ（タイムスタンプ付き）
+
+    @Test("バッジ保存後にloadBadgesWithTimestampでfetchedAtを取得できる")
+    func バッジ保存後にloadBadgesWithTimestampでfetchedAtを取得できる() async throws {
+        // 前提: グローバルバッジを保存する前後の時刻を記録する
+        let service = InMemoryPersistenceService()
+        let beforeSave = Date()
+        let badge = BadgeVersionSnapshot(
+            setId: "broadcaster",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/broadcaster/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/broadcaster/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/broadcaster/1/4x.png",
+            title: "配信者",
+            description: nil
+        )
+
+        // 操作: グローバルスコープで保存する
+        try await service.saveBadges([badge], scope: .global)
+        let afterSave = Date()
+
+        // 操作: タイムスタンプ付きで取得する
+        let result = await service.loadBadgesWithTimestamp(scope: .global)
+
+        // 検証: スナップショットが1件取得できる
+        #expect(result.snapshots.count == 1)
+        #expect(result.snapshots.first?.setId == "broadcaster")
+
+        // 検証: fetchedAt が保存操作の前後の時刻の範囲内にある
+        let fetchedAt = try #require(result.fetchedAt)
+        #expect(fetchedAt >= beforeSave)
+        #expect(fetchedAt <= afterSave)
+    }
+
+    @Test("未保存スコープのloadBadgesWithTimestampはfetchedAtにnilを返す")
+    func 未保存スコープのloadBadgesWithTimestampはfetchedAtにnilを返す() async throws {
+        // 前提: 何も保存していない空のサービス
+        let service = InMemoryPersistenceService()
+
+        // 操作: 未保存のグローバルスコープを取得する
+        let result = await service.loadBadgesWithTimestamp(scope: .global)
+
+        // 検証: スナップショットは空で fetchedAt は nil
+        #expect(result.snapshots.isEmpty)
+        #expect(result.fetchedAt == nil)
+    }
+
+    @Test("loadBadgesWithTimestampはスコープごとにタイムスタンプを分離する")
+    func loadBadgesWithTimestampはスコープごとにタイムスタンプを分離する() async throws {
+        // 前提: グローバルバッジのみ保存し、チャンネルバッジは保存しない
+        let service = InMemoryPersistenceService()
+        let globalBadge = BadgeVersionSnapshot(
+            setId: "moderator",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/mod/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/mod/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/mod/1/4x.png",
+            title: "モデレーター",
+            description: nil
+        )
+        try await service.saveBadges([globalBadge], scope: .global)
+
+        // 操作: グローバルとチャンネルそれぞれのタイムスタンプ付きバッジを取得する
+        let globalResult = await service.loadBadgesWithTimestamp(scope: .global)
+        let channelResult = await service.loadBadgesWithTimestamp(
+            scope: .channel(broadcasterId: "未保存チャンネルID")
+        )
+
+        // 検証: グローバルは保存済みなので fetchedAt が存在する
+        #expect(!globalResult.snapshots.isEmpty)
+        #expect(globalResult.fetchedAt != nil)
+
+        // 検証: チャンネルは未保存なので空かつ fetchedAt は nil
+        #expect(channelResult.snapshots.isEmpty)
+        #expect(channelResult.fetchedAt == nil)
+    }
+
     // MARK: - ライフサイクル
 
     @Test("clearUserScopedでユーザー固有データのみ削除される")

--- a/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
@@ -22,15 +22,6 @@ struct ProfileImageStorePersistenceTests {
         )
     }
 
-    private func makeSatoProfile() -> UserProfileSnapshot {
-        UserProfileSnapshot(
-            userId: "ユーザーID002",
-            login: "sato_hanako",
-            displayName: "佐藤花子",
-            profileImageUrl: nil
-        )
-    }
-
     // MARK: - キャッシュ先読み（API 呼び出し抑制）
 
     @Test("永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される")
@@ -38,7 +29,7 @@ struct ProfileImageStorePersistenceTests {
         // 前提: 山田太郎のプロフィールを InMemoryPersistenceService に事前保存する
         let persistence = InMemoryPersistenceService()
         let yamada = makeYamadaProfile()
-        try? await persistence.saveUserProfiles([yamada])
+        try await persistence.saveUserProfiles([yamada])
 
         // 前提: API クライアントは呼ばれてはならない（永続化から解決できるため）
         let apiClient = MockProfileImageAPIClient()
@@ -128,7 +119,7 @@ struct ProfileImageStorePersistenceTests {
         // 前提: 永続化に山田太郎を保存済み
         let persistence = InMemoryPersistenceService()
         let yamada = makeYamadaProfile()
-        try? await persistence.saveUserProfiles([yamada])
+        try await persistence.saveUserProfiles([yamada])
 
         let apiClient = MockProfileImageAPIClient()
         let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)

--- a/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
@@ -22,10 +22,25 @@ struct ProfileImageStorePersistenceTests {
         )
     }
 
+    /// 永続化サービスに期待数のプロフィールが保存されるまでポーリング待機する
+    private func waitForSavedProfiles(
+        in persistence: InMemoryPersistenceService,
+        userIds: [String],
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> [UserProfileSnapshot] {
+        let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            let saved = await persistence.loadUserProfiles(userIds: userIds)
+            if saved.count == userIds.count { return saved }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await persistence.loadUserProfiles(userIds: userIds)
+    }
+
     // MARK: - キャッシュ先読み（API 呼び出し抑制）
 
     @Test("永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される")
-    func 永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される() async {
+    func 永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される() async throws {
         // 前提: 山田太郎のプロフィールを InMemoryPersistenceService に事前保存する
         let persistence = InMemoryPersistenceService()
         let yamada = makeYamadaProfile()
@@ -43,8 +58,8 @@ struct ProfileImageStorePersistenceTests {
         #expect(callCount == 0)
 
         // 検証: 永続化から復元されたプロフィールで表示名・画像URLを解決できる
-        let displayName = await store.displayName(for: "ユーザーID001")
-        let imageURL = await store.profileImageUrl(for: "ユーザーID001")
+        let displayName = store.displayName(for: "ユーザーID001")
+        let imageURL = store.profileImageUrl(for: "ユーザーID001")
         #expect(displayName == "山田太郎")
         #expect(imageURL?.absoluteString == "https://cdn.example.com/profile/yamada.png")
     }
@@ -72,7 +87,7 @@ struct ProfileImageStorePersistenceTests {
         #expect(callCount == 1)
 
         // 検証: displayName が解決できる
-        let displayName = await store.displayName(for: "ユーザーID001")
+        let displayName = store.displayName(for: "ユーザーID001")
         #expect(displayName == "山田太郎")
     }
 
@@ -102,11 +117,11 @@ struct ProfileImageStorePersistenceTests {
         let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)
         await store.fetchUsers(userIds: ["ユーザーID001", "ユーザーID002"])
 
-        // write-back は Task で非同期に行うため少し待機する
-        try? await Task.sleep(nanoseconds: 100_000_000)
-
-        // 検証: 永続化サービスに両ユーザーのプロフィールが保存されている
-        let saved = await persistence.loadUserProfiles(userIds: ["ユーザーID001", "ユーザーID002"])
+        // 検証: 永続化サービスに両ユーザーのプロフィールが保存されている（write-back の完了を bounded poll で待機）
+        let saved = await waitForSavedProfiles(
+            in: persistence,
+            userIds: ["ユーザーID001", "ユーザーID002"]
+        )
         #expect(saved.count == 2)
         #expect(saved.map(\.displayName).contains("山田太郎"))
         #expect(saved.map(\.displayName).contains("佐藤花子"))
@@ -115,7 +130,7 @@ struct ProfileImageStorePersistenceTests {
     // MARK: - clear 後の復元
 
     @Test("clear後にfetchUsersを呼ぶと永続化キャッシュから復元されAPIを呼ばない")
-    func clear後にfetchUsersを呼ぶと永続化キャッシュから復元されAPIを呼ばない() async {
+    func clear後にfetchUsersを呼ぶと永続化キャッシュから復元されAPIを呼ばない() async throws {
         // 前提: 永続化に山田太郎を保存済み
         let persistence = InMemoryPersistenceService()
         let yamada = makeYamadaProfile()
@@ -128,7 +143,7 @@ struct ProfileImageStorePersistenceTests {
         await store.fetchUsers(userIds: ["ユーザーID001"])
 
         // 操作: clear() を呼ぶ（in-memory キャッシュを消去、永続化データは保持）
-        await store.clear()
+        store.clear()
 
         // 操作: 再度 fetchUsers を呼ぶ
         await store.fetchUsers(userIds: ["ユーザーID001"])
@@ -138,7 +153,7 @@ struct ProfileImageStorePersistenceTests {
         #expect(callCount == 0)
 
         // 検証: clear 後でも displayName が解決できる
-        let displayName = await store.displayName(for: "ユーザーID001")
+        let displayName = store.displayName(for: "ユーザーID001")
         #expect(displayName == "山田太郎")
     }
 }

--- a/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
@@ -1,0 +1,153 @@
+// ProfileImageStorePersistenceTests.swift
+// ProfileImageStore の永続化配線テスト（キャッシュ先読み / write-back / clear 後の復元）
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+/// ProfileImageStore の永続化配線テストスイート
+@Suite("ProfileImageStorePersistenceTests")
+@MainActor
+struct ProfileImageStorePersistenceTests {
+
+    // MARK: - ヘルパー
+
+    /// テスト用ユーザープロフィールスナップショットを生成する
+    private func makeYamadaProfile() -> UserProfileSnapshot {
+        UserProfileSnapshot(
+            userId: "ユーザーID001",
+            login: "yamada_taro",
+            displayName: "山田太郎",
+            profileImageUrl: "https://cdn.example.com/profile/yamada.png"
+        )
+    }
+
+    private func makeSatoProfile() -> UserProfileSnapshot {
+        UserProfileSnapshot(
+            userId: "ユーザーID002",
+            login: "sato_hanako",
+            displayName: "佐藤花子",
+            profileImageUrl: nil
+        )
+    }
+
+    // MARK: - キャッシュ先読み（API 呼び出し抑制）
+
+    @Test("永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される")
+    func 永続化済みプロフィールはfetchUsers呼び出し時にAPIを呼ばずに解決される() async {
+        // 前提: 山田太郎のプロフィールを InMemoryPersistenceService に事前保存する
+        let persistence = InMemoryPersistenceService()
+        let yamada = makeYamadaProfile()
+        try? await persistence.saveUserProfiles([yamada])
+
+        // 前提: API クライアントは呼ばれてはならない（永続化から解決できるため）
+        let apiClient = MockProfileImageAPIClient()
+
+        // 操作: persistenceService 付きで ProfileImageStore を初期化し fetchUsers を呼ぶ
+        let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)
+        await store.fetchUsers(userIds: ["ユーザーID001"])
+
+        // 検証: API は呼ばれなかった
+        let callCount = await apiClient.callCount
+        #expect(callCount == 0)
+
+        // 検証: 永続化から復元されたプロフィールで表示名・画像URLを解決できる
+        let displayName = await store.displayName(for: "ユーザーID001")
+        let imageURL = await store.profileImageUrl(for: "ユーザーID001")
+        #expect(displayName == "山田太郎")
+        #expect(imageURL?.absoluteString == "https://cdn.example.com/profile/yamada.png")
+    }
+
+    @Test("永続化にないプロフィールはAPIを呼んで取得する")
+    func 永続化にないプロフィールはAPIを呼んで取得する() async {
+        // 前提: 永続化サービスは空、API クライアントは山田太郎を返す
+        let persistence = InMemoryPersistenceService()
+        let apiClient = MockProfileImageAPIClient()
+        await apiClient.setUsers([
+            HelixUserData(
+                id: "ユーザーID001",
+                login: "yamada_taro",
+                displayName: "山田太郎",
+                profileImageUrl: URL(string: "https://cdn.example.com/profile/yamada.png")
+            )
+        ])
+
+        // 操作: fetchUsers を呼ぶ（永続化にないので API を呼ぶはず）
+        let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)
+        await store.fetchUsers(userIds: ["ユーザーID001"])
+
+        // 検証: API が1回呼ばれた
+        let callCount = await apiClient.callCount
+        #expect(callCount == 1)
+
+        // 検証: displayName が解決できる
+        let displayName = await store.displayName(for: "ユーザーID001")
+        #expect(displayName == "山田太郎")
+    }
+
+    // MARK: - write-back
+
+    @Test("APIフェッチ後にプロフィールが永続化サービスに保存される")
+    func APIフェッチ後にプロフィールが永続化サービスに保存される() async {
+        // 前提: 空の永続化サービスと、山田太郎・佐藤花子を返す API クライアント
+        let persistence = InMemoryPersistenceService()
+        let apiClient = MockProfileImageAPIClient()
+        await apiClient.setUsers([
+            HelixUserData(
+                id: "ユーザーID001",
+                login: "yamada_taro",
+                displayName: "山田太郎",
+                profileImageUrl: URL(string: "https://cdn.example.com/profile/yamada.png")
+            ),
+            HelixUserData(
+                id: "ユーザーID002",
+                login: "sato_hanako",
+                displayName: "佐藤花子",
+                profileImageUrl: nil
+            )
+        ])
+
+        // 操作: fetchUsers で2ユーザーを取得する
+        let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)
+        await store.fetchUsers(userIds: ["ユーザーID001", "ユーザーID002"])
+
+        // write-back は Task で非同期に行うため少し待機する
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // 検証: 永続化サービスに両ユーザーのプロフィールが保存されている
+        let saved = await persistence.loadUserProfiles(userIds: ["ユーザーID001", "ユーザーID002"])
+        #expect(saved.count == 2)
+        #expect(saved.map(\.displayName).contains("山田太郎"))
+        #expect(saved.map(\.displayName).contains("佐藤花子"))
+    }
+
+    // MARK: - clear 後の復元
+
+    @Test("clear後にfetchUsersを呼ぶと永続化キャッシュから復元されAPIを呼ばない")
+    func clear後にfetchUsersを呼ぶと永続化キャッシュから復元されAPIを呼ばない() async {
+        // 前提: 永続化に山田太郎を保存済み
+        let persistence = InMemoryPersistenceService()
+        let yamada = makeYamadaProfile()
+        try? await persistence.saveUserProfiles([yamada])
+
+        let apiClient = MockProfileImageAPIClient()
+        let store = ProfileImageStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: まず fetchUsers を呼んでキャッシュに入れる
+        await store.fetchUsers(userIds: ["ユーザーID001"])
+
+        // 操作: clear() を呼ぶ（in-memory キャッシュを消去、永続化データは保持）
+        await store.clear()
+
+        // 操作: 再度 fetchUsers を呼ぶ
+        await store.fetchUsers(userIds: ["ユーザーID001"])
+
+        // 検証: API は呼ばれなかった（永続化から復元）
+        let callCount = await apiClient.callCount
+        #expect(callCount == 0)
+
+        // 検証: clear 後でも displayName が解決できる
+        let displayName = await store.displayName(for: "ユーザーID001")
+        #expect(displayName == "山田太郎")
+    }
+}

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -498,6 +498,83 @@ struct SwiftDataPersistenceServiceTests {
         #expect(loadedBadge == badgeData)
     }
 
+    // MARK: - バッジ（タイムスタンプ付き）
+
+    @Test("バッジ保存後にloadBadgesWithTimestampでfetchedAtを取得できる")
+    func バッジ保存後にloadBadgesWithTimestampでfetchedAtを取得できる() async throws {
+        // 前提: グローバルバッジを保存する前後の時刻を記録する
+        let service = try makeService()
+        let beforeSave = Date()
+        let badge = BadgeVersionSnapshot(
+            setId: "broadcaster",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/broadcaster/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/broadcaster/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/broadcaster/1/4x.png",
+            title: "配信者",
+            description: nil
+        )
+
+        // 操作: グローバルスコープで保存する
+        try await service.saveBadges([badge], scope: .global)
+        let afterSave = Date()
+
+        // 操作: タイムスタンプ付きで取得する
+        let result = await service.loadBadgesWithTimestamp(scope: .global)
+
+        // 検証: スナップショットが1件取得できる
+        #expect(result.snapshots.count == 1)
+        #expect(result.snapshots.first?.setId == "broadcaster")
+
+        // 検証: fetchedAt が保存操作の前後の時刻の範囲内にある
+        let fetchedAt = try #require(result.fetchedAt)
+        #expect(fetchedAt >= beforeSave)
+        #expect(fetchedAt <= afterSave)
+    }
+
+    @Test("未保存スコープのloadBadgesWithTimestampはfetchedAtにnilを返す")
+    func 未保存スコープのloadBadgesWithTimestampはfetchedAtにnilを返す() async throws {
+        // 前提: 何も保存していない空のサービス
+        let service = try makeService()
+
+        // 操作: 未保存のグローバルスコープを取得する
+        let result = await service.loadBadgesWithTimestamp(scope: .global)
+
+        // 検証: スナップショットは空で fetchedAt は nil
+        #expect(result.snapshots.isEmpty)
+        #expect(result.fetchedAt == nil)
+    }
+
+    @Test("loadBadgesWithTimestampはスコープごとにタイムスタンプを分離する")
+    func loadBadgesWithTimestampはスコープごとにタイムスタンプを分離する() async throws {
+        // 前提: グローバルバッジのみ保存し、チャンネルバッジは保存しない
+        let service = try makeService()
+        let globalBadge = BadgeVersionSnapshot(
+            setId: "moderator",
+            version: "1",
+            imageUrl1x: "https://cdn.example.com/mod/1/1x.png",
+            imageUrl2x: "https://cdn.example.com/mod/1/2x.png",
+            imageUrl4x: "https://cdn.example.com/mod/1/4x.png",
+            title: "モデレーター",
+            description: nil
+        )
+        try await service.saveBadges([globalBadge], scope: .global)
+
+        // 操作: グローバルとチャンネルそれぞれのタイムスタンプ付きバッジを取得する
+        let globalResult = await service.loadBadgesWithTimestamp(scope: .global)
+        let channelResult = await service.loadBadgesWithTimestamp(
+            scope: .channel(broadcasterId: "未保存チャンネルID")
+        )
+
+        // 検証: グローバルは保存済みなので fetchedAt が存在する
+        #expect(!globalResult.snapshots.isEmpty)
+        #expect(globalResult.fetchedAt != nil)
+
+        // 検証: チャンネルは未保存なので空かつ fetchedAt は nil
+        #expect(channelResult.snapshots.isEmpty)
+        #expect(channelResult.fetchedAt == nil)
+    }
+
     // MARK: - ライフサイクル
 
     @Test("clearUserScopedでユーザー固有データのみ削除されグローバル_チャンネル_履歴は保持される")


### PR DESCRIPTION
## Summary

- `PersistenceService` に `loadBadgesWithTimestamp(scope:)` を追加し、TTL（24h）判定で stale-while-revalidate を実現
- `BadgeStore` に永続化 seed・write-back・TTL 判定を追加。`seedFromPersistence()` でオフラインキャッシュから即描画できるよう配線
- `ProfileImageStore.fetchUsers(userIds:)` に永続化キャッシュ先読みを追加し、API 呼び出しを最小化
- `TwitchChatApp` の `PersistenceContainer.makeOnDisk()` を do-catch に変更し、失敗時に InMemory へフォールバック
- `ChatViewModel` / `ChannelManager` に `persistenceService` を伝播

## Test plan

- [ ] `swift test --filter BadgeStorePersistenceTests` が全件パス
- [ ] `swift test --filter ProfileImageStorePersistenceTests` が全件パス
- [ ] `swift test --filter SwiftDataPersistenceService` が全件パス
- [ ] `swift test --filter PersistenceService` が全件パス
- [ ] `swiftlint lint --strict` で 0 violations
- [ ] アプリ起動 → チャンネル参加 → バッジ表示を確認
- [ ] アプリ再起動（24h 以内）→ ネットワーク切断状態でも同チャンネルのバッジが即表示されること

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ディスク永続化を導入し、バッジやプロフィール画像が再起動後も保持されるようになりました
  * バッジに24時間のTTLを追加し、永続化からのシード（stale-while-revalidate）で読み込みを高速化

* **改善**
  * 永続化初期化失敗時はログ出力して自動的にメモリ内にフォールバックするように強化

* **テスト**
  * 永続化の振る舞い（タイムスタンプ、スコープ分離、TTL）を検証する包括的なテスト群を追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->