### PR TITLE
feat: エモートの永続化配線（永続化基盤 PR-4）

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -61,7 +61,10 @@ struct TwitchChatApp: App {
                         followedStreamStore.clear()
                         followedChannelStore.clear()
                         profileImageStore.clear()
-                        Task { await channelManager.disconnectAll() }
+                        Task {
+                            await channelManager.disconnectAll()
+                            await channelManager.clearPersistedUserData()
+                        }
                     case .unknown:
                         break
                     }

--- a/Sources/TwitchChat/Persistence/InMemoryPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/InMemoryPersistenceService.swift
@@ -17,9 +17,12 @@ actor InMemoryPersistenceService: PersistenceService {
 
     // MARK: - ストレージ
 
-    private var userEmotes: [String: [HelixEmote]] = [:]
-    private var globalEmotes: [HelixEmote] = []
-    private var channelEmotes: [String: [HelixEmote]] = [:]
+    /// ユーザーエモートとその保存時刻（TTL 判定用）
+    private var userEmotes: [String: (emotes: [HelixEmote], savedAt: Date)] = [:]
+    /// グローバルエモートとその保存時刻（TTL 判定用）
+    private var globalEmotes: (emotes: [HelixEmote], savedAt: Date)?
+    /// チャンネルエモートとその保存時刻（TTL 判定用）
+    private var channelEmotes: [String: (emotes: [HelixEmote], savedAt: Date)] = [:]
     /// バッジデータとその保存時刻を保持する（TTL 判定に使用）
     private var badges: [BadgeScope: (snapshots: [BadgeVersionSnapshot], savedAt: Date)] = [:]
     private var userProfiles: [String: UserProfileSnapshot] = [:]
@@ -32,27 +35,42 @@ actor InMemoryPersistenceService: PersistenceService {
     // MARK: - PersistenceService
 
     func loadUserEmotes(userId: String) async -> [HelixEmote] {
-        userEmotes[userId] ?? []
+        userEmotes[userId]?.emotes ?? []
     }
 
     func saveUserEmotes(_ emotes: [HelixEmote], userId: String) async throws {
-        userEmotes[userId] = emotes
+        userEmotes[userId] = (emotes: emotes, savedAt: Date())
     }
 
     func loadGlobalEmotes() async -> [HelixEmote] {
-        globalEmotes
+        globalEmotes?.emotes ?? []
     }
 
     func saveGlobalEmotes(_ emotes: [HelixEmote]) async throws {
-        globalEmotes = emotes
+        globalEmotes = (emotes: emotes, savedAt: Date())
     }
 
     func loadChannelEmotes(broadcasterId: String) async -> [HelixEmote] {
-        channelEmotes[broadcasterId] ?? []
+        channelEmotes[broadcasterId]?.emotes ?? []
     }
 
     func saveChannelEmotes(_ emotes: [HelixEmote], broadcasterId: String) async throws {
-        channelEmotes[broadcasterId] = emotes
+        channelEmotes[broadcasterId] = (emotes: emotes, savedAt: Date())
+    }
+
+    func loadGlobalEmotesWithTimestamp() async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        guard let entry = globalEmotes else { return (emotes: [], fetchedAt: nil) }
+        return (emotes: entry.emotes, fetchedAt: entry.savedAt)
+    }
+
+    func loadUserEmotesWithTimestamp(userId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        guard let entry = userEmotes[userId] else { return (emotes: [], fetchedAt: nil) }
+        return (emotes: entry.emotes, fetchedAt: entry.savedAt)
+    }
+
+    func loadChannelEmotesWithTimestamp(broadcasterId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        guard let entry = channelEmotes[broadcasterId] else { return (emotes: [], fetchedAt: nil) }
+        return (emotes: entry.emotes, fetchedAt: entry.savedAt)
     }
 
     func loadBadges(scope: BadgeScope) async -> [BadgeVersionSnapshot] {
@@ -133,6 +151,21 @@ actor InMemoryPersistenceService: PersistenceService {
     /// テスト用: バッジを任意の保存日時で登録する（TTL 検証用）
     func saveBadgesWithDate(_ badgeList: [BadgeVersionSnapshot], scope: BadgeScope, savedAt: Date) async {
         badges[scope] = (snapshots: badgeList, savedAt: savedAt)
+    }
+
+    /// テスト用: グローバルエモートを任意の保存日時で登録する（TTL 検証用）
+    func saveGlobalEmotesWithDate(_ emotes: [HelixEmote], savedAt: Date) async {
+        globalEmotes = (emotes: emotes, savedAt: savedAt)
+    }
+
+    /// テスト用: ユーザーエモートを任意の保存日時で登録する（TTL 検証用）
+    func saveUserEmotesWithDate(_ emotes: [HelixEmote], userId: String, savedAt: Date) async {
+        userEmotes[userId] = (emotes: emotes, savedAt: savedAt)
+    }
+
+    /// テスト用: チャンネルエモートを任意の保存日時で登録する（TTL 検証用）
+    func saveChannelEmotesWithDate(_ emotes: [HelixEmote], broadcasterId: String, savedAt: Date) async {
+        channelEmotes[broadcasterId] = (emotes: emotes, savedAt: savedAt)
     }
 #endif
 }

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -48,6 +48,27 @@ actor PersistenceActor {
         try upsertEmotes(emotes, scope: .channel(broadcasterId: broadcasterId))
     }
 
+    /// グローバルエモートをタイムスタンプ付きで取得する
+    ///
+    /// `updatedAt` の最大値を `fetchedAt` として返す。未保存の場合は `fetchedAt` が nil。
+    func loadGlobalEmotesWithTimestamp() -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        fetchEmotesWithTimestamp(scopeRaw: EmoteScope.global.rawValue)
+    }
+
+    /// 指定ユーザーのエモートをタイムスタンプ付きで取得する
+    ///
+    /// `updatedAt` の最大値を `fetchedAt` として返す。未保存の場合は `fetchedAt` が nil。
+    func loadUserEmotesWithTimestamp(userId: String) -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        fetchEmotesWithTimestamp(scopeRaw: EmoteScope.user(userId: userId).rawValue)
+    }
+
+    /// 指定チャンネルのエモートをタイムスタンプ付きで取得する
+    ///
+    /// `updatedAt` の最大値を `fetchedAt` として返す。未保存の場合は `fetchedAt` が nil。
+    func loadChannelEmotesWithTimestamp(broadcasterId: String) -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        fetchEmotesWithTimestamp(scopeRaw: EmoteScope.channel(broadcasterId: broadcasterId).rawValue)
+    }
+
     // MARK: - バッジ
 
     /// 指定スコープのバッジを取得する
