### PR TITLE
feat: チャット履歴の永続化配線 + VOD video_id 紐付け（永続化基盤 PR-5）

### DIFF
--- a/Sources/TwitchChat/Models/ChatMessage.swift
+++ b/Sources/TwitchChat/Models/ChatMessage.swift
@@ -98,6 +98,12 @@ struct ChatMessage: Sendable, Identifiable {
     /// ユーザー名やバッジは表示せず、テキストのみをシステムスタイルで表示する。
     let isSystemNotice: Bool
 
+    /// このメッセージが投稿された配信の VOD video_id（Twitch Helix API の video.id）
+    ///
+    /// ROOMSTATE 受信後に Helix /helix/videos で取得した最新 archive の id をスタンプする。
+    /// VOD 保存無効の配信者や archive 未生成のタイミングでは nil になる。
+    let videoId: String?
+
     /// 楽観的 UI 表示のためのローカル ChatMessage を生成する
     ///
     /// Twitch IRC は自分が送信した PRIVMSG をエコーバックしないため、
@@ -141,6 +147,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentMsgBody = nil
         self.isOptimistic = true
         self.isSystemNotice = false
+        self.videoId = nil
     }
 
     /// IRCMessage から ChatMessage を生成する
@@ -189,6 +196,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentMsgBody = ircMessage.tags["reply-parent-msg-body"].flatMap { $0.isEmpty ? nil : $0 }
         self.isOptimistic = false
         self.isSystemNotice = false
+        self.videoId = nil
     }
 
     /// 楽観的 UI メッセージの ID を EventSub で受信した本物の message ID で差し替えた新しいインスタンスを生成する
@@ -218,6 +226,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentMsgBody = original.replyParentMsgBody
         self.isOptimistic = false
         self.isSystemNotice = original.isSystemNotice
+        self.videoId = original.videoId
     }
 
     /// 永続化層からの復元用イニシャライザ（PersistedChatMessage.toDomain() から呼ぶ）
@@ -241,7 +250,8 @@ struct ChatMessage: Sendable, Identifiable {
         replyParentUserLogin: String?,
         replyParentDisplayName: String?,
         replyParentMsgBody: String?,
-        isSystemNotice: Bool
+        isSystemNotice: Bool,
+        videoId: String? = nil
     ) {
         self.id = id
         self.username = username
@@ -260,6 +270,7 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentDisplayName = replyParentDisplayName
         self.replyParentMsgBody = replyParentMsgBody
         self.isSystemNotice = isSystemNotice
+        self.videoId = videoId
     }
 
     /// システム通知メッセージを生成する
@@ -287,5 +298,36 @@ struct ChatMessage: Sendable, Identifiable {
         self.replyParentMsgBody = nil
         self.isOptimistic = false
         self.isSystemNotice = true
+        self.videoId = nil
+    }
+}
+
+// MARK: - roomId / videoId の後付けヘルパー
+
+extension ChatMessage {
+    /// roomId と videoId を指定した値で上書きした新しいインスタンスを返す
+    ///
+    /// flush 時に ROOMSTATE 受信後の `currentRoomId` / Helix 取得後の `currentVideoId` を
+    /// 後付けスタンプするために使用する。nil を渡した場合は既存の値を維持する。
+    func withRoomIdAndVideoId(roomId: String?, videoId: String?) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            username: username,
+            displayName: displayName,
+            text: text,
+            colorHex: colorHex,
+            badges: badges,
+            emotePositions: emotes,
+            roomId: roomId ?? self.roomId,
+            isAction: isAction,
+            receivedAt: receivedAt,
+            replyParentMsgId: replyParentMsgId,
+            isOptimistic: isOptimistic,
+            replyParentUserLogin: replyParentUserLogin,
+            replyParentDisplayName: replyParentDisplayName,
+            replyParentMsgBody: replyParentMsgBody,
+            isSystemNotice: isSystemNotice,
+            videoId: videoId ?? self.videoId
+        )
     }
 }

--- a/Sources/TwitchChat/Models/HelixVideo.swift
+++ b/Sources/TwitchChat/Models/HelixVideo.swift
@@ -1,0 +1,32 @@
+// HelixVideo.swift
+// Helix API /helix/videos レスポンスの DTO 定義
+// video_id（VOD の一意識別子）をチャットメッセージと紐付けるために使用する
+
+import Foundation
+
+// MARK: - Helix /videos レスポンス
+
+/// Helix GET /helix/videos のレスポンス全体
+struct HelixVideosResponse: Decodable, Sendable {
+    let data: [HelixVideoData]
+}
+
+/// Helix /helix/videos の各動画エントリー
+struct HelixVideoData: Decodable, Sendable {
+    /// VOD の一意識別子（video_id）
+    let id: String
+    /// 配信者のユーザー ID
+    let userId: String
+    /// この VOD に対応するストリーム ID（nil の場合はハイライト等）
+    let streamId: String?
+    /// 動画の種別（"archive" = 過去配信、"highlight"、"upload" など）
+    let type: String
+    /// 動画タイトル
+    let title: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, type, title
+        case userId = "user_id"
+        case streamId = "stream_id"
+    }
+}

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -596,7 +596,8 @@ extension PersistedChatMessage {
             replyParentMsgBody: message.replyParentMsgBody,
             isSystemNotice: message.isSystemNotice,
             tmiSentAt: nil,
-            senderUserId: nil
+            senderUserId: nil,
+            videoId: message.videoId
         )
     }
 
@@ -621,7 +622,8 @@ extension PersistedChatMessage {
             replyParentUserLogin: replyParentUserLogin,
             replyParentDisplayName: replyParentDisplayName,
             replyParentMsgBody: replyParentMsgBody,
-            isSystemNotice: isSystemNotice
+            isSystemNotice: isSystemNotice,
+            videoId: videoId
         )
     }
 }

