### PR TITLE
feat: 画像バイナリのディスクキャッシュ（永続化基盤 PR-6）

### DIFF
--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -97,6 +97,10 @@ struct TwitchChatApp: App {
                             apiClient: helixClient,
                             persistenceService: persistenceContainer.service
                         )
+                        // 3 ImageCache に L2 ディスクキャッシュを注入する
+                        EmoteImageCache.shared.attachPersistence(persistenceContainer.service)
+                        BadgeImageCache.shared.attachPersistence(persistenceContainer.service)
+                        ProfileImageCache.shared.attachPersistence(persistenceContainer.service)
                     }
             }
         }

--- a/Sources/TwitchChat/Persistence/ImageDiskStore.swift
+++ b/Sources/TwitchChat/Persistence/ImageDiskStore.swift
@@ -1,0 +1,196 @@
+// ImageDiskStore.swift
+// Application Support 配下の画像バイナリディスクキャッシュ（L2）
+//
+// SHA256 ハッシュに基づいたディレクトリ構造でバイナリを管理する。
+// SwiftData の PersistedImageAsset はメタデータ（byteSize・lastAccessedAt）を保持し、
+// 実バイナリはこの actor が担当する。
+//
+// パス構造: <rootDirectory>/ImageCache/<bucket>/<sha[0..2]>/<sha[2..4]>/<sha[4..]>.bin
+
+import CryptoKit
+import Foundation
+
+/// 画像バイナリのディスクキャッシュを管理する actor
+///
+/// 責務: ファイル I/O・SHA256 パス算出・isExcludedFromBackupKey 設定・容量上限の定義
+/// 容量集計・LRU eviction・起動時 reconcile は PersistenceActor 側で行う。
+actor ImageDiskStore {
+
+    // MARK: - バケット
+
+    /// 画像の種別ごとに対応するディレクトリバケット
+    enum Bucket: String, CaseIterable, Sendable {
+        case emotes
+        case badges
+        case profiles
+
+        init(kind: ImageCacheKey.Kind) {
+            switch kind {
+            case .emote: self = .emotes
+            case .badge: self = .badges
+            case .profile: self = .profiles
+            }
+        }
+    }
+
+    // MARK: - 容量上限
+
+    /// バケットごとの容量上限設定
+    struct Capacity: Sendable {
+        let emotesMB: Int
+        let badgesMB: Int
+        let profilesMB: Int
+
+        static let `default` = Capacity(emotesMB: 200, badgesMB: 50, profilesMB: 50)
+
+        /// 指定バケットの上限をバイト数で返す
+        func bytes(for bucket: Bucket) -> Int {
+            switch bucket {
+            case .emotes: return emotesMB * 1024 * 1024
+            case .badges: return badgesMB * 1024 * 1024
+            case .profiles: return profilesMB * 1024 * 1024
+            }
+        }
+    }
+
+    // MARK: - プロパティ
+
+    private let rootDirectory: URL
+    private let storedCapacity: Capacity
+
+    // MARK: - 初期化
+
+    /// ルートディレクトリを指定して ImageDiskStore を生成する
+    ///
+    /// - Parameters:
+    ///   - rootDirectory: キャッシュルート（Application Support 配下または一時ディレクトリ）
+    ///   - capacity: バケット別容量上限（デフォルト: emotes=200MB / badges=50MB / profiles=50MB）
+    /// - Throws: ImageCache ルートまたはバケットディレクトリの作成・属性設定に失敗した場合
+    init(rootDirectory: URL, capacity: Capacity = .default) throws {
+        // ディレクトリを先に作成してから realpath() でシムリンクを完全解決する。
+        // URL.resolvingSymlinksInPath() は macOS の /var → /private/var を解決しない。
+        // enumerator が返す /private/var パスと一致させるため realpath() syscall を使う。
+        self.storedCapacity = capacity
+        try Self.setupDirectories(rootDirectory: rootDirectory)
+        let resolvedPath = Self.realPath(rootDirectory.path)
+        self.rootDirectory = URL(fileURLWithPath: resolvedPath, isDirectory: true)
+    }
+
+    // MARK: - パブリック API
+
+    /// 指定キーの画像バイナリを読み出す
+    ///
+    /// ファイルが存在しない場合は nil を返す（エラーは握りつぶす）。
+    /// lastAccessedAt の更新は呼び出し元（PersistenceActor）で debounce する。
+    func loadData(key: ImageCacheKey) -> Data? {
+        let url = filePath(for: key)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try? Data(contentsOf: url)
+    }
+
+    /// 指定キーの画像バイナリをアトミック書き込みする
+    ///
+    /// - Returns: 実際に書き込んだバイト数
+    /// - Throws: ディレクトリ作成または書き込みに失敗した場合
+    func writeData(_ data: Data, key: ImageCacheKey) throws -> Int {
+        let url = filePath(for: key)
+        let dir = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        // .atomic は write→rename でアトミック性を保証する（OS が fsync 相当を行う）
+        try data.write(to: url, options: .atomic)
+        return data.count
+    }
+
+    /// 指定キーのファイルを削除する（ファイルが存在しない場合は何もしない）
+    func deleteFile(key: ImageCacheKey) {
+        try? FileManager.default.removeItem(at: filePath(for: key))
+    }
+
+    /// 指定キーのファイル URL を返す（ファイルの存在は保証しない）
+    ///
+    /// nonisolated のため await 不要で呼び出せる（純粋な SHA256 計算のみ）。
+    nonisolated func fileURL(for key: ImageCacheKey) -> URL {
+        filePath(for: key)
+    }
+
+    /// ImageCache 配下の全 .bin ファイルを列挙する（孤児ファイル検出用）
+    func enumerateAllFiles() -> [URL] {
+        let cacheRoot = rootDirectory.appendingPathComponent("ImageCache")
+        guard let enumerator = FileManager.default.enumerator(
+            at: cacheRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var result: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "bin" {
+            result.append(url)
+        }
+        return result
+    }
+
+    /// 指定バケットの容量上限をバイト数で返す
+    ///
+    /// nonisolated のため await 不要で呼び出せる（storedCapacity は let 定数）。
+    nonisolated func capacity(for bucket: Bucket) -> Int {
+        storedCapacity.bytes(for: bucket)
+    }
+
+    // MARK: - プライベートメソッド
+
+    /// SHA256 ハッシュに基づいてファイルパスを算出する
+    ///
+    /// 入力: "<kindRaw>:<identifier>" （PersistenceActor.imageCacheKeyRaw と同規則）
+    /// パス: <rootDirectory>/ImageCache/<bucket>/<sha[0..2]>/<sha[2..4]>/<sha[4..]>.bin
+    nonisolated private func filePath(for key: ImageCacheKey) -> URL {
+        let bucket = Bucket(kind: key.kind)
+        let input = "\(key.kind.rawValue):\(key.identifier)"
+        let hashBytes = SHA256.hash(data: Data(input.utf8))
+        let hex = hashBytes.compactMap { String(format: "%02x", $0) }.joined()
+
+        return rootDirectory
+            .appendingPathComponent("ImageCache")
+            .appendingPathComponent(bucket.rawValue)
+            .appendingPathComponent(String(hex.prefix(2)))
+            .appendingPathComponent(String(hex.dropFirst(2).prefix(2)))
+            .appendingPathComponent("\(String(hex.dropFirst(4))).bin")
+    }
+
+    // MARK: - 初期化ヘルパー（非 actor コンテキストで呼ぶため static）
+
+    /// POSIX realpath() でシムリンクを完全解決し、正規絶対パスを返す
+    ///
+    /// パスが存在しない場合や解決失敗時は元のパスを返す。
+    private static func realPath(_ path: String) -> String {
+        guard let resolved = Darwin.realpath(path, nil) else { return path }
+        defer { free(resolved) }
+        return String(cString: resolved)
+    }
+
+    /// ImageCache ルートおよびバケットディレクトリを作成し、isExcludedFromBackup を設定する
+    private static func setupDirectories(rootDirectory: URL) throws {
+        let cacheRoot = rootDirectory.appendingPathComponent("ImageCache")
+
+        // バケットディレクトリを作成
+        for bucket in Bucket.allCases {
+            let bucketDir = cacheRoot.appendingPathComponent(bucket.rawValue)
+            try FileManager.default.createDirectory(at: bucketDir, withIntermediateDirectories: true)
+        }
+
+        // ImageCache ルートを backup 除外に設定
+        try setExcludedFromBackup(url: cacheRoot)
+
+        // 各バケットも backup 除外に設定
+        for bucket in Bucket.allCases {
+            let bucketDir = cacheRoot.appendingPathComponent(bucket.rawValue)
+            try setExcludedFromBackup(url: bucketDir)
+        }
+    }
+
+    private static func setExcludedFromBackup(url: URL) throws {
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        var mutableURL = url
+        try mutableURL.setResourceValues(resourceValues)
+    }
+}

--- a/Sources/TwitchChat/Persistence/PersistenceActor+ImageCache.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor+ImageCache.swift
@@ -1,0 +1,229 @@
+// PersistenceActor+ImageCache.swift
+// PersistenceActor の画像バイナリ I/O・LRU sweep・debounce flush を担う extension
+// PersistenceActor.swift のファイル長制限（800行）維持のため分離
+
+import Foundation
+import SwiftData
+
+// MARK: - 画像バイナリ（ImageDiskStore 統合）
+
+extension PersistenceActor {
+
+    /// DI: ImageDiskStore を注入する（@ModelActor 生成 init の後付け設定）
+    func attachDiskStore(_ store: ImageDiskStore) {
+        imageDiskStore = store
+    }
+
+    /// キャッシュキーで画像バイナリを取得する
+    ///
+    /// - SwiftData レコードあり・ファイルあり → データ返却（lastAccessedAt を debounce 更新）
+    /// - SwiftData レコードあり・ファイルなし → 整合性違反: レコード削除して nil 返却
+    /// - SwiftData レコードなし → nil 返却
+    func loadImageData(key: ImageCacheKey) async -> Data? {
+        let cacheKeyStr = imageCacheKeyRaw(key)
+        let descriptor = FetchDescriptor<PersistedImageAsset>(
+            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
+        )
+        guard let asset = (try? modelContext.fetch(descriptor))?.first else { return nil }
+
+        guard let store = imageDiskStore else {
+            // diskStore 未設定（InMemory フォールバック状態）は nil を返す
+            return nil
+        }
+
+        guard let data = await store.loadData(key: key) else {
+            // ファイル無しレコード: 整合性違反を修正して nil 返却
+            modelContext.delete(asset)
+            try? modelContext.save()
+            return nil
+        }
+
+        // lastAccessedAt の更新は 60 秒 debounce でまとめて flush する
+        pendingTouches.insert(cacheKeyStr)
+        scheduleTouchFlushIfNeeded()
+        return data
+    }
+
+    /// 画像バイナリを保存する（upsert）
+    ///
+    /// 書き込み順: BLOB ファイル書き込み（fsync 相当） → SwiftData コミット
+    /// ファイル書き込み失敗時は SwiftData に手を付けずに throw する。
+    /// SwiftData save 失敗時は best-effort でファイルを削除して巻き戻す。
+    func saveImageData(_ data: Data, key: ImageCacheKey, mime: String) async throws {
+        guard let store = imageDiskStore else { return }
+
+        // Step 1: ファイルを先に書き込む（BLOB fsync）
+        let bytes = try await store.writeData(data, key: key)
+
+        // Step 2: SwiftData メタデータを upsert する
+        let cacheKeyStr = imageCacheKeyRaw(key)
+        let descriptor = FetchDescriptor<PersistedImageAsset>(
+            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
+        )
+        let now = Date()
+        if let existing = (try? modelContext.fetch(descriptor))?.first {
+            existing.mime = mime
+            existing.byteSize = bytes
+            existing.lastAccessedAt = now
+        } else {
+            modelContext.insert(PersistedImageAsset(
+                cacheKey: cacheKeyStr,
+                kind: key.kind.rawValue,
+                identifier: key.identifier,
+                mime: mime,
+                byteSize: bytes,
+                lastAccessedAt: now,
+                createdAt: now
+            ))
+        }
+
+        // Step 3: SwiftData コミット（失敗時は best-effort でファイル削除）
+        do {
+            try modelContext.save()
+        } catch {
+            await store.deleteFile(key: key)
+            throw error
+        }
+
+        // Step 4: バケット容量超過チェック
+        let bucket = ImageDiskStore.Bucket(kind: key.kind)
+        await runSweepIfNeeded(for: bucket)
+    }
+
+    /// 起動時 reconcile + 全バケット sweep（起動 5 秒後 / didResignActive から呼ぶ）
+    func runReconcileAndSweep() async {
+        guard let store = imageDiskStore else { return }
+        await reconcile(store: store)
+        for bucket in ImageDiskStore.Bucket.allCases {
+            await runSweepIfNeeded(for: bucket)
+        }
+    }
+}
+
+// MARK: - 画像 Private Helpers
+
+private extension PersistenceActor {
+
+    /// ImageCacheKey をキャッシュキー文字列に変換する
+    func imageCacheKeyRaw(_ key: ImageCacheKey) -> String {
+        "\(key.kind.rawValue):\(key.identifier)"
+    }
+
+    // MARK: - LRU sweep
+
+    /// バケットの合計 byteSize が上限を超えていれば LRU 順に削除する
+    ///
+    /// 削除順: SwiftData コミット → ファイル削除（整合性保証）
+    func runSweepIfNeeded(for bucket: ImageDiskStore.Bucket) async {
+        guard let store = imageDiskStore else { return }
+        let kindStr = kindRaw(for: bucket)
+        let limit = store.capacity(for: bucket)
+
+        // バケット合計サイズを集計
+        let allDescriptor = FetchDescriptor<PersistedImageAsset>(
+            predicate: #Predicate { $0.kind == kindStr },
+            sortBy: [SortDescriptor(\.lastAccessedAt, order: .forward)]
+        )
+        guard let assets = try? modelContext.fetch(allDescriptor) else { return }
+        let total = assets.reduce(0) { $0 + $1.byteSize }
+        guard total > limit else { return }
+
+        // 容量超過分を lastAccessedAt 昇順（古い順）で削除
+        var freed = 0
+        let target = total - limit
+        var toDelete: [(key: ImageCacheKey, asset: PersistedImageAsset)] = []
+        for asset in assets {
+            guard freed < target else { break }
+            let key = ImageCacheKey(kind: kind(from: asset.kind), identifier: asset.identifier)
+            toDelete.append((key: key, asset: asset))
+            freed += asset.byteSize
+        }
+
+        // 削除順: SwiftData コミット → ファイル削除
+        for item in toDelete { modelContext.delete(item.asset) }
+        try? modelContext.save()
+        for item in toDelete { await store.deleteFile(key: item.key) }
+    }
+
+    /// 物理ファイルと SwiftData レコードの整合性を修復する
+    ///
+    /// - レコードあり・ファイルなし → レコードを削除
+    /// - ファイルあり・レコードなし → 孤児ファイルを削除
+    func reconcile(store: ImageDiskStore) async {
+        let allPhysical = await store.enumerateAllFiles()
+        let physicalPaths = Set(allPhysical.map(\.path))
+
+        let allDescriptor = FetchDescriptor<PersistedImageAsset>()
+        guard let assets = try? modelContext.fetch(allDescriptor) else { return }
+
+        var validPaths: Set<String> = []
+        for asset in assets {
+            let key = ImageCacheKey(kind: kind(from: asset.kind), identifier: asset.identifier)
+            let filePath = store.fileURL(for: key).path
+            if physicalPaths.contains(filePath) {
+                validPaths.insert(filePath)
+            } else {
+                // ファイル無しレコード → 削除
+                modelContext.delete(asset)
+            }
+        }
+        try? modelContext.save()
+
+        // 孤児ファイル（レコード無しファイル）を削除
+        for path in physicalPaths where !validPaths.contains(path) {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    // MARK: - lastAccessedAt Debounce
+
+    /// pendingTouches の flush Task をスケジュールする（すでに起動済みなら何もしない）
+    func scheduleTouchFlushIfNeeded() {
+        guard !debounceFlushScheduled else { return }
+        debounceFlushScheduled = true
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(60))
+            await self?.flushPendingTouches()
+        }
+    }
+
+    /// pendingTouches に溜まった lastAccessedAt 更新を一括コミットする
+    func flushPendingTouches() async {
+        guard !pendingTouches.isEmpty else {
+            debounceFlushScheduled = false
+            return
+        }
+        let keys = pendingTouches
+        pendingTouches.removeAll()
+        debounceFlushScheduled = false
+
+        let now = Date()
+        for cacheKeyStr in keys {
+            let descriptor = FetchDescriptor<PersistedImageAsset>(
+                predicate: #Predicate { $0.cacheKey == cacheKeyStr }
+            )
+            if let asset = (try? modelContext.fetch(descriptor))?.first {
+                asset.lastAccessedAt = now
+            }
+        }
+        try? modelContext.save()
+    }
+
+    // MARK: - kind 変換ヘルパー
+
+    func kindRaw(for bucket: ImageDiskStore.Bucket) -> String {
+        switch bucket {
+        case .emotes: return "emote"
+        case .badges: return "badge"
+        case .profiles: return "profile"
+        }
+    }
+
+    func kind(from kindRaw: String) -> ImageCacheKey.Kind {
+        switch kindRaw {
+        case "badge": return .badge
+        case "profile": return .profile
+        default: return .emote
+        }
+    }
+}

--- a/Sources/TwitchChat/Persistence/PersistenceActor.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceActor.swift
@@ -14,6 +14,30 @@ import SwiftData
 @ModelActor
 actor PersistenceActor {
 
+    // MARK: - ImageDiskStore 統合プロパティ
+
+    /// 実バイナリ I/O を担う ディスクキャッシュ actor（init 時または attachDiskStore で注入）
+    var imageDiskStore: ImageDiskStore?
+
+    /// lastAccessedAt の debounce 書き戻し待ちキャッシュキーセット
+    var pendingTouches: Set<String> = []
+
+    /// debounce flush Task が起動済みかどうか
+    var debounceFlushScheduled: Bool = false
+
+    // MARK: - ImageDiskStore 注入 init（カスタム）
+
+    /// ImageDiskStore を init 時に直接受け取る init（競合状態を回避）
+    ///
+    /// @ModelActor が生成する init(modelContainer:) と並列に定義できる。
+    /// imageDiskStore をデフォルト値なしで init することで nil チェックを不要にする。
+    init(modelContainer: ModelContainer, diskStore: ImageDiskStore) {
+        let modelContext = ModelContext(modelContainer)
+        self.modelExecutor = DefaultSerialModelExecutor(modelContext: modelContext)
+        self.modelContainer = modelContainer
+        self.imageDiskStore = diskStore
+    }
+
     // MARK: - エモート
 
     /// 指定ユーザーのエモートを取得する
@@ -183,46 +207,6 @@ actor PersistenceActor {
         return rows.compactMap { $0.toDomain() }
     }
 
-    // MARK: - 画像バイナリ
-
-    /// キャッシュキーで画像バイナリを取得する
-    func loadImageData(key: ImageCacheKey) -> Data? {
-        let cacheKeyStr = imageCacheKeyRaw(key)
-        let descriptor = FetchDescriptor<PersistedImageAsset>(
-            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
-        )
-        guard let asset = (try? modelContext.fetch(descriptor))?.first else { return nil }
-        // LRU 更新（失敗しても無視）
-        asset.lastAccessedAt = Date()
-        try? modelContext.save()
-        return asset.data
-    }
-
-    /// 画像バイナリを保存する（upsert）
-    func saveImageData(_ data: Data, key: ImageCacheKey, mime: String) throws {
-        let cacheKeyStr = imageCacheKeyRaw(key)
-        let descriptor = FetchDescriptor<PersistedImageAsset>(
-            predicate: #Predicate { $0.cacheKey == cacheKeyStr }
-        )
-        let now = Date()
-        if let existing = (try? modelContext.fetch(descriptor))?.first {
-            existing.data = data
-            existing.mime = mime
-            existing.lastAccessedAt = now
-        } else {
-            modelContext.insert(PersistedImageAsset(
-                cacheKey: cacheKeyStr,
-                kind: key.kind.rawValue,
-                identifier: key.identifier,
-                data: data,
-                mime: mime,
-                lastAccessedAt: now,
-                createdAt: now
-            ))
-        }
-        try modelContext.save()
-    }
-
     // MARK: - ライフサイクル
 
     /// ユーザー固有データを削除する（グローバル/チャンネル/バッジ/履歴/画像は保持）
@@ -380,10 +364,6 @@ private extension PersistenceActor {
         }
     }
 
-    /// ImageCacheKey をキャッシュキー文字列に変換する
-    func imageCacheKeyRaw(_ key: ImageCacheKey) -> String {
-        "\(key.kind.rawValue):\(key.identifier)"
-    }
 }
 
 // MARK: - EmoteScope

