### PR TITLE
fix: 初回チャンネル参加時に全エモートが表示されないレース条件を修正

### DIFF
--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -559,6 +559,29 @@ actor EmoteStore {
         }
     }
 
+    /// ユーザーエモートが完全に取得済みかどうかを返す
+    ///
+    /// `ChannelManager.joinChannel` がプリロードストアの完了状態を確認するために使用する。
+    /// `fetchUserEmotes` が全ページ完了した場合、または TTL 内の永続化データを
+    /// `seedUserEmotes` でロードした場合に `true` になる。
+    ///
+    /// - Returns: 完全取得済みなら `true`、未ロードまたは途中の場合は `false`
+    func isUserEmotesFullyLoaded() -> Bool {
+        isUserEmotesLoaded
+    }
+
+    /// プリロードストアのスナップショットからユーザーエモートを仮充填する
+    ///
+    /// `ChannelManager.joinChannel` がプリロード未完了時に呼び出す。
+    /// `setUserEmotes(_:)` と異なり `isUserEmotesLoaded` フラグを立てないため、
+    /// `startFetchTasks` の `fetchUserEmotes` が引き続き完全取得を実行できる。
+    /// ピッカーの即時表示と正確な全エモート取得を両立する。
+    ///
+    /// - Parameter emotes: 仮充填するユーザーエモート一覧（プリロード途中のスナップショット）
+    func seedUserEmotesFromPreload(_ emotes: [HelixEmote]) {
+        userEmotes = emotes
+    }
+
     /// ユーザーエモート一覧を直接設定する
     ///
     /// `ChannelManager` が新規接続チャンネルの `ChatViewModel` にプリロード済み