--- a/Sources/TwitchChat/Persistence/SchemaV1.swift
+++ b/Sources/TwitchChat/Persistence/SchemaV1.swift
@@ -107,8 +107,12 @@ final class PersistedChatMessage {
     var tmiSentAt: Date?
     /// V1 枠確保（user-id タグのパース後に充填予定）
     var senderUserId: String?
+    /// このメッセージが投稿された配信の VOD video_id（Helix /helix/videos から取得）
+    ///
+    /// VOD 保存無効・archive 未生成の場合は nil。
+    var videoId: String?
 
-    #Index<PersistedChatMessage>([\.roomId, \.receivedAt], [\.text])
+    #Index<PersistedChatMessage>([\.roomId, \.receivedAt], [\.text], [\.videoId, \.receivedAt])
 
     init(
         id: String,
@@ -128,7 +132,8 @@ final class PersistedChatMessage {
         replyParentMsgBody: String?,
         isSystemNotice: Bool,
         tmiSentAt: Date?,
-        senderUserId: String?
+        senderUserId: String?,
+        videoId: String? = nil
     ) {
         self.id = id
         self.username = username
@@ -148,6 +153,7 @@ final class PersistedChatMessage {
         self.isSystemNotice = isSystemNotice
         self.tmiSentAt = tmiSentAt
         self.senderUserId = senderUserId
+        self.videoId = videoId
     }
 }
 

--- a/Sources/TwitchChat/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel+Persistence.swift
@@ -42,9 +42,11 @@ extension ChatViewModel {
                 videoId: $0.videoId ?? videoId
             )
         }
-        pendingPersistQueue.removeAll()
+        // removeAll() は appendMessages() 成功後に行う
+        // 失敗時はキューを保持して次の flush サイクルで再試行する
         do {
             try await persistenceService.appendMessages(snapshot)
+            pendingPersistQueue.removeFirst(min(snapshot.count, pendingPersistQueue.count))
         } catch {
             #if DEBUG
             print("[ChatViewModel] flushPendingPersistQueue 失敗 error=\(error)")
@@ -59,14 +61,16 @@ extension ChatViewModel {
     func seedFromPersistence(roomId: String) async {
         guard let persistenceService else { return }
         guard messages.isEmpty || messages.allSatisfy(\.isOptimistic) else { return }
+        // await 中に新着が届いた場合を検知するため件数をスナップショット
+        let initialCount = messages.count
         let recent = await persistenceService.loadRecentMessages(roomId: roomId, limit: 50, before: nil)
         guard !recent.isEmpty else { return }
+        // await 復帰後に状態が変化していたら seed を中止する
+        guard messages.count == initialCount,
+              messages.isEmpty || messages.allSatisfy(\.isOptimistic) else { return }
         // loadRecentMessages は降順（新しい順）で返すため昇順に変換して先頭に挿入
         let ordered = Array(recent.reversed())
-        messages.insert(contentsOf: ordered, at: 0)
-        if messages.count > Self.maxMessages {
-            messages.removeFirst(messages.count - Self.maxMessages)
-        }
+        applyHistoricalSeed(ordered)
     }
 
     /// Helix /helix/videos から現在配信中の VOD video_id を取得して currentVideoId に設定する
@@ -83,16 +87,17 @@ extension ChatViewModel {
                     URLQueryItem(name: "first", value: "1")
                 ]
             )
-            currentVideoId = response.data.first?.id
+            let videoId = response.data.first?.id
+            updateCurrentVideoId(videoId)
             #if DEBUG
-            if let videoId = currentVideoId {
+            if let videoId {
                 print("[ChatViewModel] currentVideoId 確定 broadcasterId=\(broadcasterId) videoId=\(videoId)")
             } else {
                 print("[ChatViewModel] currentVideoId 未取得（archive 未生成） broadcasterId=\(broadcasterId)")
             }
             #endif
         } catch {
-            currentVideoId = nil
+            updateCurrentVideoId(nil)
             #if DEBUG
             print("[ChatViewModel] fetchLatestVideoId 失敗 broadcasterId=\(broadcasterId) error=\(error) → nil で続行")
             #endif

--- a/Sources/TwitchChat/ViewModels/ChatViewModel+Persistence.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel+Persistence.swift
@@ -1,0 +1,101 @@
+// ChatViewModel+Persistence.swift
+// チャット履歴の永続化バッファリング・seed・VOD video_id 取得を担当する ChatViewModel 拡張
+
+import Foundation
+
+extension ChatViewModel {
+
+    // MARK: - 永続化（バッファリング書き込み・seed・videoId 取得）
+
+    /// 200ms 間隔で pendingPersistQueue を永続化する flush ループを開始する
+    ///
+    /// `FollowedStreamStore.startAutoRefresh()` と同じパターンで unstructured Task を使用する。
+    /// 既存のループがある場合は先にキャンセルしてから新しいループを開始する。
+    func startFlushLoop() {
+        flushTask?.cancel()
+        flushTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.flushInterval)
+                guard !Task.isCancelled else { break }
+                await self?.flushPendingPersistQueue()
+            }
+        }
+    }
+
+    /// pendingPersistQueue の内容を永続化サービスに書き出す
+    ///
+    /// - `currentRoomId` が未確定の場合は次の flush サイクルまで保留する
+    /// - `roomId` が nil のメッセージは `currentRoomId` で上書き
+    /// - `videoId` が nil のメッセージは `currentVideoId` で上書き（取得済みの場合）
+    func flushPendingPersistQueue() async {
+        guard let persistenceService else {
+            pendingPersistQueue.removeAll()
+            return
+        }
+        guard !pendingPersistQueue.isEmpty else { return }
+        // roomId 未確定の場合は次のサイクルまで保留する
+        guard let roomId = currentRoomId else { return }
+        let videoId = currentVideoId
+        let snapshot = pendingPersistQueue.map {
+            $0.withRoomIdAndVideoId(
+                roomId: $0.roomId ?? roomId,
+                videoId: $0.videoId ?? videoId
+            )
+        }
+        pendingPersistQueue.removeAll()
+        do {
+            try await persistenceService.appendMessages(snapshot)
+        } catch {
+            #if DEBUG
+            print("[ChatViewModel] flushPendingPersistQueue 失敗 error=\(error)")
+            #endif
+        }
+    }
+
+    /// 永続化サービスから直近 50 件を読み込んで messages に seed する
+    ///
+    /// - 既に新着メッセージが届いている場合（`messages` が空でない場合）はスキップする
+    /// - 降順で返るメッセージを昇順に変換して先頭に挿入する
+    func seedFromPersistence(roomId: String) async {
+        guard let persistenceService else { return }
+        guard messages.isEmpty || messages.allSatisfy(\.isOptimistic) else { return }
+        let recent = await persistenceService.loadRecentMessages(roomId: roomId, limit: 50, before: nil)
+        guard !recent.isEmpty else { return }
+        // loadRecentMessages は降順（新しい順）で返すため昇順に変換して先頭に挿入
+        let ordered = Array(recent.reversed())
+        messages.insert(contentsOf: ordered, at: 0)
+        if messages.count > Self.maxMessages {
+            messages.removeFirst(messages.count - Self.maxMessages)
+        }
+    }
+
+    /// Helix /helix/videos から現在配信中の VOD video_id を取得して currentVideoId に設定する
+    ///
+    /// 取得できなかった場合（archive 未生成・VOD 保存無効・ネットワークエラーなど）は
+    /// `currentVideoId = nil` のまま続行する（エラーによる切断はしない）。
+    func fetchLatestVideoId(broadcasterId: String) async {
+        do {
+            let response: HelixVideosResponse = try await helixAPIClient.get(
+                url: Self.videosURL,
+                queryItems: [
+                    URLQueryItem(name: "user_id", value: broadcasterId),
+                    URLQueryItem(name: "type", value: "archive"),
+                    URLQueryItem(name: "first", value: "1")
+                ]
+            )
+            currentVideoId = response.data.first?.id
+            #if DEBUG
+            if let videoId = currentVideoId {
+                print("[ChatViewModel] currentVideoId 確定 broadcasterId=\(broadcasterId) videoId=\(videoId)")
+            } else {
+                print("[ChatViewModel] currentVideoId 未取得（archive 未生成） broadcasterId=\(broadcasterId)")
+            }
+            #endif
+        } catch {
+            currentVideoId = nil
+            #if DEBUG
+            print("[ChatViewModel] fetchLatestVideoId 失敗 broadcasterId=\(broadcasterId) error=\(error) → nil で続行")
+            #endif
+        }
+    }
+}

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -55,7 +55,7 @@ final class ChatViewModel {
     // MARK: - Published プロパティ
 
     /// 受信済みチャットメッセージ（最新 500 件）
-    var messages: [ChatMessage] = []
+    private(set) var messages: [ChatMessage] = []
 
     /// 接続状態
     private(set) var connectionState: ConnectionState = .disconnected
@@ -138,8 +138,8 @@ final class ChatViewModel {
     /// 現在配信中の VOD video_id（Helix /helix/videos から取得）
     ///
     /// ROOMSTATE 受信後に非同期で取得する。VOD 保存無効・archive 未生成の場合は nil。
-    /// テストからポーリング条件として参照できるよう公開する。
-    var currentVideoId: String?
+    /// テストからポーリング条件として参照できるよう `private(set)` で公開する。
+    private(set) var currentVideoId: String?
 
     /// 永続化サービス（nil の場合は永続化なし）
     let persistenceService: (any PersistenceService)?
@@ -241,6 +241,9 @@ final class ChatViewModel {
             connectionState = .connected
         } catch {
             connectionState = .error(error.localizedDescription)
+            flushTask?.cancel()
+            videoIdFetchTask?.cancel()
+            pendingPersistQueue.removeAll()
             receiveTask?.cancel()
             noticeReceiveTask?.cancel()
             connectionStateReceiveTask?.cancel()
@@ -354,16 +357,17 @@ final class ChatViewModel {
 
     /// チャンネルから切断する
     func disconnect() async {
-        // flush ループと video_id 取得タスクを停止してから残存キューを書き出す
-        flushTask?.cancel()
-        videoIdFetchTask?.cancel()
-        await flushPendingPersistQueue()
-
+        // 先に受信タスクをすべて止めて pendingPersistQueue への追加を防いでから flush する
         receiveTask?.cancel()
         noticeReceiveTask?.cancel()
         connectionStateReceiveTask?.cancel()
         userStateReceiveTask?.cancel()
         roomStateReceiveTask?.cancel()
+        // flush ループを止め、残存キューを書き出す
+        flushTask?.cancel()
+        videoIdFetchTask?.cancel()
+        await flushPendingPersistQueue()
+
         globalBadgeFetchTask?.cancel()
         channelBadgeFetchTask?.cancel()
         globalEmoteFetchTask?.cancel()
@@ -386,6 +390,21 @@ final class ChatViewModel {
     }
 
     // MARK: - プライベートメソッド
+
+    /// 永続化 seed メッセージを messages 先頭に挿入し maxMessages に収める
+    ///
+    /// `seedFromPersistence` からのみ呼ぶ。private setter を extension から間接的に使う為に存在する。
+    func applyHistoricalSeed(_ ordered: [ChatMessage]) {
+        messages.insert(contentsOf: ordered, at: 0)
+        if messages.count > Self.maxMessages {
+            messages.removeFirst(messages.count - Self.maxMessages)
+        }
+    }
+
+    /// currentVideoId を更新する（fetchLatestVideoId からのみ呼ぶ）
+    func updateCurrentVideoId(_ id: String?) {
+        currentVideoId = id
+    }
 
     /// メッセージをリストに追加し、上限を超えた場合は古いものを削除する
     private func appendMessage(_ message: ChatMessage) {

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -363,9 +363,17 @@ final class ChatViewModel {
         connectionStateReceiveTask?.cancel()
         userStateReceiveTask?.cancel()
         roomStateReceiveTask?.cancel()
+        // cancel() 後に終了を待ち、遅延受信が MainActor へ割り込むのを防ぐ
+        await receiveTask?.value
+        await noticeReceiveTask?.value
+        await connectionStateReceiveTask?.value
+        await userStateReceiveTask?.value
+        await roomStateReceiveTask?.value
         // flush ループを止め、残存キューを書き出す
         flushTask?.cancel()
         videoIdFetchTask?.cancel()
+        await flushTask?.value
+        await videoIdFetchTask?.value
         await flushPendingPersistQueue()
 
         globalBadgeFetchTask?.cancel()

--- a/Sources/TwitchChat/ViewModels/ChatViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/ChatViewModel.swift
@@ -44,12 +44,18 @@ final class ChatViewModel {
     // MARK: - 定数
 
     /// メモリ管理のための最大メッセージ保持件数
-    private static let maxMessages = 500
+    static let maxMessages = 500
+
+    /// 永続化バッファの flush 間隔
+    static let flushInterval: Duration = .milliseconds(200)
+
+    /// Helix /helix/videos エンドポイント URL
+    static let videosURL = URL(string: "https://api.twitch.tv/helix/videos")!
 
     // MARK: - Published プロパティ
 
     /// 受信済みチャットメッセージ（最新 500 件）
-    private(set) var messages: [ChatMessage] = []
+    var messages: [ChatMessage] = []
 
     /// 接続状態
     private(set) var connectionState: ConnectionState = .disconnected
@@ -129,6 +135,27 @@ final class ChatViewModel {
     /// ROOMSTATE 購読のポーリング条件として参照できるよう `private(set)` で公開する。
     private(set) var currentRoomId: String?
 
+    /// 現在配信中の VOD video_id（Helix /helix/videos から取得）
+    ///
+    /// ROOMSTATE 受信後に非同期で取得する。VOD 保存無効・archive 未生成の場合は nil。
+    /// テストからポーリング条件として参照できるよう公開する。
+    var currentVideoId: String?
+
+    /// 永続化サービス（nil の場合は永続化なし）
+    let persistenceService: (any PersistenceService)?
+
+    /// Helix API クライアント（video_id 取得に使用）
+    let helixAPIClient: any HelixAPIClientProtocol
+
+    /// 永続化待ちメッセージバッファ（200ms ごとに flush される）
+    var pendingPersistQueue: [ChatMessage] = []
+
+    /// 200ms 間隔で pendingPersistQueue を flush する Task
+    var flushTask: Task<Void, Never>?
+
+    /// Helix /helix/videos から video_id を取得する Task
+    private var videoIdFetchTask: Task<Void, Never>?
+
     /// room-id が確定したときに呼ばれるコールバック
     ///
     /// ChannelManager が EventSub の subscribeChatMessage を呼ぶタイミングを知るために使用する。
@@ -169,6 +196,8 @@ final class ChatViewModel {
         self.ircClient = ircClient
         self.authState = authState
         let helixClient = apiClient ?? HelixAPIClient(tokenProvider: authState)
+        self.helixAPIClient = helixClient
+        self.persistenceService = persistenceService
         self.badgeStore = BadgeStore(apiClient: helixClient, persistenceService: persistenceService)
         self.emoteStore = EmoteStore(apiClient: helixClient, persistenceService: persistenceService)
         self.moderationService = moderationService ?? ModerationService(apiClient: helixClient)
@@ -188,37 +217,16 @@ final class ChatViewModel {
         channelBadgesFetched = false
         channelEmotesFetched = false
         currentRoomId = nil
+        currentVideoId = nil
+        pendingPersistQueue.removeAll()
 
         // チャンネル切替時に前チャンネルのバッジ・エモートが誤解決されないようクリア
         await badgeStore.resetChannelBadges()
         await emoteStore.resetChannelEmotes()
 
-        // グローバルバッジ・エモート定義を並行フェッチ（切断時にキャンセルできるよう保持）
-        // seedFromPersistence でキャッシュを先読みしてから fetchGlobalBadges を実行する（stale-while-revalidate）
-        globalBadgeFetchTask = Task {
-            await badgeStore.seedFromPersistence()
-            await badgeStore.fetchGlobalBadges()
-        }
-        globalEmoteFetchTask = Task {
-            await emoteStore.seedFromPersistence()
-            await emoteStore.fetchGlobalEmotes()
-        }
-
-        // ユーザーエモートを並行フェッチ（user:read:emotes スコープがある場合のみ）
-        // ユーザースコープのため接続時に1回のみ取得し、チャンネル切替時には再取得しない
-        if let userId = authState.userId, authState.canReadUserEmotes {
-            userEmoteFetchTask = Task { await emoteStore.fetchUserEmotes(userId: userId) }
-        } else {
-            #if DEBUG
-            if authState.userId == nil {
-                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: userId が未取得（未ログイン）")
-            } else if !authState.canReadUserEmotes {
-                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: user:read:emotes スコープなし（再ログインで取得可能）")
-            }
-            #endif
-        }
-
+        startFetchTasks()
         startStreamTasks()
+        startFlushLoop()
 
         do {
             // ログイン済みなら認証接続、ログアウト中なら匿名接続にフォールバック
@@ -240,6 +248,31 @@ final class ChatViewModel {
             globalBadgeFetchTask?.cancel()
             globalEmoteFetchTask?.cancel()
             userEmoteFetchTask?.cancel()
+        }
+    }
+
+    /// グローバル・チャンネルバッジ、エモート、ユーザーエモートのフェッチタスクを開始する
+    ///
+    /// connect() の本体長を抑えるために切り出したヘルパーメソッド。
+    private func startFetchTasks() {
+        globalBadgeFetchTask = Task {
+            await badgeStore.seedFromPersistence()
+            await badgeStore.fetchGlobalBadges()
+        }
+        globalEmoteFetchTask = Task {
+            await emoteStore.seedFromPersistence()
+            await emoteStore.fetchGlobalEmotes()
+        }
+        if let userId = authState.userId, authState.canReadUserEmotes {
+            userEmoteFetchTask = Task { await emoteStore.fetchUserEmotes(userId: userId) }
+        } else {
+            #if DEBUG
+            if authState.userId == nil {
+                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: userId が未取得（未ログイン）")
+            } else if !authState.canReadUserEmotes {
+                print("[ChatViewModel] ユーザーエモートフェッチをスキップ: user:read:emotes スコープなし（再ログインで取得可能）")
+            }
+            #endif
         }
     }
 
@@ -321,6 +354,11 @@ final class ChatViewModel {
 
     /// チャンネルから切断する
     func disconnect() async {
+        // flush ループと video_id 取得タスクを停止してから残存キューを書き出す
+        flushTask?.cancel()
+        videoIdFetchTask?.cancel()
+        await flushPendingPersistQueue()
+
         receiveTask?.cancel()
         noticeReceiveTask?.cancel()
         connectionStateReceiveTask?.cancel()
@@ -341,8 +379,10 @@ final class ChatViewModel {
         await ircClient.disconnect()
         connectionState = .disconnected
         currentRoomId = nil
+        currentVideoId = nil
         currentUserState = nil
         optimisticPendingMessages.removeAll()
+        pendingPersistQueue.removeAll()
     }
 
     // MARK: - プライベートメソッド
@@ -372,6 +412,7 @@ final class ChatViewModel {
         if messages.count > Self.maxMessages {
             messages.removeFirst(messages.count - Self.maxMessages)
         }
+        pendingPersistQueue.append(message)
     }
 
     /// ROOMSTATE から取得した room-id を currentRoomId に設定する
@@ -391,6 +432,10 @@ final class ChatViewModel {
                 channelEmotesFetched = true
                 channelEmoteFetchTask = Task { await emoteStore.fetchChannelEmotes(broadcasterId: roomId) }
             }
+            // 直近メッセージを永続化から先読みして seed する
+            Task { await self.seedFromPersistence(roomId: roomId) }
+            // 配信中の VOD video_id を Helix から取得する
+            videoIdFetchTask = Task { await self.fetchLatestVideoId(broadcasterId: roomId) }
         }
     }
 
@@ -694,4 +739,5 @@ final class ChatViewModel {
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespaces)
     }
+
 }

--- a/Tests/TwitchChatTests/ChatHistoryPersistenceTests.swift
+++ b/Tests/TwitchChatTests/ChatHistoryPersistenceTests.swift
@@ -1,0 +1,383 @@
+// ChatHistoryPersistenceTests.swift
+// チャット履歴の永続化（バッファリング書き込み・seed・videoId 紐付け）の統合テスト
+// ChatViewModel + InMemoryPersistenceService + MockHelixAPIClientForVideos を組み合わせる
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - Helix /videos モック
+
+/// Helix /helix/videos エンドポイントをスタブするテスト用モック
+///
+/// - `stubbedVideoId` に値を渡すと VOD video_id を返す（nil なら空配列）
+/// - `shouldThrow: true` で全 GET リクエストを throw する（Helix エラーシミュレーション）
+struct MockHelixAPIClientForVideos: HelixAPIClientProtocol {
+    /// スタブする VOD video_id（nil の場合は archive なしとして空配列を返す）
+    let stubbedVideoId: String?
+    /// true の場合、`URLError.badServerResponse` を throw する
+    let shouldThrow: Bool
+
+    init(stubbedVideoId: String? = nil, shouldThrow: Bool = false) {
+        self.stubbedVideoId = stubbedVideoId
+        self.shouldThrow = shouldThrow
+    }
+
+    func get<T: Decodable & Sendable>(url: URL, queryItems: [URLQueryItem]?) async throws -> T {
+        if url.absoluteString.contains("/helix/videos") {
+            if shouldThrow {
+                throw URLError(.badServerResponse)
+            }
+            let data: [HelixVideoData]
+            if let videoId = stubbedVideoId {
+                data = [HelixVideoData(
+                    id: videoId,
+                    userId: "配信者ID",
+                    streamId: "stream001",
+                    type: "archive",
+                    title: "テスト配信"
+                )]
+            } else {
+                data = []
+            }
+            let response = HelixVideosResponse(data: data)
+            // swiftlint:disable:next force_cast
+            return response as! T
+        }
+        // /helix/videos 以外は AuthConfigError でサイレントスキップさせる
+        // （BadgeStore / EmoteStore は catch is AuthConfigError で無視する）
+        throw AuthConfigError.missingClientID
+    }
+
+    func post<Body: Encodable & Sendable, T: Decodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws -> T {
+        throw AuthConfigError.missingClientID
+    }
+
+    func postNoContent<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw AuthConfigError.missingClientID
+    }
+
+    func patch<Body: Encodable & Sendable>(
+        url: URL, queryItems: [URLQueryItem]?, body: Body
+    ) async throws {
+        throw AuthConfigError.missingClientID
+    }
+
+    func delete(url: URL, queryItems: [URLQueryItem]?) async throws {
+        throw AuthConfigError.missingClientID
+    }
+}
+
+// MARK: - テスト
+
+@Suite("ChatHistoryPersistence テスト")
+@MainActor
+struct ChatHistoryPersistenceTests {
+
+    // MARK: - ヘルパー
+
+    /// ViewModel の状態変化を条件が満たされるまで待機する
+    ///
+    /// - Parameters:
+    ///   - timeout: 最大待機秒数（デフォルト 2.0 秒）
+    ///   - condition: 満たされるべき条件
+    private func waitFor(timeout: TimeInterval = 2.0, condition: () -> Bool) async {
+        let start = Date()
+        while !condition() {
+            if Date().timeIntervalSince(start) >= timeout { break }
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms ポーリング
+        }
+    }
+
+    /// 永続化サービス・Helix モック付き ChatViewModel を生成する
+    private func makeViewModelWithPersistence(
+        stubbedVideoId: String? = nil,
+        shouldThrowHelixError: Bool = false
+    ) -> (ChatViewModel, MockTwitchIRCClient, InMemoryPersistenceService) {
+        let mockClient = MockTwitchIRCClient()
+        let persistence = InMemoryPersistenceService()
+        let helixMock = MockHelixAPIClientForVideos(
+            stubbedVideoId: stubbedVideoId,
+            shouldThrow: shouldThrowHelixError
+        )
+        let viewModel = ChatViewModel(
+            ircClient: mockClient,
+            apiClient: helixMock,
+            persistenceService: persistence
+        )
+        return (viewModel, mockClient, persistence)
+    }
+
+    /// room-id タグ付きの IRC PRIVMSG 文字列を MockTwitchIRCClient 経由で ViewModel に流し込む
+    private func sendIRCMessage(
+        text: String,
+        displayName: String = "テスト視聴者",
+        roomId: String? = nil,
+        to mockClient: MockTwitchIRCClient
+    ) {
+        let roomIdTag = roomId.map { ";room-id=\($0)" } ?? ""
+        let raw = "@badges=;color=#FF0000;display-name=\(displayName)"
+            + ";emotes=;id=\(UUID().uuidString)\(roomIdTag);user-id=11111"
+            + " :テスト視聴者!テスト視聴者@テスト視聴者.tmi.twitch.tv"
+            + " PRIVMSG #テストチャンネル :\(text)"
+        guard let ircMsg = IRCMessageParser.parse(raw),
+              let chatMsg = ChatMessage(from: ircMsg) else { return }
+        Task { await mockClient.sendMessage(chatMsg) }
+    }
+
+    // MARK: - バッファリング書き込み
+
+    @Test("appendMessage後200ms以内にメッセージが永続化される")
+    func appendMessage後200ms以内にメッセージが永続化される() async throws {
+        // 前提: 永続化サービス付き ViewModel を接続
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        await viewModel.connect(to: "テストチャンネル")
+
+        // ROOMSTATE を流して roomId を確定させる
+        await mockClient.sendRoomState(roomId: "配信者ID_001")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // 実行: チャットメッセージを送信
+        sendIRCMessage(text: "こんにちは、配信！", to: mockClient)
+        await waitFor { viewModel.messages.count >= 1 }
+
+        // 300ms 待機（200ms flush タイマーが 1 サイクル以上発火するまで）
+        try await Task.sleep(for: .milliseconds(300))
+
+        // 検証: 永続化サービスにメッセージが書き込まれている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_001", limit: 10, before: nil)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.text == "こんにちは、配信！")
+
+        await viewModel.disconnect()
+    }
+
+    @Test("disconnect時に残存キューがflushされる")
+    func disconnect時に残存キューがflushされる() async throws {
+        // 前提: 200ms flush 前に disconnect を呼ぶシナリオ
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        await viewModel.connect(to: "テストチャンネル")
+
+        await mockClient.sendRoomState(roomId: "配信者ID_002")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // 実行: メッセージ送信後 50ms 以内（flush 前）に disconnect
+        sendIRCMessage(text: "切断直前のコメント", to: mockClient)
+        await waitFor { viewModel.messages.count >= 1 }
+        try await Task.sleep(for: .milliseconds(50)) // 200ms より短い
+        await viewModel.disconnect()
+
+        // 検証: disconnect 時に残存キューが flush されている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_002", limit: 10, before: nil)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.text == "切断直前のコメント")
+    }
+
+    @Test("roomIdなしメッセージはROOMSTATE受信後に一括書き込まれる")
+    func roomIdなしメッセージはROOMSTATE受信後に一括書き込まれる() async throws {
+        // 前提: ROOMSTATE 未受信の状態で接続
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        await viewModel.connect(to: "テストチャンネル")
+
+        // ROOMSTATE 前に room-id なし PRIVMSG を 3 件送信
+        sendIRCMessage(text: "1通目：roomIdなし", to: mockClient)
+        sendIRCMessage(text: "2通目：roomIdなし", to: mockClient)
+        sendIRCMessage(text: "3通目：roomIdなし", to: mockClient)
+        await waitFor { viewModel.messages.count >= 3 }
+
+        // ROOMSTATE を流して roomId を確定させる
+        await mockClient.sendRoomState(roomId: "配信者ID_003")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // flush 完了を待機
+        try await Task.sleep(for: .milliseconds(300))
+
+        // 検証: 3件すべてが roomId 付きで永続化されている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_003", limit: 10, before: nil)
+        #expect(loaded.count == 3)
+        #expect(loaded.allSatisfy { $0.roomId == "配信者ID_003" })
+
+        await viewModel.disconnect()
+    }
+
+    @Test("currentVideoIdがメッセージに永続化される")
+    func currentVideoIdがメッセージに永続化される() async throws {
+        // 前提: Helix が videoId "VOD_テスト12345" を返すモック付き ViewModel
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence(stubbedVideoId: "VOD_テスト12345")
+        await viewModel.connect(to: "テストチャンネル")
+
+        // ROOMSTATE を流すと内部で Helix /videos 呼び出しが起動する
+        await mockClient.sendRoomState(roomId: "配信者ID_004")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // videoId の取得完了を待機
+        await waitFor { viewModel.currentVideoId != nil }
+        #expect(viewModel.currentVideoId == "VOD_テスト12345")
+
+        // 実行: videoId 確定後にメッセージを送信
+        sendIRCMessage(text: "VOD紐付けテスト", to: mockClient)
+        await waitFor { viewModel.messages.count >= 1 }
+        try await Task.sleep(for: .milliseconds(300))
+
+        // 検証: videoId が付いて永続化されている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_004", limit: 10, before: nil)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.videoId == "VOD_テスト12345")
+
+        await viewModel.disconnect()
+    }
+
+    @Test("videoIdが取得できない場合はnilで永続化される")
+    func videoIdが取得できない場合はnilで永続化される() async throws {
+        // 前提: Helix が空配列を返す（VOD 保存無効など）
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence(stubbedVideoId: nil)
+        await viewModel.connect(to: "テストチャンネル")
+
+        await mockClient.sendRoomState(roomId: "配信者ID_005")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // 実行: videoId なしでメッセージを送信
+        sendIRCMessage(text: "VODなし配信のコメント", to: mockClient)
+        await waitFor { viewModel.messages.count >= 1 }
+        try await Task.sleep(for: .milliseconds(300))
+
+        // 検証: videoId が nil で永続化されている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_005", limit: 10, before: nil)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.videoId == nil)
+
+        await viewModel.disconnect()
+    }
+
+    @Test("Helixエラー時はnilで続行して接続が維持される")
+    func Helixエラー時はnilで続行して接続が維持される() async throws {
+        // 前提: Helix がエラーを throw するモック
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence(shouldThrowHelixError: true)
+        await viewModel.connect(to: "テストチャンネル")
+
+        await mockClient.sendRoomState(roomId: "配信者ID_006")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // Helix 呼び出しが完了するまで少し待機
+        try await Task.sleep(for: .milliseconds(100))
+
+        // 検証: エラーでも接続が維持されている
+        #expect(viewModel.connectionState == .connected)
+        #expect(viewModel.currentVideoId == nil)
+
+        // 実行: エラー後もメッセージを永続化できる
+        sendIRCMessage(text: "Helixエラー後も動いてます", to: mockClient)
+        await waitFor { viewModel.messages.count >= 1 }
+        try await Task.sleep(for: .milliseconds(300))
+
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_006", limit: 10, before: nil)
+        #expect(loaded.count == 1)
+        #expect(loaded.first?.videoId == nil)
+
+        await viewModel.disconnect()
+    }
+
+    // MARK: - 起動時 seed
+
+    @Test("connect時にloadRecentMessagesで直近50件がseedされる")
+    func connect時にloadRecentMessagesで直近50件がseedされる() async throws {
+        // 前提: 永続化サービスに事前に 50 件のメッセージを書き込む
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        let roomId = "配信者ID_007"
+        let past = Date().addingTimeInterval(-3600) // 1時間前
+        let seedMessages = (1...50).map { i in
+            ChatMessage(
+                id: "過去メッセージID_\(i)",
+                username: "過去視聴者\(i)",
+                displayName: "過去視聴者\(i)",
+                text: "過去のコメント\(i)番目",
+                colorHex: nil,
+                badges: [],
+                emotePositions: [],
+                roomId: roomId,
+                isAction: false,
+                receivedAt: past.addingTimeInterval(Double(i)),
+                replyParentMsgId: nil,
+                isOptimistic: false,
+                replyParentUserLogin: nil,
+                replyParentDisplayName: nil,
+                replyParentMsgBody: nil,
+                isSystemNotice: false
+            )
+        }
+        try await persistence.appendMessages(seedMessages)
+
+        // 実行: connect → ROOMSTATE 受信で seed が起動する
+        await viewModel.connect(to: "テストチャンネル")
+        await mockClient.sendRoomState(roomId: roomId)
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // seed 完了を待機
+        await waitFor(timeout: 2.0) { viewModel.messages.count >= 50 }
+
+        // 検証: 50 件が表示されていること、すべて isOptimistic = false
+        #expect(viewModel.messages.count == 50)
+        #expect(viewModel.messages.allSatisfy { !$0.isOptimistic })
+
+        await viewModel.disconnect()
+    }
+
+    // MARK: - maxMessages 超過
+
+    @Test("maxMessagesを超えるとメモリから落ちるがdiskには残る")
+    func maxMessagesを超えるとメモリから落ちるがdiskには残る() async throws {
+        // 前提: 接続済み ViewModel
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        await viewModel.connect(to: "テストチャンネル")
+
+        await mockClient.sendRoomState(roomId: "配信者ID_008")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // 実行: 600 件のメッセージを送信（maxMessages = 500 を超える）
+        for i in 1...600 {
+            sendIRCMessage(text: "メッセージ\(i)通目", to: mockClient)
+        }
+        await waitFor(timeout: 10.0) { viewModel.messages.count == 500 }
+
+        // flush が完了するまで待機
+        try await Task.sleep(for: .milliseconds(500))
+
+        // 検証: in-memory は 500 件（古い分がカット）
+        #expect(viewModel.messages.count == 500)
+
+        // 検証: disk には 600 件残っている
+        let loaded = await persistence.loadRecentMessages(roomId: "配信者ID_008", limit: 600, before: nil)
+        #expect(loaded.count == 600)
+
+        await viewModel.disconnect()
+    }
+
+    // MARK: - 全文検索の基盤
+
+    @Test("searchMessagesがChatViewModelの書き込みを返す")
+    func searchMessagesがChatViewModelの書き込みを返す() async throws {
+        // 前提: 接続済み ViewModel
+        let (viewModel, mockClient, persistence) = makeViewModelWithPersistence()
+        await viewModel.connect(to: "テストチャンネル")
+
+        await mockClient.sendRoomState(roomId: "配信者ID_009")
+        await waitFor { viewModel.currentRoomId != nil }
+
+        // 実行: 特定キーワードを含むメッセージを送信
+        sendIRCMessage(text: "今日の天気はどうですか？", to: mockClient)
+        sendIRCMessage(text: "ゲームが面白いですね！", to: mockClient)
+        await waitFor { viewModel.messages.count >= 2 }
+        try await Task.sleep(for: .milliseconds(300))
+
+        // 検証: 「天気」で検索すると 1 件のみヒット
+        let results = await persistence.searchMessages(query: "天気", roomId: "配信者ID_009", limit: 10)
+        #expect(results.count == 1)
+        #expect(results.first?.text == "今日の天気はどうですか？")
+
+        await viewModel.disconnect()
+    }
+}

--- a/Tests/TwitchChatTests/ChatViewModelTests.swift
+++ b/Tests/TwitchChatTests/ChatViewModelTests.swift
@@ -912,7 +912,13 @@ struct ChatViewModelTests {
         let mockClient = MockTwitchIRCClient()
         let mockModeration = MockModerationService()
         let authState = try await makeLoggedInAuthState(userLogin: "モデレーター")
-        let viewModel = ChatViewModel(ircClient: mockClient, authState: authState, moderationService: mockModeration)
+        // Helix 副作用（fetchLatestVideoId）を抑止するためモックを注入する
+        let viewModel = ChatViewModel(
+            ircClient: mockClient,
+            authState: authState,
+            apiClient: MockHelixAPIClientForVideos(),
+            moderationService: mockModeration
+        )
         await viewModel.connect(to: "テストチャンネル")
         await waitFor { viewModel.connectionState == .connected }
 

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -638,6 +638,74 @@ struct SwiftDataPersistenceServiceTests {
     }
 }
 
+// MARK: - videoId round-trip テスト
+
+extension SwiftDataPersistenceServiceTests {
+
+    @Test("videoId付きメッセージを保存して復元できる")
+    func videoId付きメッセージを保存して復元できる() async throws {
+        // 前提: videoId を持つメッセージを作成
+        let service = try makeService()
+        let original = ChatMessage(
+            id: "vod_msg_001",
+            username: "suzuki_ichiro",
+            displayName: "鈴木一郎",
+            text: "VOD紐付けテスト",
+            colorHex: nil,
+            badges: [],
+            emotePositions: [],
+            roomId: "配信者チャンネルID_001",
+            isAction: false,
+            receivedAt: Date(),
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: false,
+            videoId: "v987654321"
+        )
+
+        // 操作: 保存して取得
+        try await service.appendMessages([original])
+        let loaded = await service.loadRecentMessages(roomId: "配信者チャンネルID_001", limit: 10, before: nil)
+
+        // 検証: videoId が正しく復元される
+        #expect(loaded.first?.videoId == "v987654321")
+    }
+
+    @Test("videoIdがnilのメッセージを保存して復元できる")
+    func videoIdがnilのメッセージを保存して復元できる() async throws {
+        // 前提: videoId が nil のメッセージ（VOD保存無効チャンネル等）
+        let service = try makeService()
+        let original = ChatMessage(
+            id: "no_vod_msg_001",
+            username: "tanaka_jiro",
+            displayName: "田中次郎",
+            text: "VODなしテスト",
+            colorHex: nil,
+            badges: [],
+            emotePositions: [],
+            roomId: "配信者チャンネルID_002",
+            isAction: false,
+            receivedAt: Date(),
+            replyParentMsgId: nil,
+            isOptimistic: false,
+            replyParentUserLogin: nil,
+            replyParentDisplayName: nil,
+            replyParentMsgBody: nil,
+            isSystemNotice: false
+        )
+
+        // 操作: 保存して取得
+        try await service.appendMessages([original])
+        let loaded = await service.loadRecentMessages(roomId: "配信者チャンネルID_002", limit: 10, before: nil)
+
+        // 検証: videoId が nil のまま復元される
+        #expect(loaded.first?.videoId == nil)
+    }
+}
+
 // MARK: - テスト用 ChatMessage イニシャライザ
 
 private extension ChatMessage {


### PR DESCRIPTION
## Summary

- `ChatMessage` に `videoId: String?` プロパティを追加。Helix `/helix/videos?user_id=<broadcasterId>&type=archive&first=1` で取得した最新 archive VOD の ID をチャットメッセージに紐付ける
- `SchemaV1.PersistedChatMessage` に `videoId` カラムを追加（V1 枠確保・nil 許容・`versionIdentifier` 据え置き）
- `ChatViewModel` に 200ms flush ループ・disconnect 時 flush・ROOMSTATE seed・Helix video_id 取得を実装
- `ChatViewModel+Persistence.swift` を新設し、永続化関連メソッドをファイル分離（file_length SwiftLint 遵守）
- `ChatHistoryPersistenceTests`（9件）と `SwiftDataPersistenceServiceTests` videoId round-trip（2件）を追加

## Test plan

- [ ] `swift test --filter ChatHistoryPersistenceTests`（9件全通過）
- [ ] `swift test --filter SwiftDataPersistenceServiceTests`（26件全通過、videoId round-trip 2件含む）
- [ ] `swift build` ビルドエラーなし
- [ ] `swiftlint lint --strict` 違反ゼロ
- [ ] 手動: VOD 保存有効チャンネルで `videoId` が SQLite に記録されることを確認

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリース ノート

* **新機能**
  * チャットメッセージにVOD識別子の追跡を追加し、該当する場合は保存されます。
  * バッファリングされた自動保存ループと起動時の履歴シード機能を導入しました。

* **改善**
  * 接続/切断時の永続化フローとエラー耐性を強化しました。
  * メモリ上は最大500件を保持しつつ、完全な履歴はディスクに保存します。

* **テスト**
  * 永続化・復元・VOD付与・フラッシュ動作をカバーする統合テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->