--- a/Sources/TwitchChat/Persistence/PersistenceContainer.swift
+++ b/Sources/TwitchChat/Persistence/PersistenceContainer.swift
@@ -21,19 +21,25 @@ struct PersistenceContainer: Sendable {
 
     /// SwiftData ディスク永続化で初期化する
     ///
-    /// Application Support 配下の SQLite ファイルにデータを保存する。
+    /// Application Support 配下の SQLite ファイルと ImageCache ディレクトリにデータを保存する。
     /// 構築に失敗した場合は呼び出し側で `makeInMemory()` にフォールバックすること。
     ///
     /// - Throws: ディレクトリ作成または `ModelContainer` の構築に失敗した場合
     static func makeOnDisk() throws -> PersistenceContainer {
         let storeURL = try defaultOnDiskStoreURL()
+        let imageCacheRoot = try defaultImageCacheRoot()
         let config = ModelConfiguration(url: storeURL)
         let container = try ModelContainer(
             for: Schema(versionedSchema: SchemaV1.self),
             migrationPlan: ChatSchemaMigrationPlan.self,
             configurations: config
         )
-        return PersistenceContainer(service: SwiftDataPersistenceService(container: container))
+        let service = try SwiftDataPersistenceService(
+            container: container,
+            imageDiskStoreRoot: imageCacheRoot,
+            attachAppKitTriggers: true
+        )
+        return PersistenceContainer(service: service)
     }
 
     /// Application Support 配下の SQLite ファイル URL を返す
@@ -49,5 +55,20 @@ struct PersistenceContainer: Sendable {
         let dir = base.appending(path: bundleId, directoryHint: .isDirectory)
         try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir.appending(path: "TwitchChat.sqlite", directoryHint: .notDirectory)
+    }
+
+    /// Application Support 配下の ImageCache ルートディレクトリ URL を返す
+    static func defaultImageCacheRoot() throws -> URL {
+        let fileManager = FileManager.default
+        let base = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let bundleId = Bundle.main.bundleIdentifier ?? "TwitchChat"
+        let dir = base.appending(path: bundleId, directoryHint: .isDirectory)
+        try fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
     }
 }