--- a/Sources/TwitchChat/Services/EmoteStore.swift
+++ b/Sources/TwitchChat/Services/EmoteStore.swift
@@ -576,10 +576,14 @@ actor EmoteStore {
     /// `setUserEmotes(_:)` と異なり `isUserEmotesLoaded` フラグを立てないため、
     /// `startFetchTasks` の `fetchUserEmotes` が引き続き完全取得を実行できる。
     /// ピッカーの即時表示と正確な全エモート取得を両立する。
+    /// 完全取得完了後は `fetchUserEmotes` 内の `notifyUserEmoteSetsUpdated()` で追加通知が行われる。
     ///
     /// - Parameter emotes: 仮充填するユーザーエモート一覧（プリロード途中のスナップショット）
     func seedUserEmotesFromPreload(_ emotes: [HelixEmote]) {
         userEmotes = emotes
+        if !emotes.isEmpty {
+            notifyUserEmoteSetsUpdated()
+        }
     }
 
     /// ユーザーエモート一覧を直接設定する

--- a/Sources/TwitchChat/ViewModels/ChannelManager.swift
+++ b/Sources/TwitchChat/ViewModels/ChannelManager.swift
@@ -187,9 +187,18 @@ final class ChannelManager {
 
         // プリロード済みユーザーエモートをシードして初回ピッカー表示を高速化する
         // connect() より前にシードすることで、USERSTATE 到着前からエモートが利用可能になる
+        //
+        // プリロード完了済みの場合: setUserEmotes（isUserEmotesLoaded=true）で完全データをシード
+        // プリロード進行中の場合: seedUserEmotesFromPreload（フラグを立てない）で途中データをシード
+        //   → connect() の startFetchTasks が fetchUserEmotes で完全取得を引き継ぐ
+        let preloadComplete = await preloadEmoteStore.isUserEmotesFullyLoaded()
         let userEmotesSnapshot = await preloadEmoteStore.userEmotesSnapshot()
         if !userEmotesSnapshot.isEmpty {
-            await viewModel.emoteStore.setUserEmotes(userEmotesSnapshot)
+            if preloadComplete {
+                await viewModel.emoteStore.setUserEmotes(userEmotesSnapshot)
+            } else {
+                await viewModel.emoteStore.seedUserEmotesFromPreload(userEmotesSnapshot)
+            }
         }
 
         channels[normalized] = viewModel

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -739,7 +739,6 @@ struct EmoteStoreTests {
     func testIsUserEmotesFullyLoadedInitiallyFalse() async {
         // 前提: エモートが設定されていない初期状態
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-
         // 検証: 初期状態では false
         let loaded = await store.isUserEmotesFullyLoaded()
         #expect(loaded == false)
@@ -749,9 +748,7 @@ struct EmoteStoreTests {
     func testIsUserEmotesFullyLoadedTrueAfterSetUserEmotes() async {
         // 前提: ユーザーエモートを直接セット（プリロード完了をシミュレート）
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
-
         await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
-
         // 検証: setUserEmotes 後は fully loaded
         let loaded = await store.isUserEmotesFullyLoaded()
         #expect(loaded == true)

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -754,7 +754,7 @@ struct EmoteStoreTests {
         #expect(loaded == true)
     }
 
-    @Test("seedUserEmotesFromPreload はエモートをセットするが isUserEmotesLoaded フラグを立てない")
+    @Test("seedUserEmotesFromPreload はエモートをセットするが isUserEmotesFullyLoaded フラグを立てない")
     func testSeedUserEmotesFromPreloadDoesNotSetLoadedFlag() async {
         // 前提: プリロード途中のスナップショット（ページ 1 のみ取得済み）をシミュレート
         let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())

--- a/Tests/TwitchChatTests/EmoteStoreTests.swift
+++ b/Tests/TwitchChatTests/EmoteStoreTests.swift
@@ -732,4 +732,72 @@ struct EmoteStoreTests {
         // 検証: グローバルエモート未設定のため空配列
         #expect(snapshot.isEmpty)
     }
+
+    // MARK: - プリロード競合対策
+
+    @Test("isUserEmotesFullyLoaded は初期状態で false を返す")
+    func testIsUserEmotesFullyLoadedInitiallyFalse() async {
+        // 前提: エモートが設定されていない初期状態
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        // 検証: 初期状態では false
+        let loaded = await store.isUserEmotesFullyLoaded()
+        #expect(loaded == false)
+    }
+
+    @Test("isUserEmotesFullyLoaded は setUserEmotes 後に true を返す")
+    func testIsUserEmotesFullyLoadedTrueAfterSetUserEmotes() async {
+        // 前提: ユーザーエモートを直接セット（プリロード完了をシミュレート）
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
+
+        // 検証: setUserEmotes 後は fully loaded
+        let loaded = await store.isUserEmotesFullyLoaded()
+        #expect(loaded == true)
+    }
+
+    @Test("seedUserEmotesFromPreload はエモートをセットするが isUserEmotesLoaded フラグを立てない")
+    func testSeedUserEmotesFromPreloadDoesNotSetLoadedFlag() async {
+        // 前提: プリロード途中のスナップショット（ページ 1 のみ取得済み）をシミュレート
+        let store = EmoteStore(apiClient: MockHelixAPIClientForEmote())
+
+        await store.seedUserEmotesFromPreload([.ユーザーエモート別チャンネルSub])
+
+        // 検証: エモートはセットされているが isUserEmotesLoaded は false のまま
+        let snapshot = await store.userEmotesSnapshot()
+        let loaded = await store.isUserEmotesFullyLoaded()
+        #expect(snapshot.count == 1)
+        #expect(snapshot.first?.id == HelixEmote.ユーザーエモート別チャンネルSub.id)
+        #expect(loaded == false)
+    }
+
+    @Test("seedUserEmotesFromPreload 後の fetchUserEmotes は新規フェッチを実行する")
+    func testFetchUserEmotesRunsAfterSeedFromPreload() async {
+        // 前提: fetchUserEmotes のカウントを計測するモッククライアント
+        let counter = FetchCounter()
+        let store = EmoteStore(apiClient: CountingMockClient(counter: counter, countedEndpoint: "/emotes/user"))
+
+        // プリロード途中データをシードしてから fetchUserEmotes を呼ぶ
+        await store.seedUserEmotesFromPreload([.ユーザーエモート別チャンネルSub])
+        await store.fetchUserEmotes(userId: "123456")
+
+        // 検証: fetchUserEmotes が実際に API を呼んだこと（loaded フラグで弾かれていない）
+        let count = await counter.value
+        #expect(count == 1)
+    }
+
+    @Test("setUserEmotes 後の fetchUserEmotes はフェッチをスキップする（最適化パス）")
+    func testFetchUserEmotesSkipsAfterSetUserEmotes() async {
+        // 前提: プリロード完了済み（setUserEmotes で isLoaded=true）をシミュレート
+        let counter = FetchCounter()
+        let store = EmoteStore(apiClient: CountingMockClient(counter: counter, countedEndpoint: "/emotes/user"))
+
+        await store.setUserEmotes([.ユーザーエモート別チャンネルSub])
+        await store.fetchUserEmotes(userId: "123456")
+
+        // 検証: setUserEmotes 後は fetchUserEmotes が API を呼ばない（isLoaded=true でガード）
+        let count = await counter.value
+        #expect(count == 0)
+    }
 }


### PR DESCRIPTION
## Summary

- `preloadUserEmotes()` の fire-and-forget Task と `joinChannel()` の競合を修正
- ページネーション途中のスナップショットが `setUserEmotes()` に渡り `isUserEmotesLoaded=true` がセットされ、以降の `fetchUserEmotes` が全スキップされる問題を解消
- `EmoteStore` に `isUserEmotesFullyLoaded()` と `seedUserEmotesFromPreload()` を追加
- `ChannelManager.joinChannel` でプリロード完了済みかを確認し、未完了時は `seedUserEmotesFromPreload` を使用（`isUserEmotesLoaded` フラグを立てずにデータのみシード）
- `seedUserEmotesFromPreload` に `notifyUserEmoteSetsUpdated()` を追加してピッカーへの即時反映を保証

## Root Cause

```
ログイン → preloadUserEmotes() (fire-and-forget Task, ページネーション進行中)
             ↓
joinChannel() 呼び出し
             ↓
userEmotesSnapshot() → ページ1のみの部分データ取得
             ↓
setUserEmotes(部分データ) → isUserEmotesLoaded = true ← バグの起点
             ↓
startFetchTasks の fetchUserEmotes → guard !isUserEmotesLoaded → 即リターン
USERSTATE ハンドラの fetchUserEmotes → guard !isUserEmotesLoaded → 即リターン
             ↓
エモートが部分データで固定（2チャンネル目はプリロード完了後なので正常）
```

## Test plan

- [x] `swift build` 成功
- [x] `swift test --filter "EmoteStoreTests|EmotePickerViewModelTests|ChannelManagerTests|EmoteStorePersistenceTests"` 全121テスト通過
- [x] `swiftlint lint --quiet` 警告ゼロ
- [x] CodeRabbit 2件の指摘対応済み

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エモート事前読み込み機能を強化し、チャネル接続時のエモートピッカーの応答性が向上しました。

* **テスト**
  * エモート事前読み込み動作と競合条件シナリオの包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->