@@ -244,6 +265,20 @@ private extension PersistenceActor {
         )
         let rows = (try? modelContext.fetch(descriptor)) ?? []
         return rows.map { $0.toDomain() }
+    }
+
+    /// スコープ別エモートをタイムスタンプ付きで fetch する
+    ///
+    /// `updatedAt` の最大値を `fetchedAt` として返す。バッジの `fetchBadgeRows` と同じ流儀。
+    func fetchEmotesWithTimestamp(scopeRaw: String) -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        let descriptor = FetchDescriptor<PersistedEmote>(
+            predicate: #Predicate { $0.scope == scopeRaw }
+        )
+        let rows = (try? modelContext.fetch(descriptor)) ?? []
+        guard !rows.isEmpty else { return (emotes: [], fetchedAt: nil) }
+        let emotes = rows.map { $0.toDomain() }
+        let fetchedAt = rows.map(\.updatedAt).max()
+        return (emotes: emotes, fetchedAt: fetchedAt)
     }
 
     /// エモートをスコープ単位で upsert する（既存を全件差し替え）

--- a/Sources/TwitchChat/Persistence/PersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceService.swift
@@ -40,6 +40,24 @@ protocol PersistenceService: Sendable {
     /// - Throws: ディスクまたはデータベース書き込みに失敗した場合
     func saveChannelEmotes(_ emotes: [HelixEmote], broadcasterId: String) async throws
 
+    /// グローバルエモートをタイムスタンプ付きでロードする
+    ///
+    /// TTL 判定（24h stale-while-revalidate）に使用する。
+    /// 未保存の場合は `fetchedAt` に nil を返す。
+    func loadGlobalEmotesWithTimestamp() async -> (emotes: [HelixEmote], fetchedAt: Date?)
+
+    /// 指定ユーザーのエモートをタイムスタンプ付きでロードする
+    ///
+    /// TTL 判定（24h stale-while-revalidate）に使用する。
+    /// 未保存の場合は `fetchedAt` に nil を返す。
+    func loadUserEmotesWithTimestamp(userId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?)
+
+    /// 指定チャンネルのエモートをタイムスタンプ付きでロードする
+    ///
+    /// TTL 判定（24h stale-while-revalidate）に使用する。
+    /// 未保存の場合は `fetchedAt` に nil を返す。
+    func loadChannelEmotesWithTimestamp(broadcasterId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?)
+
     // MARK: - バッジ・プロフィール
 
     /// 指定スコープのバッジ一覧をロードする

--- a/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
@@ -59,6 +59,18 @@ struct SwiftDataPersistenceService: PersistenceService {
         try await actor.saveChannelEmotes(emotes, broadcasterId: broadcasterId)
     }
 
+    func loadGlobalEmotesWithTimestamp() async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        await actor.loadGlobalEmotesWithTimestamp()
+    }
+
+    func loadUserEmotesWithTimestamp(userId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        await actor.loadUserEmotesWithTimestamp(userId: userId)
+    }
+
+    func loadChannelEmotesWithTimestamp(broadcasterId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) {
+        await actor.loadChannelEmotesWithTimestamp(broadcasterId: broadcasterId)
+    }
+
     // MARK: - バッジ・プロフィール
 
     func loadBadges(scope: BadgeScope) async -> [BadgeVersionSnapshot] {

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -139,13 +139,14 @@ actor EmoteStore {
         // 永続化キャッシュから先読みしてオフライン時の即時表示と API 呼び出し抑止を実現する
         if let persistence = persistenceService {
             let cached = await persistence.loadChannelEmotesWithTimestamp(broadcasterId: broadcasterId)
+            // emotes が空でも fetchedAt があれば「取得済み空配列」として TTL を適用する
             if !cached.emotes.isEmpty {
                 channelEmotes = cached.emotes
                 notifyUserEmoteSetsUpdated()
-                if let fetchedAt = cached.fetchedAt,
-                   Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
-                    return
-                }
+            }
+            if let fetchedAt = cached.fetchedAt,
+               Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
+                return
             }
         }
         do {
@@ -486,9 +487,11 @@ actor EmoteStore {
         guard !isGlobalLoaded else { return }
         guard let persistence = persistenceService else { return }
         let result = await persistence.loadGlobalEmotesWithTimestamp()
-        guard !result.emotes.isEmpty else { return }
+        // emotes が空でも fetchedAt があれば「取得済み空配列」として TTL を適用する
         globalEmotes = result.emotes
-        notifyUserEmoteSetsUpdated()
+        if !result.emotes.isEmpty {
+            notifyUserEmoteSetsUpdated()
+        }
         if let fetchedAt = result.fetchedAt,
            Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
             isGlobalLoaded = true
@@ -506,9 +509,11 @@ actor EmoteStore {
         guard !isUserEmotesLoaded else { return }
         guard let persistence = persistenceService else { return }
         let result = await persistence.loadUserEmotesWithTimestamp(userId: userId)
-        guard !result.emotes.isEmpty else { return }
+        // emotes が空でも fetchedAt があれば「取得済み空配列」として TTL を適用する
         userEmotes = result.emotes
-        notifyUserEmoteSetsUpdated()
+        if !result.emotes.isEmpty {
+            notifyUserEmoteSetsUpdated()
+        }
         if let fetchedAt = result.fetchedAt,
            Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
             isUserEmotesLoaded = true

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -15,6 +15,11 @@ actor EmoteStore {
 
     // MARK: - 定数
 
+    /// エモートの TTL（24 時間）
+    ///
+    /// stale-while-revalidate 判定に使用する。TTL 以内の永続化データがあれば API コールを抑止する。
+    private static let emoteTTL: TimeInterval = 86400
+
     /// Helix グローバルエモートエンドポイント
     private static let helixGlobalEmotesURL = URL(string: "https://api.twitch.tv/helix/chat/emotes/global")!
 
@@ -103,6 +108,7 @@ actor EmoteStore {
                 )
                 self.globalEmotes = response.data
                 self.isGlobalLoaded = true
+                self.writeBackEmotes(response.data, scope: .global)
             } catch let error as URLError where error.code == .userAuthenticationRequired {
                 // 未ログイン時は次回接続時に再取得できるよう isGlobalLoaded を更新しない
             } catch HelixAPIError.unauthorized {
@@ -130,12 +136,25 @@ actor EmoteStore {
     func fetchChannelEmotes(broadcasterId: String) async {
         // Twitch の room-id は ASCII 十進数のみで構成される（URLパラメータインジェクション対策）
         guard !broadcasterId.isEmpty, broadcasterId.allSatisfy({ $0.isASCII && $0.isNumber }) else { return }
+        // 永続化キャッシュから先読みしてオフライン時の即時表示と API 呼び出し抑止を実現する
+        if let persistence = persistenceService {
+            let cached = await persistence.loadChannelEmotesWithTimestamp(broadcasterId: broadcasterId)
+            if !cached.emotes.isEmpty {
+                channelEmotes = cached.emotes
+                notifyUserEmoteSetsUpdated()
+                if let fetchedAt = cached.fetchedAt,
+                   Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
+                    return
+                }
+            }
+        }
         do {
             let response: HelixEmotesResponse = try await apiClient.get(
                 url: Self.helixChannelEmotesURL,
                 queryItems: [URLQueryItem(name: "broadcaster_id", value: broadcasterId)]
             )
             channelEmotes = response.data
+            writeBackEmotes(response.data, scope: .channel(broadcasterId: broadcasterId))
             // チャンネルエモートのロード完了をピッカーに通知する
             notifyUserEmoteSetsUpdated()
         } catch let error as URLError where error.code == .userAuthenticationRequired {
@@ -178,6 +197,8 @@ actor EmoteStore {
             #endif
             do {
                 let accumulated = try await self.performUserEmotesFetch(userId: userId)
+                // 全ページ完了後に write-back（途中キャンセル時は部分データを保存しない）
+                self.writeBackEmotes(accumulated, scope: .user(userId: userId))
                 self.isUserEmotesLoaded = true
                 #if DEBUG
                 print("[EmoteStore] fetchUserEmotes: フェッチ完了 \(accumulated.count)件")
@@ -453,6 +474,84 @@ actor EmoteStore {
     func cancelUserEmotesFetch() {
         userEmotesTask?.cancel()
         userEmotesTask = nil
+    }
+
+    /// 永続化済みグローバルエモートを読み込んでキャッシュを事前充填する
+    ///
+    /// チャンネル接続時に呼び出す。TTL（24h）以内のデータなら `isGlobalLoaded = true`
+    /// にして後続の `fetchGlobalEmotes()` による API 呼び出しを抑止する（stale-while-revalidate）。
+    /// TTL 超過時は古いデータでキャッシュを充填した上で `isGlobalLoaded = false` のままにし、
+    /// 後続の `fetchGlobalEmotes()` で再フェッチさせる。
+    func seedFromPersistence() async {
+        guard !isGlobalLoaded else { return }
+        guard let persistence = persistenceService else { return }
+        let result = await persistence.loadGlobalEmotesWithTimestamp()
+        guard !result.emotes.isEmpty else { return }
+        globalEmotes = result.emotes
+        notifyUserEmoteSetsUpdated()
+        if let fetchedAt = result.fetchedAt,
+           Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
+            isGlobalLoaded = true
+        }
+    }
+
+    /// 永続化済みユーザーエモートを読み込んでキャッシュを事前充填する
+    ///
+    /// `ChannelManager.preloadUserEmotes()` の冒頭で呼び出す。
+    /// `setUserEmotes(_:)` と異なり `isUserEmotesLoaded` フラグを立てない。
+    /// TTL（24h）以内のデータがある場合のみフラグを立てて後続の `fetchUserEmotes` を抑止する。
+    ///
+    /// - Parameter userId: 認証済みユーザーの Twitch ユーザー ID
+    func seedUserEmotes(userId: String) async {
+        guard !isUserEmotesLoaded else { return }
+        guard let persistence = persistenceService else { return }
+        let result = await persistence.loadUserEmotesWithTimestamp(userId: userId)
+        guard !result.emotes.isEmpty else { return }
+        userEmotes = result.emotes
+        notifyUserEmoteSetsUpdated()
+        if let fetchedAt = result.fetchedAt,
+           Date().timeIntervalSince(fetchedAt) < Self.emoteTTL {
+            isUserEmotesLoaded = true
+        }
+    }
+
+    /// 永続化済みチャンネルエモートを読み込んでキャッシュを事前充填する
+    ///
+    /// `joinChannel` 時の `fetchChannelEmotes` 呼び出し前にセットする。
+    /// チャンネルエモートに loaded フラグはないため、TTL 判定は `fetchChannelEmotes` 冒頭で行う。
+    ///
+    /// - Parameter broadcasterId: Twitch チャンネルID（数字のみ）
+    func seedChannelEmotes(broadcasterId: String) async {
+        guard let persistence = persistenceService else { return }
+        let result = await persistence.loadChannelEmotesWithTimestamp(broadcasterId: broadcasterId)
+        guard !result.emotes.isEmpty else { return }
+        channelEmotes = result.emotes
+        notifyUserEmoteSetsUpdated()
+    }
+
+    // MARK: - write-back
+
+    /// エモートを永続化サービスに非同期保存する（fire-and-forget）
+    ///
+    /// fetch 成功直後に呼び出すことで、次回起動時の seed を有効にする。
+    private func writeBackEmotes(_ emotes: [HelixEmote], scope: EmoteScope) {
+        guard let persistence = persistenceService else { return }
+        Task { [persistence] in
+            do {
+                switch scope {
+                case .global:
+                    try await persistence.saveGlobalEmotes(emotes)
+                case .channel(let broadcasterId):
+                    try await persistence.saveChannelEmotes(emotes, broadcasterId: broadcasterId)
+                case .user(let userId):
+                    try await persistence.saveUserEmotes(emotes, userId: userId)
+                }
+            } catch {
+                #if DEBUG
+                print("[EmoteStore] write-back 失敗 scope=\(scope.rawValue) error=\(error)")
+                #endif
+            }
+        }
     }
 
     /// ユーザーエモート一覧を直接設定する

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -112,8 +112,15 @@ final class ChannelManager {
 
     // MARK: - 公開メソッド
 
+    /// ログアウト時の `clearUserScoped` 呼び出しに使う userId キャッシュ
+    ///
+    /// `AuthState.logout()` では `userId = nil` が `.loggedOut` 状態遷移より先に走る経路があるため、
+    /// ログイン直後にキャッシュしておくことで安全に参照できるようにする。
+    private var lastPreloadedUserId: String?
+
     /// ログイン時・アプリ起動時にユーザーエモートを事前取得する
     ///
+    /// 永続化キャッシュが存在する場合は先にシードしてから API フェッチを行う。
     /// プリロードストアでユーザーエモートをフェッチしておくことで、`joinChannel` 呼び出し時に
     /// 新しい `ChatViewModel` のエモートストアへ即座にシードできるようにする。
     /// `user:read:emotes` スコープがない場合や未ログイン時はスキップする。
@@ -121,7 +128,18 @@ final class ChannelManager {
     /// `TwitchChatApp` のログイン検知（`.loggedIn` 状態遷移・セッション復元）から呼び出す。
     func preloadUserEmotes() async {
         guard let userId = authState.userId, authState.canReadUserEmotes else { return }
+        lastPreloadedUserId = userId
+        await preloadEmoteStore.seedUserEmotes(userId: userId)
         await preloadEmoteStore.fetchUserEmotes(userId: userId)
+    }
+
+    /// ログアウト時にユーザースコープの永続化データを削除する
+    ///
+    /// `lastPreloadedUserId` を使うことで、`AuthState` の userId が nil 化された後でも安全に呼び出せる。
+    func clearPersistedUserData() async {
+        guard let persistenceService, let userId = lastPreloadedUserId else { return }
+        await persistenceService.clearUserScoped(userId: userId)
+        lastPreloadedUserId = nil
     }
 
     /// プリロード済みユーザーエモートの ownerId に対応する表示名を ProfileImageStore に事前キャッシュする

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -127,8 +127,11 @@ final class ChannelManager {
     ///
     /// `TwitchChatApp` のログイン検知（`.loggedIn` 状態遷移・セッション復元）から呼び出す。
     func preloadUserEmotes() async {
-        guard let userId = authState.userId, authState.canReadUserEmotes else { return }
+        guard let userId = authState.userId else { return }
+        // canReadUserEmotes に関わらず userId が取れた時点でキャッシュし、
+        // ログアウト時の clearPersistedUserData() が必ず userId を参照できるようにする
         lastPreloadedUserId = userId
+        guard authState.canReadUserEmotes else { return }
         await preloadEmoteStore.seedUserEmotes(userId: userId)
         await preloadEmoteStore.fetchUserEmotes(userId: userId)
     }
@@ -138,8 +141,9 @@ final class ChannelManager {
     /// `lastPreloadedUserId` を使うことで、`AuthState` の userId が nil 化された後でも安全に呼び出せる。
     func clearPersistedUserData() async {
         guard let persistenceService, let userId = lastPreloadedUserId else { return }
-        await persistenceService.clearUserScoped(userId: userId)
+        // await 前にクリアして、次のログインが lastPreloadedUserId を上書きする競合を防ぐ
         lastPreloadedUserId = nil
+        await persistenceService.clearUserScoped(userId: userId)
     }
 
     /// プリロード済みユーザーエモートの ownerId に対応する表示名を ProfileImageStore に事前キャッシュする

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -170,7 +170,7 @@ final class ChatViewModel {
         self.authState = authState
         let helixClient = apiClient ?? HelixAPIClient(tokenProvider: authState)
         self.badgeStore = BadgeStore(apiClient: helixClient, persistenceService: persistenceService)
-        self.emoteStore = EmoteStore(apiClient: helixClient)
+        self.emoteStore = EmoteStore(apiClient: helixClient, persistenceService: persistenceService)
         self.moderationService = moderationService ?? ModerationService(apiClient: helixClient)
     }
 
@@ -199,7 +199,10 @@ final class ChatViewModel {
             await badgeStore.seedFromPersistence()
             await badgeStore.fetchGlobalBadges()
         }
-        globalEmoteFetchTask = Task { await emoteStore.fetchGlobalEmotes() }
+        globalEmoteFetchTask = Task {
+            await emoteStore.seedFromPersistence()
+            await emoteStore.fetchGlobalEmotes()
+        }
 
         // ユーザーエモートを並行フェッチ（user:read:emotes スコープがある場合のみ）
         // ユーザースコープのため接続時に1回のみ取得し、チャンネル切替時には再取得しない

--- a/Tests/TwitchChatTests/EmoteStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/EmoteStorePersistenceTests.swift
@@ -1,0 +1,487 @@
+// EmoteStorePersistenceTests.swift
+// EmoteStore の永続化配線テスト（seed / write-back / TTL / scope 分離）
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// API 呼び出し回数を記録するエモート API クライアント
+///
+/// fetchGlobalEmotes / fetchChannelEmotes / fetchUserEmotes の TTL テストで
+/// 「API が呼ばれたか」を確認するために使用する
+actor MockCountingEmoteAPIClient: HelixAPIClientProtocol {
+
+    /// 成功レスポンスとして返す JSON（nil の場合は未認証エラーを返す）
+    let emoteJSON: String?
+
+    /// `get` が呼ばれた回数
+    private(set) var getCallCount = 0
+
+    init(emoteJSON: String? = nil) {
+        self.emoteJSON = emoteJSON
+    }
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        getCallCount += 1
+        if let json = emoteJSON, let data = json.data(using: .utf8) {
+            return try JSONDecoder().decode(T.self, from: data)
+        }
+        // 成功 JSON 未設定の場合は未認証エラー（assertionFailure を避けるため）
+        throw HelixAPIError.unauthorized
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T {
+        throw URLError(.badServerResponse)
+    }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        throw URLError(.badServerResponse)
+    }
+}
+
+/// 複数ページを順に返すエモート API クライアント（ページネーションテスト用）
+actor MockPaginatingEmoteAPIClient: HelixAPIClientProtocol {
+
+    /// ページ順のレスポンス JSON 配列
+    let pages: [String]
+    private var callIndex = 0
+
+    init(pages: [String]) {
+        self.pages = pages
+    }
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        let json = callIndex < pages.count ? pages[callIndex] : "{\"data\":[]}"
+        callIndex += 1
+        guard let data = json.data(using: .utf8) else { throw URLError(.badServerResponse) }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T {
+        throw URLError(.badServerResponse)
+    }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw URLError(.badServerResponse)
+    }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        throw URLError(.badServerResponse)
+    }
+}
+
+// MARK: - テストスイート
+
+/// EmoteStore の永続化配線（seed / write-back / TTL / scope 分離）テスト
+@Suite("EmoteStorePersistenceTests")
+struct EmoteStorePersistenceTests {
+
+    // MARK: - ヘルパー
+
+    /// グローバルエモート（LUL）を生成する
+    private func makeGlobalEmote() -> HelixEmote {
+        HelixEmote(
+            id: "304486245",
+            name: "LUL",
+            format: ["static"],
+            emoteType: "globals",
+            emoteSetId: "0",
+            ownerId: nil
+        )
+    }
+
+    /// ユーザーエモート（PogChamp）を生成する
+    private func makeUserEmote(id: String = "115234", name: String = "PogChamp") -> HelixEmote {
+        HelixEmote(
+            id: id,
+            name: name,
+            format: ["static"],
+            emoteType: "subscriptions",
+            emoteSetId: "300374452",
+            ownerId: "987654321"
+        )
+    }
+
+    /// チャンネルエモート（Kappa）を生成する
+    private func makeChannelEmote() -> HelixEmote {
+        HelixEmote(
+            id: "25",
+            name: "Kappa",
+            format: ["static"],
+            emoteType: "subscriptions",
+            emoteSetId: "999999",
+            ownerId: "12345678"
+        )
+    }
+
+    /// グローバル / チャンネルエモート用 JSON を生成する（HelixEmotesResponse 形式）
+    private func globalEmoteJSON() -> String {
+        """
+        {"data":[{"id":"304486245","name":"LUL","format":["static"],\
+        "emote_type":"globals","emote_set_id":"0"}]}
+        """
+    }
+
+    /// チャンネルエモート用 JSON を生成する
+    private func channelEmoteJSON() -> String {
+        """
+        {"data":[{"id":"25","name":"Kappa","format":["static"],\
+        "emote_type":"subscriptions","emote_set_id":"999999","owner_id":"12345678"}]}
+        """
+    }
+
+    /// ユーザーエモートの1ページ目 JSON（cursor あり）
+    private func userEmotePage1JSON() -> String {
+        """
+        {"data":[{"id":"115234","name":"PogChamp","format":["static"],\
+        "emote_type":"subscriptions","emote_set_id":"300374452","owner_id":"987654321"}],\
+        "pagination":{"cursor":"abc123"}}
+        """
+    }
+
+    /// ユーザーエモートの2ページ目 JSON（cursor なし = 最終ページ）
+    private func userEmotePage2JSON() -> String {
+        """
+        {"data":[{"id":"88634","name":"EleGiggle","format":["static"],\
+        "emote_type":"subscriptions","emote_set_id":"300374453","owner_id":"987654321"}],\
+        "pagination":{}}
+        """
+    }
+
+    /// 永続化サービスにグローバルエモートが保存されるまでポーリング待機する
+    private func waitForSavedGlobalEmotes(
+        in persistence: InMemoryPersistenceService,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> [HelixEmote] {
+        let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            let saved = await persistence.loadGlobalEmotes()
+            if !saved.isEmpty { return saved }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await persistence.loadGlobalEmotes()
+    }
+
+    /// 永続化サービスにユーザーエモートが保存されるまでポーリング待機する
+    private func waitForSavedUserEmotes(
+        in persistence: InMemoryPersistenceService,
+        userId: String,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> [HelixEmote] {
+        let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            let saved = await persistence.loadUserEmotes(userId: userId)
+            if !saved.isEmpty { return saved }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await persistence.loadUserEmotes(userId: userId)
+    }
+
+    /// 永続化サービスにチャンネルエモートが保存されるまでポーリング待機する
+    private func waitForSavedChannelEmotes(
+        in persistence: InMemoryPersistenceService,
+        broadcasterId: String,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> [HelixEmote] {
+        let deadline = ContinuousClock.now + .nanoseconds(Int(timeoutNanoseconds))
+        while ContinuousClock.now < deadline {
+            let saved = await persistence.loadChannelEmotes(broadcasterId: broadcasterId)
+            if !saved.isEmpty { return saved }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return await persistence.loadChannelEmotes(broadcasterId: broadcasterId)
+    }
+
+    // MARK: - seed 正常系
+
+    @Test("永続化済みグローバルエモートからseedするとallEmotesに含まれる")
+    func 永続化済みグローバルエモートからseedするとallEmotesに含まれる() async throws {
+        // 前提: InMemoryPersistenceService にグローバルエモートを事前保存する
+        let persistence = InMemoryPersistenceService()
+        let emote = makeGlobalEmote()
+        try await persistence.saveGlobalEmotes([emote])
+
+        // 操作: 永続化サービスを持つ EmoteStore を作成して seed する
+        let store = EmoteStore(apiClient: MockHelixAPIClient(), persistenceService: persistence)
+        await store.seedFromPersistence()
+
+        // 検証: seed 後に allEmotes に LUL が含まれる
+        let all = await store.allEmotes()
+        #expect(all.contains { $0.name == "LUL" })
+    }
+
+    @Test("永続化済みユーザーエモートをseedするとuserEmotesSnapshotに含まれる")
+    func 永続化済みユーザーエモートをseedするとuserEmotesSnapshotに含まれる() async throws {
+        // 前提: InMemoryPersistenceService にユーザーエモートを事前保存する
+        let persistence = InMemoryPersistenceService()
+        let emote = makeUserEmote()
+        let userId = "123456789"
+        try await persistence.saveUserEmotes([emote], userId: userId)
+
+        // 操作: seedUserEmotes を呼ぶ（isUserEmotesLoaded は立てない）
+        let store = EmoteStore(apiClient: MockHelixAPIClient(), persistenceService: persistence)
+        await store.seedUserEmotes(userId: userId)
+
+        // 検証: seed 後に userEmotesSnapshot に PogChamp が含まれる
+        let snapshot = await store.userEmotesSnapshot()
+        #expect(snapshot.contains { $0.name == "PogChamp" })
+    }
+
+    @Test("永続化済みチャンネルエモートをseedするとchannelEmotesSnapshotに含まれる")
+    func 永続化済みチャンネルエモートをseedするとchannelEmotesSnapshotに含まれる() async throws {
+        // 前提: InMemoryPersistenceService にチャンネルエモートを事前保存する
+        let persistence = InMemoryPersistenceService()
+        let emote = makeChannelEmote()
+        let broadcasterId = "12345678"
+        try await persistence.saveChannelEmotes([emote], broadcasterId: broadcasterId)
+
+        // 操作: seedChannelEmotes を呼ぶ
+        let store = EmoteStore(apiClient: MockHelixAPIClient(), persistenceService: persistence)
+        await store.seedChannelEmotes(broadcasterId: broadcasterId)
+
+        // 検証: seed 後に channelEmotesSnapshot に Kappa が含まれる
+        let snapshot = await store.channelEmotesSnapshot()
+        #expect(snapshot.contains { $0.name == "Kappa" })
+    }
+
+    @Test("persistenceServiceなしのEmoteStoreはseedを呼んでも安全")
+    func persistenceServiceなしのEmoteStoreはseedを呼んでも安全() async {
+        // 前提: persistenceService なしの EmoteStore（既存コードとの後方互換確認）
+        let store = EmoteStore(apiClient: MockHelixAPIClient())
+
+        // 操作: 各 seed メソッドを呼んでもクラッシュしない
+        await store.seedFromPersistence()
+        await store.seedUserEmotes(userId: "123456789")
+        await store.seedChannelEmotes(broadcasterId: "12345678")
+
+        // 検証: エモートが設定されていない（空の状態）
+        let all = await store.allEmotes()
+        #expect(all.isEmpty)
+    }
+
+    // MARK: - TTL 内なら isXxxLoaded が立ち API を抑止する
+
+    @Test("TTL24時間以内のグローバルseedでAPI呼び出しをスキップする")
+    func TTL24時間以内のグローバルseedでAPI呼び出しをスキップする() async {
+        // 前提: 23h 前に保存したグローバルエモート（TTL 24h 以内）
+        let persistence = InMemoryPersistenceService()
+        let emote = makeGlobalEmote()
+        let twentyThreeHoursAgo = Date().addingTimeInterval(-23 * 3600)
+        await persistence.saveGlobalEmotesWithDate([emote], savedAt: twentyThreeHoursAgo)
+
+        let apiClient = MockCountingEmoteAPIClient()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchGlobalEmotes を呼ぶ
+        await store.seedFromPersistence()
+        await store.fetchGlobalEmotes()
+
+        // 検証: TTL 以内なので API は呼ばれない（isGlobalLoaded = true で guard を通過しない）
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 0)
+    }
+
+    @Test("TTL24時間超のグローバルseedでAPIを再フェッチする")
+    func TTL24時間超のグローバルseedでAPIを再フェッチする() async {
+        // 前提: 25h 前に保存したグローバルエモート（TTL 24h 超）
+        let persistence = InMemoryPersistenceService()
+        let emote = makeGlobalEmote()
+        let twentyFiveHoursAgo = Date().addingTimeInterval(-25 * 3600)
+        await persistence.saveGlobalEmotesWithDate([emote], savedAt: twentyFiveHoursAgo)
+
+        // API は失敗させて（ネットワーク未接続想定）API が呼ばれたかどうかだけ確認する
+        let apiClient = MockCountingEmoteAPIClient()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchGlobalEmotes を呼ぶ
+        await store.seedFromPersistence()
+        await store.fetchGlobalEmotes()
+
+        // 検証: TTL 超過のため isGlobalLoaded = false のまま → API が呼ばれる
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 1)
+    }
+
+    @Test("TTL24時間以内のユーザーseedでAPI呼び出しをスキップする")
+    func TTL24時間以内のユーザーseedでAPI呼び出しをスキップする() async {
+        // 前提: 23h 前に保存したユーザーエモート（TTL 24h 以内）
+        let persistence = InMemoryPersistenceService()
+        let emote = makeUserEmote()
+        let userId = "123456789"
+        let twentyThreeHoursAgo = Date().addingTimeInterval(-23 * 3600)
+        await persistence.saveUserEmotesWithDate([emote], userId: userId, savedAt: twentyThreeHoursAgo)
+
+        let apiClient = MockCountingEmoteAPIClient()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchUserEmotes を呼ぶ
+        await store.seedUserEmotes(userId: userId)
+        await store.fetchUserEmotes(userId: userId)
+
+        // 検証: TTL 以内なので API は呼ばれない（isUserEmotesLoaded = true で guard を通過しない）
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 0)
+    }
+
+    @Test("TTL24時間超のユーザーseedでAPIを再フェッチする")
+    func TTL24時間超のユーザーseedでAPIを再フェッチする() async {
+        // 前提: 25h 前に保存したユーザーエモート（TTL 24h 超）
+        let persistence = InMemoryPersistenceService()
+        let emote = makeUserEmote()
+        let userId = "123456789"
+        let twentyFiveHoursAgo = Date().addingTimeInterval(-25 * 3600)
+        await persistence.saveUserEmotesWithDate([emote], userId: userId, savedAt: twentyFiveHoursAgo)
+
+        let apiClient = MockCountingEmoteAPIClient()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: seed してから fetchUserEmotes を呼ぶ
+        await store.seedUserEmotes(userId: userId)
+        await store.fetchUserEmotes(userId: userId)
+
+        // 検証: TTL 超過のため isUserEmotesLoaded = false のまま → API が呼ばれる
+        let callCount = await apiClient.getCallCount
+        #expect(callCount == 1)
+    }
+
+    // MARK: - write-back（fetch 成功後に永続化される）
+
+    @Test("fetchGlobalEmotes成功後にグローバルスコープで永続化される")
+    func fetchGlobalEmotes成功後にグローバルスコープで永続化される() async {
+        // 前提: グローバルエモートレスポンスを返す API クライアントと InMemoryPersistenceService
+        let apiClient = MockCountingEmoteAPIClient(emoteJSON: globalEmoteJSON())
+        let persistence = InMemoryPersistenceService()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: グローバルエモートをフェッチする
+        await store.fetchGlobalEmotes()
+
+        // 検証: 永続化サービスにエモートが保存されている（write-back の完了を bounded poll で待機）
+        let saved = await waitForSavedGlobalEmotes(in: persistence)
+        #expect(saved.contains { $0.name == "LUL" })
+    }
+
+    @Test("fetchChannelEmotes成功後にチャンネルスコープで永続化される")
+    func fetchChannelEmotes成功後にチャンネルスコープで永続化される() async {
+        // 前提: チャンネルエモートレスポンスを返す API クライアント
+        // broadcasterId は Twitch room-id 形式（数字のみ）を使用する
+        let broadcasterId = "12345678"
+        let apiClient = MockCountingEmoteAPIClient(emoteJSON: channelEmoteJSON())
+        let persistence = InMemoryPersistenceService()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: チャンネルエモートをフェッチする
+        await store.fetchChannelEmotes(broadcasterId: broadcasterId)
+
+        // 検証: チャンネルスコープで永続化されている（write-back の完了を bounded poll で待機）
+        let saved = await waitForSavedChannelEmotes(in: persistence, broadcasterId: broadcasterId)
+        #expect(saved.contains { $0.name == "Kappa" })
+    }
+
+    @Test("fetchUserEmotes全ページ完了後にユーザースコープで永続化される")
+    func fetchUserEmotes全ページ完了後にユーザースコープで永続化される() async {
+        // 前提: 2 ページ分のユーザーエモートを返す API クライアント（cursor 付き → cursor なし）
+        let userId = "123456789"
+        let apiClient = MockPaginatingEmoteAPIClient(pages: [
+            userEmotePage1JSON(),
+            userEmotePage2JSON()
+        ])
+        let persistence = InMemoryPersistenceService()
+        let store = EmoteStore(apiClient: apiClient, persistenceService: persistence)
+
+        // 操作: ユーザーエモートをフェッチする（全ページ完了後に write-back される）
+        await store.fetchUserEmotes(userId: userId)
+
+        // 検証: 両ページのエモートが永続化されている
+        let saved = await waitForSavedUserEmotes(in: persistence, userId: userId)
+        #expect(saved.contains { $0.name == "PogChamp" })
+        #expect(saved.contains { $0.name == "EleGiggle" })
+    }
+
+    // MARK: - scope 分離
+
+    @Test("clearUserScopedはユーザースコープのみ削除しグローバルとチャンネルは残る")
+    func clearUserScopedはユーザースコープのみ削除しグローバルとチャンネルは残る() async throws {
+        // 前提: グローバル・チャンネル・ユーザーの 3 スコープにエモートを保存する
+        let persistence = InMemoryPersistenceService()
+        let userId = "123456789"
+        let broadcasterId = "12345678"
+
+        try await persistence.saveGlobalEmotes([makeGlobalEmote()])
+        try await persistence.saveChannelEmotes([makeChannelEmote()], broadcasterId: broadcasterId)
+        try await persistence.saveUserEmotes([makeUserEmote()], userId: userId)
+
+        // 操作: ユーザースコープをクリアする
+        await persistence.clearUserScoped(userId: userId)
+
+        // 検証: グローバルとチャンネルは残り、ユーザースコープのみ削除される
+        let global = await persistence.loadGlobalEmotes()
+        let channel = await persistence.loadChannelEmotes(broadcasterId: broadcasterId)
+        let user = await persistence.loadUserEmotes(userId: userId)
+
+        #expect(global.contains { $0.name == "LUL" })
+        #expect(channel.contains { $0.name == "Kappa" })
+        #expect(user.isEmpty)
+    }
+
+    @Test("グローバル_ユーザー_チャンネルのエモートは別スコープで独立して永続化される")
+    func グローバル_ユーザー_チャンネルのエモートは別スコープで独立して永続化される() async throws {
+        // 前提: 3 スコープにそれぞれ異なるエモートを保存する
+        let persistence = InMemoryPersistenceService()
+        let userId = "123456789"
+        let broadcasterId = "12345678"
+
+        try await persistence.saveGlobalEmotes([makeGlobalEmote()])
+        try await persistence.saveUserEmotes([makeUserEmote()], userId: userId)
+        try await persistence.saveChannelEmotes([makeChannelEmote()], broadcasterId: broadcasterId)
+
+        // 操作: 各スコープのタイムスタンプ付きロードを実行する
+        let globalResult = await persistence.loadGlobalEmotesWithTimestamp()
+        let userResult = await persistence.loadUserEmotesWithTimestamp(userId: userId)
+        let channelResult = await persistence.loadChannelEmotesWithTimestamp(broadcasterId: broadcasterId)
+        let unknownResult = await persistence.loadUserEmotesWithTimestamp(userId: "未登録ユーザーID")
+
+        // 検証: 各スコープのエモートが独立している
+        #expect(globalResult.emotes.count == 1)
+        #expect(globalResult.emotes.first?.name == "LUL")
+        #expect(globalResult.fetchedAt != nil)
+
+        #expect(userResult.emotes.count == 1)
+        #expect(userResult.emotes.first?.name == "PogChamp")
+        #expect(userResult.fetchedAt != nil)
+
+        #expect(channelResult.emotes.count == 1)
+        #expect(channelResult.emotes.first?.name == "Kappa")
+        #expect(channelResult.fetchedAt != nil)
+
+        // 検証: 未登録スコープは空かつ fetchedAt は nil
+        #expect(unknownResult.emotes.isEmpty)
+        #expect(unknownResult.fetchedAt == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- `EmoteStore` に `seedFromPersistence` / `seedUserEmotes` / `seedChannelEmotes` を追加し、アプリ起動時に永続化キャッシュから即座にエモートをロードできるようにした
- `fetchGlobalEmotes` / `fetchChannelEmotes` / `fetchUserEmotes` 成功後に `writeBackEmotes` で fire-and-forget 保存を行い、次回起動時のキャッシュを更新する
- 24h TTL による stale-while-revalidate: TTL 内ならば API フェッチをスキップ、TTL 超過でも表示しつつ裏でリフェッチ
- `ChatViewModel` に `persistenceService` を注入し、global emote を seed→fetch チェーン化
- `ChannelManager.preloadUserEmotes` を seed→fetch チェーン化、`clearPersistedUserData()` 追加
- `TwitchChatApp` の `.loggedOut` ブランチで `clearPersistedUserData` を呼び出しユーザースコープデータを削除
- `EmoteStorePersistenceTests` に 13 テストを追加（seed / write-back / TTL 24h 境界 / scope 分離 / logout）
- `BadgeStore`（PR-3）と完全対称なパターンで実装

## Test plan

- [ ] `swift test --filter EmoteStorePersistenceTests` で 13 件全パス確認
- [ ] `swift build` でコンパイルエラーなし確認
- [ ] `swift test` でフル回帰（既存 647 件パス、TwitchIRCClient 7 件は事前確認済みの flaky）
- [ ] 手動: アプリ起動 → チャンネル参加 → エモートピッカーが表示されることを確認
- [ ] 手動: ネットワーク切断後に再起動 → エモートピッカーがキャッシュから即座に表示されることを確認
- [ ] 手動: ログアウト後に再起動 → ユーザーエモートは消去、グローバル/チャンネルエモートは残存することを確認

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 絵文字の24時間キャッシング機能を実装し、読み込みパフォーマンスを向上。一度読み込んだ絵文字はキャッシュから素早く表示されます。
  * ログアウト時のデータクリーンアップを改善。ユーザーデータは確実にクリアされます。

* **テスト**
  * 絵文字のキャッシング機能と永続化の動作検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->