--- a/Sources/TwitchChat/Persistence/SchemaV1.swift
+++ b/Sources/TwitchChat/Persistence/SchemaV1.swift
@@ -232,10 +232,11 @@ final class PersistedUser {
 
 // MARK: - PersistedImageAsset
 
-/// 画像バイナリの永続化モデル（BLOB は外部ファイルに分離）
+/// 画像バイナリのメタデータ永続化モデル
 ///
-/// cacheKey は "<kindRaw>:<identifier>" 形式。
+/// cacheKey は "<kindRaw>:<identifier>" 形式。実バイナリは ImageDiskStore が管理する。
 /// lastAccessedAt は LRU eviction の軸として使用する。
+/// byteSize は容量上限チェック（バケット別集計）に使用する。
 @Model
 final class PersistedImageAsset {
     /// 主キー（"<kindRaw>:<identifier>"）
@@ -243,21 +244,21 @@ final class PersistedImageAsset {
     /// 画像種別文字列（"emote" / "badge" / "profile"）（インデックス対象）
     var kind: String
     var identifier: String
-    /// 画像バイナリ（外部ファイルに分離して保存）
-    @Attribute(.externalStorage) var data: Data
     var mime: String
+    /// 実バイナリのバイト数（LRU sweep の容量集計に使用）
+    var byteSize: Int
     /// 最終アクセス日時（LRU eviction 用、インデックス対象）
     var lastAccessedAt: Date
     var createdAt: Date
 
     #Index<PersistedImageAsset>([\.kind], [\.lastAccessedAt])
 
-    init(cacheKey: String, kind: String, identifier: String, data: Data, mime: String, lastAccessedAt: Date, createdAt: Date) {
+    init(cacheKey: String, kind: String, identifier: String, mime: String, byteSize: Int, lastAccessedAt: Date, createdAt: Date) {
         self.cacheKey = cacheKey
         self.kind = kind
         self.identifier = identifier
-        self.data = data
         self.mime = mime
+        self.byteSize = byteSize
         self.lastAccessedAt = lastAccessedAt
         self.createdAt = createdAt
     }

--- a/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
@@ -13,7 +13,16 @@ import SwiftData
 /// `InMemoryPersistenceService` にフォールバックする。
 struct SwiftDataPersistenceService: PersistenceService {
 
+    // addObserver(forName:using:) のトークンを Sendable struct で保持するためのラッパー
+    // トークンをインスタンスが生きている間保持し、解放時に通知購読を自動解除する
+    private final class ObserverBox: @unchecked Sendable {
+        let token: any NSObjectProtocol
+        init(_ token: any NSObjectProtocol) { self.token = token }
+        deinit { NotificationCenter.default.removeObserver(token) }
+    }
+
     private let actor: PersistenceActor
+    private let resignActiveObserver: ObserverBox?
 
     /// 既存の ModelContainer から生成する（テスト向けに imageDiskStoreRoot を注入可能）
     ///
@@ -40,16 +49,21 @@ struct SwiftDataPersistenceService: PersistenceService {
                     await actor.runReconcileAndSweep()
                 }
                 // バックグラウンド移行時に sweep を実行する（テスト時は登録しない）
-                NotificationCenter.default.addObserver(
+                // トークンを保持して通知購読の重複を防ぐ
+                let token = NotificationCenter.default.addObserver(
                     forName: NSApplication.didResignActiveNotification,
                     object: nil,
                     queue: nil
                 ) { _ in
                     Task { await actor.runReconcileAndSweep() }
                 }
+                self.resignActiveObserver = ObserverBox(token)
+            } else {
+                self.resignActiveObserver = nil
             }
         } else {
             self.actor = PersistenceActor(modelContainer: container)
+            self.resignActiveObserver = nil
         }
     }
 

--- a/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
+++ b/Sources/TwitchChat/Persistence/SwiftDataPersistenceService.swift
@@ -2,6 +2,7 @@
 // PersistenceActor に委譲する薄いラッパー実装
 // PersistenceService プロトコルを満たし、TwitchChatApp からの DI 対象となる
 
+import AppKit
 import Foundation
 import SwiftData
 
@@ -14,23 +15,58 @@ struct SwiftDataPersistenceService: PersistenceService {
 
     private let actor: PersistenceActor
 
-    /// 既存の ModelContainer からサービスを生成する
-    init(container: ModelContainer) {
-        self.actor = PersistenceActor(modelContainer: container)
+    /// 既存の ModelContainer から生成する（テスト向けに imageDiskStoreRoot を注入可能）
+    ///
+    /// - Parameters:
+    ///   - container: 構築済み ModelContainer
+    ///   - imageDiskStoreRoot: ImageDiskStore のルートディレクトリ（nil の場合は diskStore 無効）
+    ///   - attachAppKitTriggers: true の場合、起動 5 秒後 sweep と didResignActive 通知を登録する
+    /// - Throws: ImageDiskStore の初期化に失敗した場合
+    init(
+        container: ModelContainer,
+        imageDiskStoreRoot: URL? = nil,
+        attachAppKitTriggers: Bool = false
+    ) throws {
+        if let root = imageDiskStoreRoot {
+            let store = try ImageDiskStore(rootDirectory: root)
+            // diskStore を init 時に同期注入してレースコンディションを排除する
+            let actor = PersistenceActor(modelContainer: container, diskStore: store)
+            self.actor = actor
+
+            if attachAppKitTriggers {
+                // 起動 5 秒後に reconcile + sweep を実行する
+                Task {
+                    try? await Task.sleep(for: .seconds(5))
+                    await actor.runReconcileAndSweep()
+                }
+                // バックグラウンド移行時に sweep を実行する（テスト時は登録しない）
+                NotificationCenter.default.addObserver(
+                    forName: NSApplication.didResignActiveNotification,
+                    object: nil,
+                    queue: nil
+                ) { _ in
+                    Task { await actor.runReconcileAndSweep() }
+                }
+            }
+        } else {
+            self.actor = PersistenceActor(modelContainer: container)
+        }
     }
 
     /// ModelContainer を新規に構築してサービスを生成する
     ///
-    /// - Parameter inMemory: `true` の場合はディスクに書き込まない（テスト用）
+    /// - Parameters:
+    ///   - inMemory: `true` の場合はディスクに書き込まない（テスト用）
+    ///   - imageDiskStoreRoot: ImageDiskStore のルートディレクトリ（nil の場合は diskStore 無効）
     /// - Throws: `ModelContainer` の構築に失敗した場合
-    init(inMemory: Bool = false) throws {
+    init(inMemory: Bool = false, imageDiskStoreRoot: URL? = nil) throws {
         let config = ModelConfiguration(isStoredInMemoryOnly: inMemory)
         let container = try ModelContainer(
             for: Schema(versionedSchema: SchemaV1.self),
             migrationPlan: ChatSchemaMigrationPlan.self,
             configurations: config
         )
-        self.init(container: container)
+        try self.init(container: container, imageDiskStoreRoot: imageDiskStoreRoot)
     }
 
     // MARK: - エモート

--- a/Sources/TwitchChat/Services/BadgeImageCache.swift
+++ b/Sources/TwitchChat/Services/BadgeImageCache.swift
@@ -32,13 +32,25 @@ final class BadgeImageCache: @unchecked Sendable {
     /// 進行中のダウンロードタスク（キー: "badgeName/version"）
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
 
-    /// inFlightTasks へのアクセスを保護するロック
+    /// inFlightTasks / persistence へのアクセスを保護するロック
     private let lock = NSLock()
 
     /// バッジ画像取得失敗時のログ出力に使用するロガー
     private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "BadgeImageCache")
 
+    /// L2 ディスクキャッシュサービス（nil の場合は L2 スキップ）
+    private var persistence: (any PersistenceService)?
+
     private init() {}
+
+    /// L2 永続化サービスを注入する（アプリ起動時に TwitchChatApp から呼ぶ）
+    func attachPersistence(_ service: any PersistenceService) {
+        lock.withLock { self.persistence = service }
+    }
+
+    private var currentPersistence: (any PersistenceService)? {
+        lock.withLock { persistence }
+    }
 
     // MARK: - 画像取得
 
@@ -66,10 +78,24 @@ final class BadgeImageCache: @unchecked Sendable {
                 guard let self else { return nil as NSImage? }
                 defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: key) } }
 
-                // BadgeStore から URL を解決してダウンロード
+                let persistence = self.currentPersistence
+                let l2Key = ImageCacheKey(kind: .badge, identifier: "\(badge.name):\(badge.version)")
+
+                // L2 ルックアップ
+                if let ps = persistence,
+                   let data = await ps.loadImageData(key: l2Key),
+                   let image = NSImage(data: data) {
+                    self.store(image, for: key)
+                    return image
+                }
+
+                // L3 HTTP ダウンロード
                 guard let url = await store.imageURL(for: badge),
-                      let image = await self.download(from: url) else { return nil }
+                      let (image, data) = await self.download(from: url) else { return nil }
                 self.store(image, for: key)
+                if let ps = persistence {
+                    try? await ps.saveImageData(data, key: l2Key, mime: "image/png")
+                }
                 return image
             }
             inFlightTasks[key] = newTask
@@ -91,10 +117,10 @@ final class BadgeImageCache: @unchecked Sendable {
 
     // MARK: - プライベートメソッド
 
-    /// 指定 URL から画像をダウンロードする
-    private func download(from url: URL) async -> NSImage? {
+    /// 指定 URL から画像をダウンロードする（L2 保存用に生データも返す）
+    private func download(from url: URL) async -> (NSImage, Data)? {
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await ImageDownloadSession.shared.data(from: url)
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.warning("バッジ画像レスポンスが HTTPURLResponse でない: \(url)")
                 return nil
@@ -107,7 +133,7 @@ final class BadgeImageCache: @unchecked Sendable {
                 logger.warning("バッジ画像データを NSImage に変換できない: \(url)")
                 return nil
             }
-            return image
+            return (image, data)
         } catch {
             logger.warning("バッジ画像ダウンロード失敗: \(url) - \(error)")
             return nil
@@ -119,4 +145,11 @@ final class BadgeImageCache: @unchecked Sendable {
         image.size = NSSize(width: Self.badgeDisplaySize, height: Self.badgeDisplaySize)
         imageCache.setObject(image, forKey: key as NSString)
     }
+
+#if DEBUG
+    /// テスト用: 永続化サービスを差し替える（nil でリセット）
+    func attachPersistenceForTesting(_ service: (any PersistenceService)?) {
+        lock.withLock { self.persistence = service }
+    }
+#endif
 }

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -57,10 +57,22 @@ final class EmoteImageCache: @unchecked Sendable {
     /// 同一エモートへの並行リクエストを1回のダウンロードに集約し、重複ネットワーク通信を防ぐ。
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
 
-    /// animatedEmoteIds / inFlightTasks へのアクセスを保護するロック
+    /// animatedEmoteIds / inFlightTasks / persistence へのアクセスを保護するロック
     private let lock = NSLock()
 
+    /// L2 ディスクキャッシュサービス（nil の場合は L2 スキップ）
+    private var persistence: (any PersistenceService)?
+
     private init() {}
+
+    /// L2 永続化サービスを注入する（アプリ起動時に TwitchChatApp から呼ぶ）
+    func attachPersistence(_ service: any PersistenceService) {
+        lock.withLock { self.persistence = service }
+    }
+
+    private var currentPersistence: (any PersistenceService)? {
+        lock.withLock { persistence }
+    }
 
     // MARK: - 画像取得
 
@@ -90,14 +102,38 @@ final class EmoteImageCache: @unchecked Sendable {
                 guard let self else { return nil as NSImage? }
                 defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: emoteId) } }
 
-                // アニメーション版を先に試みる
+                let persistence = self.currentPersistence
+
+                // L2 ルックアップ: animated → static の順で試みる
+                if let ps = persistence {
+                    let animKey = ImageCacheKey(kind: .emote, identifier: "\(emoteId):2.0:animated")
+                    if let data = await ps.loadImageData(key: animKey), let image = NSImage(data: data) {
+                        self.store(image, gifData: data, for: emoteId, isAnimated: true)
+                        return image
+                    }
+                    let staticKey = ImageCacheKey(kind: .emote, identifier: "\(emoteId):2.0:static")
+                    if let data = await ps.loadImageData(key: staticKey), let image = NSImage(data: data) {
+                        self.store(image, gifData: nil, for: emoteId, isAnimated: false)
+                        return image
+                    }
+                }
+
+                // L3 HTTP ダウンロード: アニメーション版を先に試みる
                 if let (image, data) = await self.download(emoteId: emoteId, type: "animated") {
                     self.store(image, gifData: data, for: emoteId, isAnimated: true)
+                    if let ps = persistence {
+                        let animKey = ImageCacheKey(kind: .emote, identifier: "\(emoteId):2.0:animated")
+                        try? await ps.saveImageData(data, key: animKey, mime: "image/gif")
+                    }
                     return image
                 }
                 // スタティック版にフォールバック
-                if let (image, _) = await self.download(emoteId: emoteId, type: "default") {
+                if let (image, data) = await self.download(emoteId: emoteId, type: "default") {
                     self.store(image, gifData: nil, for: emoteId, isAnimated: false)
+                    if let ps = persistence {
+                        let staticKey = ImageCacheKey(kind: .emote, identifier: "\(emoteId):2.0:static")
+                        try? await ps.saveImageData(data, key: staticKey, mime: "image/png")
+                    }
                     return image
                 }
                 return nil
@@ -171,7 +207,7 @@ final class EmoteImageCache: @unchecked Sendable {
     /// - Returns: ダウンロード成功時は `(NSImage, Data)` タプル、HTTP 200 以外または解析失敗時は nil
     private func download(emoteId: String, type: String) async -> (NSImage, Data)? {
         let url = Self.emoteURL(emoteId: emoteId, type: type)
-        guard let (data, response) = try? await URLSession.shared.data(from: url),
+        guard let (data, response) = try? await ImageDownloadSession.shared.data(from: url),
               let httpResponse = response as? HTTPURLResponse,
               httpResponse.statusCode == 200,
               let image = NSImage(data: data) else { return nil }
@@ -204,21 +240,23 @@ final class EmoteImageCache: @unchecked Sendable {
 
 #if DEBUG
     /// テスト用: GIF 生データをキャッシュに直接登録する
-    ///
-    /// - Parameters:
-    ///   - gifData: 登録する GIF バイナリデータ
-    ///   - emoteId: Twitch エモートID
     func storeForTesting(gifData: Data, for emoteId: String) {
         gifDataCache.setObject(gifData as NSData, forKey: emoteId as NSString)
     }
 
-    /// テスト用: 全キャッシュをクリアする
-    ///
-    /// テスト間の状態汚染を防ぐため、テスト終了時に呼び出す。
+    /// テスト用: 画像を L1 キャッシュに直接登録する（L1 ヒット検証用）
+    func storeImageForTesting(_ image: NSImage, for emoteId: String) {
+        store(image, gifData: nil, for: emoteId, isAnimated: false)
+    }
+
+    /// テスト用: 全キャッシュと永続化サービス参照をクリアする
     func clearForTesting() {
         imageCache.removeAllObjects()
         gifDataCache.removeAllObjects()
-        lock.withLock { animatedEmoteIds.removeAll() }
+        lock.withLock {
+            animatedEmoteIds.removeAll()
+            persistence = nil
+        }
     }
 #endif
 }

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -260,6 +260,8 @@ final class EmoteImageCache: @unchecked Sendable {
         lock.withLock {
             animatedEmoteIds.removeAll()
             persistence = nil
+            inFlightTasks.values.forEach { $0.cancel() }
+            inFlightTasks = [:]
         }
     }
 #endif

--- a/Sources/TwitchChat/Services/EmoteImageCache.swift
+++ b/Sources/TwitchChat/Services/EmoteImageCache.swift
@@ -233,6 +233,10 @@ final class EmoteImageCache: @unchecked Sendable {
             if let data = gifData {
                 gifDataCache.setObject(data as NSData, forKey: emoteId as NSString)
             }
+        } else {
+            // スタティック版で上書きする場合、古いアニメーション状態を削除して矛盾を防ぐ
+            _ = lock.withLock { animatedEmoteIds.remove(emoteId) }
+            gifDataCache.removeObject(forKey: emoteId as NSString)
         }
     }
 

--- a/Sources/TwitchChat/Services/ImageDownloadSession.swift
+++ b/Sources/TwitchChat/Services/ImageDownloadSession.swift
@@ -1,0 +1,21 @@
+// ImageDownloadSession.swift
+// 画像ダウンロード専用 URLSession（L2 ディスクキャッシュと二重管理にならないよう URLCache を無効化）
+//
+// URLSession.shared はデフォルトで URLCache（L2 相当）を使用するため、
+// アプリ独自の ImageDiskStore（L2）と競合する。
+// この shared インスタンスは URLCache を 0 に設定し、L2 管理を ImageDiskStore に一元化する。
+
+import Foundation
+
+/// 画像ダウンロード専用の URLSession
+///
+/// `URLCache` を無効化することで OS の URL キャッシュと ImageDiskStore の二重管理を回避する。
+/// 3 つの ImageCache（エモート・バッジ・プロフィール）が共用する。
+enum ImageDownloadSession {
+    static let shared: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.urlCache = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        return URLSession(configuration: config)
+    }()
+}

--- a/Sources/TwitchChat/Services/ProfileImageCache.swift
+++ b/Sources/TwitchChat/Services/ProfileImageCache.swift
@@ -37,13 +37,25 @@ final class ProfileImageCache: @unchecked Sendable {
     /// 進行中のダウンロードタスク（キー: userId）
     private var inFlightTasks: [String: Task<NSImage?, Never>] = [:]
 
-    /// inFlightTasks へのアクセスを保護するロック
+    /// inFlightTasks / persistence へのアクセスを保護するロック
     private let lock = NSLock()
 
     /// ダウンロード失敗時のログ出力に使用するロガー
     private let logger = Logger(subsystem: "dev.mtane.TwitchChat", category: "ProfileImageCache")
 
+    /// L2 ディスクキャッシュサービス（nil の場合は L2 スキップ）
+    private var persistence: (any PersistenceService)?
+
     private init() {}
+
+    /// L2 永続化サービスを注入する（アプリ起動時に TwitchChatApp から呼ぶ）
+    func attachPersistence(_ service: any PersistenceService) {
+        lock.withLock { self.persistence = service }
+    }
+
+    private var currentPersistence: (any PersistenceService)? {
+        lock.withLock { persistence }
+    }
 
     // MARK: - 画像取得
 
@@ -70,9 +82,24 @@ final class ProfileImageCache: @unchecked Sendable {
                 guard let self else { return nil as NSImage? }
                 defer { _ = self.lock.withLock { self.inFlightTasks.removeValue(forKey: userId) } }
 
-                guard let image = await self.download(from: imageUrl) else { return nil }
-                self.store(image, for: userId)
-                return image
+                let persistence = self.currentPersistence
+                let l2Key = ImageCacheKey(kind: .profile, identifier: userId)
+
+                // L2 ルックアップ
+                if let ps = persistence,
+                   let data = await ps.loadImageData(key: l2Key),
+                   let image = NSImage(data: data) {
+                    let resized = self.store(image, for: userId)
+                    return resized
+                }
+
+                // L3 HTTP ダウンロード
+                guard let (image, data) = await self.download(from: imageUrl) else { return nil }
+                let resized = self.store(image, for: userId)
+                if let ps = persistence {
+                    try? await ps.saveImageData(data, key: l2Key, mime: "image/png")
+                }
+                return resized
             }
             inFlightTasks[userId] = newTask
             return newTask
@@ -83,10 +110,10 @@ final class ProfileImageCache: @unchecked Sendable {
 
     // MARK: - プライベートメソッド
 
-    /// 指定 URL から画像をダウンロードする
-    private func download(from url: URL) async -> NSImage? {
+    /// 指定 URL から画像をダウンロードする（L2 保存用に生データも返す）
+    private func download(from url: URL) async -> (NSImage, Data)? {
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
+            let (data, response) = try await ImageDownloadSession.shared.data(from: url)
             guard let httpResponse = response as? HTTPURLResponse else {
                 logger.warning("プロフィール画像レスポンスが HTTPURLResponse でない: \(url)")
                 return nil
@@ -99,7 +126,7 @@ final class ProfileImageCache: @unchecked Sendable {
                 logger.warning("プロフィール画像データを NSImage に変換できない: \(url)")
                 return nil
             }
-            return image
+            return (image, data)
         } catch {
             logger.warning("プロフィール画像ダウンロード失敗: \(url) - \(error)")
             return nil
@@ -110,7 +137,9 @@ final class ProfileImageCache: @unchecked Sendable {
     ///
     /// NSGraphicsContext はメインスレッド以外での使用が未定義動作のため、
     /// CoreGraphics ベースの CGContext でリサイズする（バックグラウンドスレッドセーフ）。
-    private func store(_ image: NSImage, for userId: String) {
+    /// リサイズ後の NSImage を返すことで L2 ヒット時に呼び出し元が直接返却できる。
+    @discardableResult
+    private func store(_ image: NSImage, for userId: String) -> NSImage {
         let targetSize = NSSize(width: Self.displaySize, height: Self.displaySize)
         let resized: NSImage
         // CGImage を取得して CoreGraphics コンテキストでリサイズ描画する
@@ -140,5 +169,13 @@ final class ProfileImageCache: @unchecked Sendable {
             resized = image
         }
         imageCache.setObject(resized, forKey: userId as NSString)
+        return resized
     }
+
+#if DEBUG
+    /// テスト用: 永続化サービスを差し替える（nil でリセット）
+    func attachPersistenceForTesting(_ service: (any PersistenceService)?) {
+        lock.withLock { self.persistence = service }
+    }
+#endif
 }

--- a/Tests/TwitchChatTests/BadgeImageCacheTests.swift
+++ b/Tests/TwitchChatTests/BadgeImageCacheTests.swift
@@ -1,11 +1,13 @@
 // BadgeImageCacheTests.swift
-// BadgeImageCache のキャッシュキーと表示サイズのテスト
+// BadgeImageCache のキャッシュキー・表示サイズ・L2 キャッシュ統合のテスト
 
+import AppKit
 import Foundation
 import Testing
 @testable import TwitchChat
 
-@Suite("BadgeImageCacheTests")
+/// シングルトン BadgeImageCache.shared の状態を共有するため、テストを順次実行する。
+@Suite("BadgeImageCacheTests", .serialized)
 struct BadgeImageCacheTests {
 
     @Test("バッジの表示サイズが18ptである")
@@ -23,5 +25,53 @@ struct BadgeImageCacheTests {
     func testCacheKey(badge: Badge, expectedKey: String) {
         let key = BadgeImageCache.cacheKey(for: badge)
         #expect(key == expectedKey)
+    }
+
+    // MARK: - L2 キャッシュ統合
+
+    @Test("L2 に有効な画像データがある場合は BadgeStore・HTTP なしで画像を返す")
+    func L2ヒット時はHTTPなしでバッジ画像を返す() async {
+        // 前提: サブスクライバーバッジの L2 データをモックに投入する
+        let badge = Badge(name: "subscriber", version: "12")
+        let mock = MockPersistenceService()
+        guard let pngData = makeMiniPNGData() else {
+            Issue.record("テスト用 PNG データ生成失敗")
+            return
+        }
+        let l2Key = ImageCacheKey(kind: .badge, identifier: "subscriber:12")
+        await mock.seedImageData(pngData, key: l2Key)
+
+        BadgeImageCache.shared.attachPersistence(mock)
+        defer { BadgeImageCache.shared.attachPersistenceForTesting(nil) }
+
+        // 前提: BadgeStore のダミー（L2 ヒット時は imageURL は呼ばれない）
+        let dummyStore = BadgeStore(apiClient: MockHelixAPIClient())
+
+        // 実行: image(for:store:) を呼ぶ（L2 ヒットで返るはず）
+        let result = await BadgeImageCache.shared.image(for: badge, store: dummyStore)
+
+        // 検証: 画像が返った（L2 から復元）
+        #expect(result != nil)
+        // 検証: loadImageData が1回呼ばれた
+        let loadCount = await mock.loadImageDataCallCount
+        #expect(loadCount == 1)
+        // 検証: L2 保存は呼ばれなかった（HTTP は不発火）
+        let saveCount = await mock.saveImageDataCallCount
+        #expect(saveCount == 0)
+    }
+
+    // MARK: - テスト用ヘルパー
+
+    /// CoreGraphics で 2×2 ピクセルの PNG データを生成する（L2 シード用）
+    private func makeMiniPNGData() -> Data? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 2, pixelsHigh: 2,
+            bitsPerSample: 8, samplesPerPixel: 3,
+            hasAlpha: false, isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        return bitmap.representation(using: .png, properties: [:])
     }
 }

--- a/Tests/TwitchChatTests/EmoteImageCacheTests.swift
+++ b/Tests/TwitchChatTests/EmoteImageCacheTests.swift
@@ -1,13 +1,16 @@
 // EmoteImageCacheTests.swift
 // EmoteImageCache の単体テスト
-// URL 生成ロジックとエモート表示サイズを検証する（画像ダウンロードは外部依存のためテスト対象外）
+// URL 生成ロジック・表示サイズ・L2 キャッシュ統合を検証する
 
+import AppKit
 import Foundation
 import Testing
 @testable import TwitchChat
 
 /// EmoteImageCache のテストスイート
-@Suite("EmoteImageCache テスト")
+///
+/// シングルトン EmoteImageCache.shared の状態を共有するため、テストを順次実行する。
+@Suite("EmoteImageCache テスト", .serialized)
 struct EmoteImageCacheTests {
 
     // MARK: - スタティック URL 生成
@@ -95,5 +98,79 @@ struct EmoteImageCacheTests {
 
         // 検証: 登録したデータが取得できる
         #expect(result == testGIFData)
+    }
+
+    // MARK: - L2 キャッシュ統合
+
+    @Test("L1 ヒット時は loadImageData を呼ばない")
+    func L1ヒット時はloadImageDataを呼ばない() async {
+        // 前提: テスト用エモートID で L1 に画像を直接登録する
+        let emoteId = "エモートID_L1テスト_\(UUID())"
+        defer { EmoteImageCache.shared.clearForTesting() }
+
+        let mock = MockPersistenceService()
+        EmoteImageCache.shared.attachPersistence(mock)
+
+        // テスト用の画像を L1 に直接登録する（L1 ヒットを確実にするため）
+        let testImage = makeTestNSImage()
+        EmoteImageCache.shared.storeImageForTesting(testImage, for: emoteId)
+
+        // 実行: image(for:) を呼ぶ（L1 ヒットのはず）
+        let result = await EmoteImageCache.shared.image(for: emoteId)
+
+        // 検証: 画像が返った
+        #expect(result != nil)
+        // 検証: L2 は参照されなかった
+        let loadCount = await mock.loadImageDataCallCount
+        #expect(loadCount == 0)
+    }
+
+    @Test("L2 に有効な画像データがある場合は HTTP なしで画像を返す")
+    func L2ヒット時はHTTPなしで画像を返す() async {
+        // 前提: テスト用エモートID の static キーを L2（モック）に事前投入する
+        let emoteId = "エモートID_L2テスト_\(UUID())"
+        defer { EmoteImageCache.shared.clearForTesting() }
+
+        let mock = MockPersistenceService()
+        guard let pngData = makeMiniPNGData() else {
+            Issue.record("テスト用 PNG データ生成失敗")
+            return
+        }
+        // static キーを L2 に投入（animated は投入しない）
+        let staticKey = ImageCacheKey(kind: .emote, identifier: "\(emoteId):2.0:static")
+        await mock.seedImageData(pngData, key: staticKey)
+        EmoteImageCache.shared.attachPersistence(mock)
+
+        // 実行: image(for:) を呼ぶ（L2 ヒットで返るはず）
+        let result = await EmoteImageCache.shared.image(for: emoteId)
+
+        // 検証: 画像が返った（L2 から復元）
+        #expect(result != nil)
+        // 検証: loadImageData が呼ばれた（animated: 1回 miss + static: 1回 hit）
+        let loadCount = await mock.loadImageDataCallCount
+        #expect(loadCount == 2)
+        // 検証: L2 保存は呼ばれなかった（HTTP は不発火）
+        let saveCount = await mock.saveImageDataCallCount
+        #expect(saveCount == 0)
+    }
+
+    // MARK: - テスト用ヘルパー
+
+    /// テスト用の最小 NSImage を生成する（L1 直接登録用）
+    private func makeTestNSImage() -> NSImage {
+        NSImage(size: NSSize(width: 20, height: 20))
+    }
+
+    /// CoreGraphics で 2×2 ピクセルの PNG データを生成する（L2 シード用）
+    private func makeMiniPNGData() -> Data? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 2, pixelsHigh: 2,
+            bitsPerSample: 8, samplesPerPixel: 3,
+            hasAlpha: false, isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        return bitmap.representation(using: .png, properties: [:])
     }
 }

--- a/Tests/TwitchChatTests/ImageDiskStoreTests.swift
+++ b/Tests/TwitchChatTests/ImageDiskStoreTests.swift
@@ -1,0 +1,276 @@
+// ImageDiskStoreTests.swift
+// ImageDiskStore の単体テスト
+// 一時ディレクトリを用いた実ファイル I/O で SHA256 パス算出・書き込み・削除・LRU sweep・isExcludedFromBackup を検証する
+
+import CryptoKit
+import Foundation
+import Testing
+@testable import TwitchChat
+
+/// ImageDiskStore のテストスイート
+@Suite("ImageDiskStore テスト")
+struct ImageDiskStoreTests {
+
+    // MARK: - ヘルパー
+
+    /// 一時ルートディレクトリを作成する（テスト終了後は呼び出し元が defer で削除する）
+    private func makeTempRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImageDiskStoreTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    // MARK: - SHA256 パス算出
+
+    @Test("エモートキーの SHA256 ファイルパスが正しく算出される")
+    func エモートキーのSHA256パスが正しく算出される() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .emote, identifier: "12345:2.0:animated")
+
+        // 前提: "emote:12345:2.0:animated" の SHA256 hex を CryptoKit で計算
+        let input = "emote:12345:2.0:animated"
+        let hashBytes = SHA256.hash(data: Data(input.utf8))
+        let hex = hashBytes.compactMap { String(format: "%02x", $0) }.joined()
+        // ImageDiskStore.init と同じ realpath() 解決を手動で再現する
+        // テスト用の一時ディレクトリは存在前に realpath 解決できないため、先に存在確認してから比較
+        let expectedURL = store.fileURL(for: key)
+
+        // 検証: fileURL が SHA256 のパス階層に一致する（nonisolated のため await 不要）
+        let fileURL = store.fileURL(for: key)
+        #expect(fileURL == expectedURL)
+    }
+
+    @Test("バッジキーのファイルパスがバケット 'badges' 配下に生成される")
+    func バッジキーのパスがbadgesバケット配下になる() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .badge, identifier: "broadcaster:1")
+
+        // 検証: パスに "badges" が含まれる（nonisolated のため await 不要）
+        let fileURL = store.fileURL(for: key)
+        #expect(fileURL.path.contains("/ImageCache/badges/"))
+    }
+
+    @Test("プロフィールキーのファイルパスがバケット 'profiles' 配下に生成される")
+    func プロフィールキーのパスがprofilesバケット配下になる() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .profile, identifier: "ユーザー001")
+
+        // 検証: パスに "profiles" が含まれる（nonisolated のため await 不要）
+        let fileURL = store.fileURL(for: key)
+        #expect(fileURL.path.contains("/ImageCache/profiles/"))
+    }
+
+    // MARK: - ラウンドトリップ（書き込み・読み出し）
+
+    @Test("エモート画像データを書き込んで読み出せる")
+    func エモート画像データの書き込みと読み出しができる() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .emote, identifier: "25:2.0:static")
+        let testData = Data("エモートテストデータ_Kappa".utf8)
+
+        // 操作: 書き込み
+        let writtenBytes = try await store.writeData(testData, key: key)
+
+        // 検証: 返り値のバイト数が一致し、読み出しデータも一致する
+        #expect(writtenBytes == testData.count)
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == testData)
+    }
+
+    @Test("バッジ画像データを書き込んで読み出せる")
+    func バッジ画像データの書き込みと読み出しができる() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .badge, identifier: "subscriber:6")
+        let testData = Data("バッジテストデータ_6ヶ月サブスク".utf8)
+
+        // 操作: 書き込み
+        _ = try await store.writeData(testData, key: key)
+
+        // 検証: 読み出しデータが一致する
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == testData)
+    }
+
+    @Test("プロフィール画像データを書き込んで読み出せる")
+    func プロフィール画像データの書き込みと読み出しができる() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .profile, identifier: "配信者001")
+        let testData = Data("プロフィール画像テストデータ".utf8)
+
+        // 操作: 書き込み
+        _ = try await store.writeData(testData, key: key)
+
+        // 検証: 読み出しデータが一致する
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == testData)
+    }
+
+    @Test("同一キーへの上書きで最新データが読み出される")
+    func 同一キーへの上書きで最新データが読み出される() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .emote, identifier: "1902:2.0:static")
+        let firstData = Data("最初のデータ".utf8)
+        let secondData = Data("上書き後のデータ_LUL".utf8)
+
+        // 操作: 2 回書き込む
+        _ = try await store.writeData(firstData, key: key)
+        let writtenBytes = try await store.writeData(secondData, key: key)
+
+        // 検証: 最新データが読み出せる
+        #expect(writtenBytes == secondData.count)
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == secondData)
+    }
+
+    @Test("存在しないキーの loadData が nil を返す")
+    func 存在しないキーのloadDataがnilを返す() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .emote, identifier: "存在しないエモートID:2.0:static")
+
+        // 検証: ファイルが無いので nil が返る
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == nil)
+    }
+
+    // MARK: - ファイル削除
+
+    @Test("deleteFile 後に loadData が nil を返す")
+    func deleteFile後にloadDataがnilを返す() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .badge, identifier: "broadcaster:1")
+        let testData = Data("バッジ削除テスト".utf8)
+
+        // 前提: 書き込んで読み出せる状態にする
+        _ = try await store.writeData(testData, key: key)
+        #expect(await store.loadData(key: key) != nil)
+
+        // 操作: 削除
+        await store.deleteFile(key: key)
+
+        // 検証: 削除後は nil
+        let loaded = await store.loadData(key: key)
+        #expect(loaded == nil)
+    }
+
+    // MARK: - isExcludedFromBackup
+
+    @Test("ImageCache ルートディレクトリに isExcludedFromBackup が設定される")
+    func ImageCacheルートにisExcludedFromBackupが設定される() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // 操作: ImageDiskStore を生成（init で isExcludedFromBackup を設定する）
+        let store = try ImageDiskStore(rootDirectory: root)
+        _ = store
+
+        // 検証: ImageCache ルートが backup 除外になっている
+        let cacheRoot = root.appendingPathComponent("ImageCache")
+        let values = try cacheRoot.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        #expect(values.isExcludedFromBackup == true)
+    }
+
+    @Test("各バケットディレクトリに isExcludedFromBackup が設定される")
+    func 各バケットディレクトリにisExcludedFromBackupが設定される() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        _ = store
+
+        // 検証: emotes / badges / profiles の各バケットが backup 除外になっている
+        for bucket in ["emotes", "badges", "profiles"] {
+            let bucketDir = root.appendingPathComponent("ImageCache/\(bucket)")
+            let values = try bucketDir.resourceValues(forKeys: [.isExcludedFromBackupKey])
+            #expect(values.isExcludedFromBackup == true, "バケット '\(bucket)' が backup 除外でない")
+        }
+    }
+
+    // MARK: - enumerateAllFiles
+
+    @Test("enumerateAllFiles が書き込んだ全ファイルを列挙する")
+    func enumerateAllFilesが全ファイルを列挙する() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let keys: [ImageCacheKey] = [
+            ImageCacheKey(kind: .emote, identifier: "25:2.0:animated"),
+            ImageCacheKey(kind: .badge, identifier: "broadcaster:1"),
+            ImageCacheKey(kind: .profile, identifier: "視聴者ユーザー001")
+        ]
+
+        // 操作: 3 種の画像を書き込む
+        for key in keys {
+            _ = try await store.writeData(Data("テストデータ".utf8), key: key)
+        }
+
+        // 検証: 3 ファイルが列挙される（URL 表現差異を避けてパス文字列で比較）
+        let allFiles = await store.enumerateAllFiles()
+        #expect(allFiles.count == 3)
+        let allPaths = allFiles.map(\.path)
+        for key in keys {
+            let expected = store.fileURL(for: key).path
+            #expect(allPaths.contains(expected), "ファイルが列挙されていない: \(expected)")
+        }
+    }
+
+    @Test("deleteFile 後は enumerateAllFiles に含まれない")
+    func deleteFile後はenumerateAllFilesに含まれない() async throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = try ImageDiskStore(rootDirectory: root)
+        let key = ImageCacheKey(kind: .emote, identifier: "1902:2.0:static")
+        _ = try await store.writeData(Data("削除テスト".utf8), key: key)
+
+        // 操作: 削除
+        await store.deleteFile(key: key)
+
+        // 検証: 削除後はファイルが列挙されない（パス文字列で比較）
+        let allFiles = await store.enumerateAllFiles()
+        let expectedPath = store.fileURL(for: key).path
+        #expect(!allFiles.map(\.path).contains(expectedPath))
+    }
+
+    // MARK: - capacity
+
+    @Test("capacity(for:) がバケット別の上限バイト数を返す")
+    func capacityがバケット別の上限バイト数を返す() throws {
+        let root = makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let capacity = ImageDiskStore.Capacity(emotesMB: 200, badgesMB: 50, profilesMB: 50)
+        let store = try ImageDiskStore(rootDirectory: root, capacity: capacity)
+
+        // 検証: MB → バイト換算が正しい（capacity は nonisolated のため await 不要）
+        #expect(store.capacity(for: .emotes) == 200 * 1024 * 1024)
+        #expect(store.capacity(for: .badges) == 50 * 1024 * 1024)
+        #expect(store.capacity(for: .profiles) == 50 * 1024 * 1024)
+    }
+}

--- a/Tests/TwitchChatTests/ImageDiskStoreTests.swift
+++ b/Tests/TwitchChatTests/ImageDiskStoreTests.swift
@@ -29,17 +29,22 @@ struct ImageDiskStoreTests {
         let store = try ImageDiskStore(rootDirectory: root)
         let key = ImageCacheKey(kind: .emote, identifier: "12345:2.0:animated")
 
-        // 前提: "emote:12345:2.0:animated" の SHA256 hex を CryptoKit で計算
+        // SHA256 hex を CryptoKit で手計算する（"emote:<identifier>" が入力）
         let input = "emote:12345:2.0:animated"
         let hashBytes = SHA256.hash(data: Data(input.utf8))
         let hex = hashBytes.compactMap { String(format: "%02x", $0) }.joined()
-        // ImageDiskStore.init と同じ realpath() 解決を手動で再現する
-        // テスト用の一時ディレクトリは存在前に realpath 解決できないため、先に存在確認してから比較
-        let expectedURL = store.fileURL(for: key)
 
-        // 検証: fileURL が SHA256 のパス階層に一致する（nonisolated のため await 不要）
+        // 期待するパス要素を組み立てる: <先頭2桁>/<次2桁>/<残り>.bin
+        let expectedDir1 = String(hex.prefix(2))
+        let expectedDir2 = String(hex.dropFirst(2).prefix(2))
+        let expectedFile = "\(String(hex.dropFirst(4))).bin"
+
+        // 検証: fileURL が SHA256 ハッシュから算出したパス階層と一致する（nonisolated のため await 不要）
         let fileURL = store.fileURL(for: key)
-        #expect(fileURL == expectedURL)
+        #expect(fileURL.lastPathComponent == expectedFile, "ファイル名が SHA256 の残りバイトと一致しない")
+        #expect(fileURL.deletingLastPathComponent().lastPathComponent == expectedDir2, "第2ディレクトリが SHA256 の3-4バイト目と一致しない")
+        #expect(fileURL.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent == expectedDir1, "第1ディレクトリが SHA256 の1-2バイト目と一致しない")
+        #expect(fileURL.path.contains("/ImageCache/emotes/"), "バケット 'emotes' 配下でない")
     }
 
     @Test("バッジキーのファイルパスがバケット 'badges' 配下に生成される")

--- a/Tests/TwitchChatTests/Mocks/MockPersistenceService.swift
+++ b/Tests/TwitchChatTests/Mocks/MockPersistenceService.swift
@@ -1,0 +1,63 @@
+// MockPersistenceService.swift
+// 3 段ルックアップ（L1→L2→L3）の検証用モック PersistenceService
+// loadImageData / saveImageData の呼び出し回数とデータを記録する
+
+import Foundation
+@testable import TwitchChat
+
+/// 画像 I/O の呼び出し追跡に特化したモック永続化サービス
+///
+/// - `loadImageDataCallCount` で L2 参照回数を検証できる
+/// - `saveImageDataCallCount` で L2 書き込み回数を検証できる
+/// - `seedImageData(_:key:)` でテスト用 L2 データを事前投入できる
+actor MockPersistenceService: PersistenceService {
+
+    // MARK: - 追跡カウンタ
+
+    var loadImageDataCallCount = 0
+    var saveImageDataCallCount = 0
+
+    // MARK: - ストレージ
+
+    private var storage: [ImageCacheKey: Data] = [:]
+
+    // MARK: - テスト用ヘルパー
+
+    /// 指定キーの画像データを L2 として事前投入する
+    func seedImageData(_ data: Data, key: ImageCacheKey) {
+        storage[key] = data
+    }
+
+    // MARK: - 画像 I/O
+
+    func loadImageData(key: ImageCacheKey) async -> Data? {
+        loadImageDataCallCount += 1
+        return storage[key]
+    }
+
+    func saveImageData(_ data: Data, key: ImageCacheKey, mime: String) async throws {
+        saveImageDataCallCount += 1
+        storage[key] = data
+    }
+
+    // MARK: - スタブ実装（テスト対象外）
+
+    func loadUserEmotes(userId: String) async -> [HelixEmote] { [] }
+    func saveUserEmotes(_ emotes: [HelixEmote], userId: String) async throws {}
+    func loadGlobalEmotes() async -> [HelixEmote] { [] }
+    func saveGlobalEmotes(_ emotes: [HelixEmote]) async throws {}
+    func loadChannelEmotes(broadcasterId: String) async -> [HelixEmote] { [] }
+    func saveChannelEmotes(_ emotes: [HelixEmote], broadcasterId: String) async throws {}
+    func loadGlobalEmotesWithTimestamp() async -> (emotes: [HelixEmote], fetchedAt: Date?) { ([], nil) }
+    func loadUserEmotesWithTimestamp(userId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) { ([], nil) }
+    func loadChannelEmotesWithTimestamp(broadcasterId: String) async -> (emotes: [HelixEmote], fetchedAt: Date?) { ([], nil) }
+    func loadBadges(scope: BadgeScope) async -> [BadgeVersionSnapshot] { [] }
+    func saveBadges(_ badges: [BadgeVersionSnapshot], scope: BadgeScope) async throws {}
+    func loadBadgesWithTimestamp(scope: BadgeScope) async -> (snapshots: [BadgeVersionSnapshot], fetchedAt: Date?) { ([], nil) }
+    func loadUserProfiles(userIds: [String]) async -> [UserProfileSnapshot] { [] }
+    func saveUserProfiles(_ profiles: [UserProfileSnapshot]) async throws {}
+    func loadRecentMessages(roomId: String, limit: Int, before: Date?) async -> [ChatMessage] { [] }
+    func appendMessages(_ messages: [ChatMessage]) async throws {}
+    func searchMessages(query: String, roomId: String?, limit: Int) async -> [ChatMessage] { [] }
+    func clearUserScoped(userId: String) async {}
+}

--- a/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
+++ b/Tests/TwitchChatTests/ProfileImageStorePersistenceTests.swift
@@ -1,6 +1,8 @@
 // ProfileImageStorePersistenceTests.swift
 // ProfileImageStore の永続化配線テスト（キャッシュ先読み / write-back / clear 後の復元）
+// および ProfileImageCache の L2 キャッシュ統合テスト
 
+import AppKit
 import Foundation
 import Testing
 @testable import TwitchChat
@@ -155,5 +157,60 @@ struct ProfileImageStorePersistenceTests {
         // 検証: clear 後でも displayName が解決できる
         let displayName = store.displayName(for: "ユーザーID001")
         #expect(displayName == "山田太郎")
+    }
+}
+
+// MARK: - ProfileImageCache L2 統合テスト
+
+/// ProfileImageCache の L2 キャッシュ（ImageDiskStore / PersistenceService）統合テストスイート
+///
+/// シングルトン ProfileImageCache.shared の状態を共有するため、テストを順次実行する。
+@Suite("ProfileImageCache L2 統合テスト", .serialized)
+struct ProfileImageCacheL2Tests {
+
+    @Test("L2 に有効な画像データがある場合は HTTP なしでプロフィール画像を返す")
+    func L2ヒット時はHTTPなしでプロフィール画像を返す() async {
+        // 前提: ユーザーID "ユーザーID_L2テスト_山田" の L2 データをモックに投入する
+        let userId = "ユーザーID_L2テスト_山田_\(UUID())"
+        let mock = MockPersistenceService()
+        guard let pngData = makeMiniPNGData() else {
+            Issue.record("テスト用 PNG データ生成失敗")
+            return
+        }
+        let l2Key = ImageCacheKey(kind: .profile, identifier: userId)
+        await mock.seedImageData(pngData, key: l2Key)
+
+        ProfileImageCache.shared.attachPersistence(mock)
+        defer { ProfileImageCache.shared.attachPersistenceForTesting(nil) }
+
+        // 前提: 存在しない URL（L2 ヒット時は HTTP は呼ばれないので何でも良い）
+        let dummyURL = URL(string: "https://example.com/dummy.png")!
+
+        // 実行: image(for:imageUrl:) を呼ぶ（L2 ヒットで返るはず）
+        let result = await ProfileImageCache.shared.image(for: userId, imageUrl: dummyURL)
+
+        // 検証: 画像が返った（L2 から復元）
+        #expect(result != nil)
+        // 検証: loadImageData が1回呼ばれた
+        let loadCount = await mock.loadImageDataCallCount
+        #expect(loadCount == 1)
+        // 検証: L2 保存は呼ばれなかった（HTTP は不発火）
+        let saveCount = await mock.saveImageDataCallCount
+        #expect(saveCount == 0)
+    }
+
+    // MARK: - ヘルパー
+
+    /// CoreGraphics で 2×2 ピクセルの PNG データを生成する（L2 シード用）
+    private func makeMiniPNGData() -> Data? {
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 2, pixelsHigh: 2,
+            bitsPerSample: 8, samplesPerPixel: 3,
+            hasAlpha: false, isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        return bitmap.representation(using: .png, properties: [:])
     }
 }

--- a/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
+++ b/Tests/TwitchChatTests/SwiftDataPersistenceServiceTests.swift
@@ -10,9 +10,19 @@ import Testing
 @Suite("SwiftDataPersistenceService テスト")
 struct SwiftDataPersistenceServiceTests {
 
-    /// テスト用の in-memory SwiftDataPersistenceService を生成する
+    /// テスト用の in-memory SwiftDataPersistenceService を生成する（diskStore 無し）
     private func makeService() throws -> SwiftDataPersistenceService {
         try SwiftDataPersistenceService(inMemory: true)
+    }
+
+    /// 一時ディレクトリに ImageDiskStore を持つ SwiftDataPersistenceService を生成する
+    ///
+    /// 呼び出し元で `defer { try? FileManager.default.removeItem(at: tempRoot) }` を記述すること。
+    private func makeServiceWithDisk() throws -> (service: SwiftDataPersistenceService, tempRoot: URL) {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SwiftDataPersistenceTests-\(UUID().uuidString)", isDirectory: true)
+        let service = try SwiftDataPersistenceService(inMemory: true, imageDiskStoreRoot: tempRoot)
+        return (service: service, tempRoot: tempRoot)
     }
 
     // MARK: - エモート
@@ -449,10 +459,12 @@ struct SwiftDataPersistenceServiceTests {
 
     @Test("画像バイナリを保存して取得できる")
     func 画像バイナリを保存して取得できる() async throws {
-        // 前提: テスト用の画像データ
-        let service = try makeService()
-        let imageData = Data("テスト画像バイナリ".utf8)
-        let key = ImageCacheKey(kind: .emote, identifier: "emote_001:2x:static")
+        // 前提: 一時ディレクトリに ImageDiskStore を持つサービス
+        let (service, tempRoot) = try makeServiceWithDisk()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let imageData = Data("テスト画像バイナリ_エモートKappa".utf8)
+        let key = ImageCacheKey(kind: .emote, identifier: "emote_001:2.0:static")
 
         // 操作: 保存して取得
         try await service.saveImageData(imageData, key: key, mime: "image/png")
@@ -464,14 +476,16 @@ struct SwiftDataPersistenceServiceTests {
 
     @Test("画像バイナリを再保存すると最新データで上書きされる")
     func 画像バイナリを再保存すると最新データで上書きされる() async throws {
-        // 前提: 初期データを保存
-        let service = try makeService()
-        let key = ImageCacheKey(kind: .badge, identifier: "broadcaster:1:2x")
-        let originalData = Data("元の画像データ".utf8)
+        // 前提: 一時ディレクトリに ImageDiskStore を持つサービス
+        let (service, tempRoot) = try makeServiceWithDisk()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let key = ImageCacheKey(kind: .badge, identifier: "broadcaster:1")
+        let originalData = Data("元の画像データ_バッジ初版".utf8)
         try await service.saveImageData(originalData, key: key, mime: "image/png")
 
         // 操作: 同じキーで別データを保存
-        let updatedData = Data("更新後の画像データ".utf8)
+        let updatedData = Data("更新後の画像データ_バッジ改版".utf8)
         try await service.saveImageData(updatedData, key: key, mime: "image/webp")
 
         // 検証: 最新データが取得できる
@@ -481,11 +495,13 @@ struct SwiftDataPersistenceServiceTests {
 
     @Test("画像種別が異なれば同じidentifierでも分離される")
     func 画像種別が異なれば同じidentifierでも分離される() async throws {
-        // 前提: 同じ identifier で異なる kind の画像を保存
-        let service = try makeService()
-        let emoteData = Data("エモート画像".utf8)
-        let badgeData = Data("バッジ画像".utf8)
-        let sharedIdentifier = "12345:2x:static"
+        // 前提: 一時ディレクトリに ImageDiskStore を持つサービス
+        let (service, tempRoot) = try makeServiceWithDisk()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let emoteData = Data("エモート画像データ".utf8)
+        let badgeData = Data("バッジ画像データ".utf8)
+        let sharedIdentifier = "12345:2.0:static"
         let emoteKey = ImageCacheKey(kind: .emote, identifier: sharedIdentifier)
         let badgeKey = ImageCacheKey(kind: .badge, identifier: sharedIdentifier)
         try await service.saveImageData(emoteData, key: emoteKey, mime: "image/png")
@@ -496,6 +512,34 @@ struct SwiftDataPersistenceServiceTests {
         let loadedBadge = await service.loadImageData(key: badgeKey)
         #expect(loadedEmote == emoteData)
         #expect(loadedBadge == badgeData)
+    }
+
+    @Test("ファイルなしレコードは loadImageData で nil が返りレコードが削除される")
+    func ファイルなしレコードはloadImageDataでnilが返りレコードが削除される() async throws {
+        // 前提: 一時ディレクトリに ImageDiskStore を持つサービス
+        let (service, tempRoot) = try makeServiceWithDisk()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let key = ImageCacheKey(kind: .emote, identifier: "削除テストエモート:2.0:static")
+        let testData = Data("テスト画像バイナリ".utf8)
+
+        // 操作: 保存後に物理ファイルを手動削除して整合性違反を作る
+        try await service.saveImageData(testData, key: key, mime: "image/png")
+
+        // ImageDiskStore のファイルパスを取得して削除（内部ヘルパー経由で確認不可のため列挙で探す）
+        let imageCacheRoot = tempRoot.appendingPathComponent("ImageCache")
+        if FileManager.default.fileExists(atPath: imageCacheRoot.path) {
+            let enumerator = FileManager.default.enumerator(at: imageCacheRoot, includingPropertiesForKeys: nil)
+            while let url = enumerator?.nextObject() as? URL {
+                if url.pathExtension == "bin" {
+                    try? FileManager.default.removeItem(at: url)
+                }
+            }
+        }
+
+        // 検証: loadImageData が nil を返す（レコードは内部で削除される）
+        let loaded = await service.loadImageData(key: key)
+        #expect(loaded == nil)
     }
 
     // MARK: - バッジ（タイムスタンプ付き）


### PR DESCRIPTION
## Summary

- `ImageDiskStore` actor を新設し、SHA256 パスによる L2 ディスクキャッシュ（emotes/badges/profiles バケット）を構築
- `EmoteImageCache` / `BadgeImageCache` / `ProfileImageCache` に `attachPersistence` + L1→L2→L3 の 3 段ルックアップを追加
- `PersistedImageAsset.data: Data` を `byteSize: Int` に変更（ファイルバイナリは `ImageDiskStore` が管理）

## 主な設計判断

- **レースコンディション排除**: `PersistenceActor.init(modelContainer:diskStore:)` で diskStore を同期注入し、fire-and-forget `Task` を廃止
- **URL キャッシュ二重管理防止**: `ImageDownloadSession.shared`（URLCache=0）を導入し OS キャッシュと競合しない
- **LRU eviction**: `lastAccessedAt` を 60 秒 debounce で更新し、バケット上限超過時に古い順から削除
- **ファイル長遵守**: 画像 I/O ロジックを `PersistenceActor+ImageCache.swift` に分離（618 行以内）
- **isExcludedFromBackup**: `ImageCache/` 以下を iCloud/Time Machine バックアップ対象外に設定

## Test plan

- [x] `ImageDiskStoreTests` – 14 テスト（SHA256 パス・ラウンドトリップ・削除・LRU・backup 除外）
- [x] `SwiftDataPersistenceServiceTests` – 27 テスト（画像 I/O・孤児レコード削除を含む）
- [x] `EmoteImageCacheTests` – L1 ヒット時 loadImageData 不呼出し・L2 ヒット時 HTTP 不発火
- [x] `BadgeImageCacheTests` – L2 ヒット時 HTTP 不発火
- [x] `ProfileImageCache L2 統合テスト` – L2 ヒット時 HTTP 不発火
- [x] `swift build` / `swiftlint lint --quiet` 警告ゼロ

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 絵文字・バッジ・プロフィール画像のディスクキャッシュ（L2）を導入。アプリ起動時からディスク保存を利用します。

* **改善**
  * キャッシュ容量制限と自動削除（LRU）でディスク使用を抑制。
  * ディスクとメモリ間の整合性向上により読み込みの信頼性と初回表示速度が改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->