### PR TITLE
feat: Twitch ライブ配信 AVPlayer + HLS 再生機能（実験的）

### DIFF
--- a/Sources/TwitchChat/App/AppStorageKeys.swift
+++ b/Sources/TwitchChat/App/AppStorageKeys.swift
@@ -1,0 +1,9 @@
+// AppStorageKeys.swift
+// @AppStorage で使用するキー文字列の共有定数
+// 複数 View に分散した文字列リテラルを一元管理し、typo や同期漏れを防ぐ
+
+/// `@AppStorage` キーの名前空間
+enum AppStorageKeys {
+    /// ライブ配信プレイヤー機能の有効・無効
+    static let livePlayerEnabled = "livePlayerEnabled"
+}

--- a/Sources/TwitchChat/App/TwitchChatApp.swift
+++ b/Sources/TwitchChat/App/TwitchChatApp.swift
@@ -20,6 +20,8 @@ struct TwitchChatApp: App {
     @State private var followedChannelStore: FollowedChannelStore?
     /// ユーザープロフィール画像URLストア
     @State private var profileImageStore: ProfileImageStore?
+    /// ライブ配信プレイヤー ViewModel（アプリ起動時に生成、チャンネル全体で共有）
+    @State private var streamPlayer = StreamPlayerViewModel()
 
     var body: some Scene {
         WindowGroup {
@@ -33,7 +35,8 @@ struct TwitchChatApp: App {
                     channelManager: channelManager,
                     followedStreamStore: followedStreamStore,
                     followedChannelStore: followedChannelStore,
-                    profileImageStore: profileImageStore
+                    profileImageStore: profileImageStore,
+                    streamPlayer: streamPlayer
                 )
                 .task {
                     await authState.restoreSession()
@@ -105,5 +108,9 @@ struct TwitchChatApp: App {
             }
         }
         .defaultSize(width: 800, height: 700)
+
+        Settings {
+            SettingsView()
+        }
     }
 }

--- a/Sources/TwitchChat/Models/Playback/StreamPlaybackManifest.swift
+++ b/Sources/TwitchChat/Models/Playback/StreamPlaybackManifest.swift
@@ -1,0 +1,15 @@
+// StreamPlaybackManifest.swift
+// Twitch ライブ配信 HLS マニフェスト URL の DTO
+
+import Foundation
+
+/// Twitch ライブ配信の HLS マスターマニフェスト URL
+///
+/// `StreamPlaybackResolver` が GQL トークン取得と Usher URL 組み立てを経て返す値。
+/// `AVPlayer` にこの URL を渡して再生を開始できる。
+struct StreamPlaybackManifest: Sendable {
+    /// AVPlayer に渡す HLS マスターマニフェスト URL（usher.ttvnw.net）
+    let url: URL
+    /// マニフェストを取得した日時（トークン失効の判断に使用する可能性あり）
+    let fetchedAt: Date
+}

--- a/Sources/TwitchChat/Models/Playback/StreamPlaybackToken.swift
+++ b/Sources/TwitchChat/Models/Playback/StreamPlaybackToken.swift
@@ -1,0 +1,30 @@
+// StreamPlaybackToken.swift
+// Twitch GQL PlaybackAccessToken レスポンスの DTO
+
+import Foundation
+
+/// Twitch GQL から取得した HLS 再生用アクセストークン
+struct StreamPlaybackToken: Sendable {
+    /// HLS マニフェスト URL に付与するトークン文字列（JWT 形式）
+    let value: String
+    /// HLS マニフェスト URL に付与する署名文字列
+    let signature: String
+}
+
+// MARK: - GQL レスポンス DTO（デコード専用）
+
+/// GQL PlaybackAccessToken クエリのルートレスポンス
+struct GQLPlaybackTokenResponse: Decodable {
+    let data: GQLPlaybackTokenData
+}
+
+/// GQL レスポンス data フィールド
+struct GQLPlaybackTokenData: Decodable {
+    let streamPlaybackAccessToken: GQLAccessToken
+}
+
+/// GQL レスポンス内のアクセストークンオブジェクト
+struct GQLAccessToken: Decodable {
+    let value: String
+    let signature: String
+}

--- a/Sources/TwitchChat/Services/Playback/PlaybackError.swift
+++ b/Sources/TwitchChat/Services/Playback/PlaybackError.swift
@@ -1,0 +1,38 @@
+// PlaybackError.swift
+// Twitch ライブ配信 HLS 再生に関するエラー型
+
+import Foundation
+
+/// Twitch ライブ配信の HLS 再生中に発生するエラー
+enum PlaybackError: Error, Equatable {
+
+    /// GQL PlaybackAccessToken リクエストが HTTP エラーを返した
+    case tokenRequestFailed(statusCode: Int)
+
+    /// GQL レスポンスのデコードに失敗した（形式変更などで発生する可能性がある）
+    case tokenDecodingFailed
+
+    /// Usher マニフェストの取得に失敗した（想定外のステータスコード）
+    case manifestUnreachable(statusCode: Int)
+
+    /// チャンネルがオフライン（Usher が 404 を返した）
+    case channelOffline
+
+    /// 地域制限またはサブスクライバー限定配信のため視聴不可（Usher が 403 を返した）
+    case geoOrSubscriberRestricted
+
+    /// ネットワークエラー
+    case network(URLError)
+
+    static func == (lhs: PlaybackError, rhs: PlaybackError) -> Bool {
+        switch (lhs, rhs) {
+        case let (.tokenRequestFailed(l), .tokenRequestFailed(r)): return l == r
+        case (.tokenDecodingFailed, .tokenDecodingFailed): return true
+        case let (.manifestUnreachable(l), .manifestUnreachable(r)): return l == r
+        case (.channelOffline, .channelOffline): return true
+        case (.geoOrSubscriberRestricted, .geoOrSubscriberRestricted): return true
+        case let (.network(l), .network(r)): return l.code == r.code
+        default: return false
+        }
+    }
+}

--- a/Sources/TwitchChat/Services/Playback/PlaybackError.swift
+++ b/Sources/TwitchChat/Services/Playback/PlaybackError.swift
@@ -12,6 +12,9 @@ enum PlaybackError: Error, Equatable {
     /// GQL レスポンスのデコードに失敗した（形式変更などで発生する可能性がある）
     case tokenDecodingFailed
 
+    /// Usher マニフェスト URL の組み立てに失敗した（内部ロジックの誤りで発生する）
+    case badURL
+
     /// Usher マニフェストの取得に失敗した（想定外のステータスコード）
     case manifestUnreachable(statusCode: Int)
 
@@ -28,6 +31,7 @@ enum PlaybackError: Error, Equatable {
         switch (lhs, rhs) {
         case let (.tokenRequestFailed(l), .tokenRequestFailed(r)): return l == r
         case (.tokenDecodingFailed, .tokenDecodingFailed): return true
+        case (.badURL, .badURL): return true
         case let (.manifestUnreachable(l), .manifestUnreachable(r)): return l == r
         case (.channelOffline, .channelOffline): return true
         case (.geoOrSubscriberRestricted, .geoOrSubscriberRestricted): return true

--- a/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
+++ b/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
@@ -1,0 +1,90 @@
+// StreamPlaybackResolver.swift
+// Twitch ライブ配信 HLS マニフェスト URL の解決
+// GQL トークン取得から Usher URL 組み立てまでを一元管理する
+
+import Foundation
+
+// MARK: - プロトコル
+
+/// Twitch ライブ配信の HLS マニフェスト URL を解決するプロトコル
+///
+/// テスト時にモックを注入できるよう抽象化する
+protocol StreamPlaybackResolverProtocol: Sendable {
+    /// 指定チャンネルの HLS マニフェスト URL を解決する
+    ///
+    /// - Parameter login: チャンネルログイン名
+    /// - Returns: `StreamPlaybackManifest`
+    /// - Throws: `PlaybackError`
+    func resolve(login: String) async throws -> StreamPlaybackManifest
+}
+
+// MARK: - 実装
+
+/// Twitch ライブ配信の HLS マニフェスト URL を解決する
+///
+/// 1. GQL PlaybackAccessToken を取得（`TwitchPlaybackTokenClientProtocol`）
+/// 2. Usher URL を組み立てて `StreamPlaybackManifest` を返す
+///
+/// AVPlayer にはこの URL をそのまま渡して再生できる。
+actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
+
+    // MARK: - 定数
+
+    /// Usher HLS マニフェストエンドポイントのベース URL
+    private static let usherBaseURL = "https://usher.ttvnw.net/api/channel/hls"
+
+    // MARK: - プロパティ
+
+    private let tokenClient: any TwitchPlaybackTokenClientProtocol
+
+    // MARK: - 初期化
+
+    /// `StreamPlaybackResolver` を初期化する
+    ///
+    /// - Parameter tokenClient: GQL アクセストークン取得クライアント
+    init(tokenClient: any TwitchPlaybackTokenClientProtocol = TwitchPlaybackTokenClient()) {
+        self.tokenClient = tokenClient
+    }
+
+    // MARK: - 公開メソッド
+
+    /// 指定チャンネルの HLS マニフェスト URL を解決する
+    ///
+    /// - Parameter login: チャンネルログイン名（大小文字不問、内部で小文字化する）
+    /// - Returns: AVPlayer に渡せる `StreamPlaybackManifest`
+    /// - Throws: `PlaybackError`
+    func resolve(login: String) async throws -> StreamPlaybackManifest {
+        let normalizedLogin = login.lowercased()
+        let token = try await tokenClient.fetchLiveToken(login: normalizedLogin)
+        let url = try buildUsherURL(login: normalizedLogin, token: token)
+        return StreamPlaybackManifest(url: url, fetchedAt: Date())
+    }
+
+    // MARK: - プライベートヘルパー
+
+    private func buildUsherURL(login: String, token: StreamPlaybackToken) throws -> URL {
+        guard var components = URLComponents(string: "\(Self.usherBaseURL)/\(login).m3u8") else {
+            throw PlaybackError.manifestUnreachable(statusCode: 0)
+        }
+
+        components.queryItems = [
+            URLQueryItem(name: "allow_source", value: "true"),
+            URLQueryItem(name: "fast_bread", value: "true"),
+            URLQueryItem(name: "p", value: String(Int.random(in: 100000...999999))),
+            URLQueryItem(name: "play_session_id", value: UUID().uuidString.lowercased()),
+            URLQueryItem(name: "player_backend", value: "mediaplayer"),
+            URLQueryItem(name: "playlist_include_framerate", value: "true"),
+            URLQueryItem(name: "reassignments_supported", value: "true"),
+            URLQueryItem(name: "sig", value: token.signature),
+            URLQueryItem(name: "supported_codecs", value: "avc1"),
+            URLQueryItem(name: "token", value: token.value),
+            URLQueryItem(name: "cdm", value: "wv"),
+            URLQueryItem(name: "player_version", value: "1.27.0")
+        ]
+
+        guard let url = components.url else {
+            throw PlaybackError.manifestUnreachable(statusCode: 0)
+        }
+        return url
+    }
+}

--- a/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
+++ b/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
@@ -64,7 +64,7 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
 
     private func buildUsherURL(login: String, token: StreamPlaybackToken) throws -> URL {
         guard var components = URLComponents(string: "\(Self.usherBaseURL)/\(login).m3u8") else {
-            throw PlaybackError.manifestUnreachable(statusCode: 0)
+            throw PlaybackError.badURL
         }
 
         components.queryItems = [
@@ -83,7 +83,7 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
         ]
 
         guard let url = components.url else {
-            throw PlaybackError.manifestUnreachable(statusCode: 0)
+            throw PlaybackError.badURL
         }
         return url
     }

--- a/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
+++ b/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
@@ -1,0 +1,177 @@
+// TwitchPlaybackTokenClient.swift
+// Twitch GQL PlaybackAccessToken 取得クライアント
+// HLS 再生に必要な署名付きトークンを gql.twitch.tv から取得する
+
+import Foundation
+
+// MARK: - データフェッチャープロトコル
+
+/// HTTP リクエストを送信してレスポンスデータを返すプロトコル
+///
+/// テスト時にモックを注入できるよう `URLSession` の依存を抽象化する
+protocol URLSessionDataFetcher: Sendable {
+    /// URLRequest を送信してレスポンスデータと URLResponse を返す
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionDataFetcher {}
+
+// MARK: - プロトコル
+
+/// Twitch ライブ配信の再生用アクセストークン取得クライアントプロトコル
+///
+/// テスト時にモックを注入できるよう抽象化する
+protocol TwitchPlaybackTokenClientProtocol: Sendable {
+    /// 指定チャンネルのライブ配信用 HLS アクセストークンを取得する
+    ///
+    /// - Parameter login: チャンネルログイン名（小文字）
+    /// - Returns: HLS マニフェスト URL 用の `StreamPlaybackToken`
+    /// - Throws: `PlaybackError`
+    func fetchLiveToken(login: String) async throws -> StreamPlaybackToken
+}
+
+// MARK: - 実装
+
+/// Twitch GQL PlaybackAccessToken 取得クライアント
+///
+/// `gql.twitch.tv/gql` に `PlaybackAccessToken` persisted query を送信し、
+/// HLS 再生に必要な署名付きトークンを返す。Twitch の公開 Web Client-ID を使う匿名アクセス。
+///
+/// - Important: この API は Twitch 非公開のため、利用規約上グレー。
+///              GQL persisted query ハッシュは Twitch Web 更新で変わる可能性がある。
+actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
+
+    // MARK: - 定数
+
+    /// GQL PlaybackAccessToken の persisted query SHA-256 ハッシュ
+    ///
+    /// Twitch Web の内部 GQL ハッシュ。Web アプリ更新により変更される可能性がある。
+    fileprivate static let liveQueryHash = "0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712"
+
+    /// GQL エンドポイント
+    private static let gqlEndpoint = URL(string: "https://gql.twitch.tv/gql")!
+
+    /// リクエストタイムアウト秒数
+    private static let requestTimeout: TimeInterval = 4
+
+    // MARK: - プロパティ
+
+    private let dataFetcher: any URLSessionDataFetcher
+    private let clientID: String
+
+    // MARK: - 初期化
+
+    /// `TwitchPlaybackTokenClient` を初期化する
+    ///
+    /// - Parameters:
+    ///   - dataFetcher: HTTP リクエストを実行するデータフェッチャー（テスト時はモックを渡す）
+    ///   - clientID: GQL リクエストに付与する Client-Id ヘッダー値
+    init(
+        dataFetcher: any URLSessionDataFetcher = TwitchPlaybackTokenClient.makeDefaultSession(),
+        clientID: String = TwitchPlaybackTokenClient.webClientID
+    ) {
+        self.dataFetcher = dataFetcher
+        self.clientID = clientID
+    }
+
+    // MARK: - 公開メソッド
+
+    /// 指定チャンネルのライブ配信用 HLS アクセストークンを取得する
+    ///
+    /// - Parameter login: チャンネルログイン名
+    /// - Returns: `StreamPlaybackToken`
+    /// - Throws: `PlaybackError`
+    func fetchLiveToken(login: String) async throws -> StreamPlaybackToken {
+        let request = try buildRequest(login: login.lowercased())
+        let (data, response) = try await fetchData(request: request)
+        try validateHTTPResponse(response, data: data)
+        return try decodeToken(from: data)
+    }
+
+    // MARK: - プライベートヘルパー
+
+    private func buildRequest(login: String) throws -> URLRequest {
+        var request = URLRequest(url: Self.gqlEndpoint, timeoutInterval: Self.requestTimeout)
+        request.httpMethod = "POST"
+        request.setValue(clientID, forHTTPHeaderField: "Client-Id")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(GQLPlaybackTokenBody(login: login))
+        return request
+    }
+
+    private func fetchData(request: URLRequest) async throws -> (Data, URLResponse) {
+        do {
+            return try await dataFetcher.data(for: request)
+        } catch let urlError as URLError {
+            throw PlaybackError.network(urlError)
+        }
+    }
+
+    private func validateHTTPResponse(_ response: URLResponse, data: Data) throws {
+        guard let http = response as? HTTPURLResponse else { return }
+        guard http.statusCode == 200 else {
+            throw PlaybackError.tokenRequestFailed(statusCode: http.statusCode)
+        }
+    }
+
+    private func decodeToken(from data: Data) throws -> StreamPlaybackToken {
+        do {
+            let gqlResponse = try JSONDecoder().decode(GQLPlaybackTokenResponse.self, from: data)
+            let accessToken = gqlResponse.data.streamPlaybackAccessToken
+            return StreamPlaybackToken(value: accessToken.value, signature: accessToken.signature)
+        } catch {
+            throw PlaybackError.tokenDecodingFailed
+        }
+    }
+}
+
+// MARK: - GQL リクエストボディ
+
+/// GQL PlaybackAccessToken persisted query のリクエストボディ
+private struct GQLPlaybackTokenBody: Encodable {
+    let operationName = "PlaybackAccessToken"
+    let extensions: GQLExtensions
+    let variables: GQLVariables
+
+    init(login: String) {
+        self.extensions = GQLExtensions(
+            persistedQuery: GQLPersistedQuery(sha256Hash: TwitchPlaybackTokenClient.liveQueryHash)
+        )
+        self.variables = GQLVariables(login: login)
+    }
+}
+
+private struct GQLExtensions: Encodable {
+    let persistedQuery: GQLPersistedQuery
+}
+
+private struct GQLPersistedQuery: Encodable {
+    let version = 1
+    let sha256Hash: String
+}
+
+private struct GQLVariables: Encodable {
+    let isLive = true
+    let login: String
+    let isVod = false
+    let vodID = ""
+    let playerType = "site"
+}
+
+// MARK: - ファクトリ
+
+extension TwitchPlaybackTokenClient {
+
+    /// Twitch Web の公開 Client-ID
+    ///
+    /// Bearer トークンを送らない匿名アクセス用。サブスク限定配信は視聴不可。
+    static let webClientID = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+
+    /// デフォルト URLSession を生成する（OS キャッシュを無効化した独立セッション）
+    static func makeDefaultSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.urlCache = URLCache(memoryCapacity: 0, diskCapacity: 0)
+        config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        return URLSession(configuration: config)
+    }
+}

--- a/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
+++ b/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
@@ -108,7 +108,9 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
     }
 
     private func validateHTTPResponse(_ response: URLResponse, data: Data) throws {
-        guard let http = response as? HTTPURLResponse else { return }
+        guard let http = response as? HTTPURLResponse else {
+            throw PlaybackError.network(URLError(.badServerResponse))
+        }
         guard http.statusCode == 200 else {
             throw PlaybackError.tokenRequestFailed(statusCode: http.statusCode)
         }

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -64,6 +64,9 @@ final class StreamPlayerViewModel {
     /// - Parameter login: チャンネルログイン名
     func load(login: String) async {
         loadTask?.cancel()
+        // チャンネル切替直後に前の配信音声が流れ続けないよう即座に停止する
+        player.pause()
+        player.replaceCurrentItem(with: nil)
         state = .resolving
         currentLogin = login
 
@@ -105,9 +108,13 @@ final class StreamPlayerViewModel {
             state = .playing
         } catch let error as PlaybackError {
             guard !Task.isCancelled else { return }
+            player.pause()
+            player.replaceCurrentItem(with: nil)
             state = mapPlaybackError(error)
         } catch {
             guard !Task.isCancelled else { return }
+            player.pause()
+            player.replaceCurrentItem(with: nil)
             state = .error(message: error.localizedDescription)
         }
     }
@@ -118,6 +125,8 @@ final class StreamPlayerViewModel {
             return .offline
         case .geoOrSubscriberRestricted:
             return .error(message: "この配信は視聴できません（地域制限またはサブスクライバー限定）")
+        case .badURL:
+            return .error(message: "マニフェスト URL の生成に失敗しました（内部エラー）")
         case .tokenDecodingFailed:
             return .error(message: "再生トークンの取得に失敗しました（APIが変更された可能性があります）")
         case .tokenRequestFailed(let statusCode):

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -1,0 +1,131 @@
+// StreamPlayerViewModel.swift
+// Twitch ライブ配信 AVPlayer の状態管理 ViewModel
+
+import AVFoundation
+import Foundation
+import Observation
+
+// MARK: - ViewModel
+
+/// Twitch ライブ配信の AVPlayer 状態を管理する ViewModel
+///
+/// `ChannelManager` が保持する 1 インスタンスで、タブ切替に追従して再生対象を差し替える。
+/// AVPlayer 実体は `player` プロパティで公開し、`StreamPlayerView` が直接参照する。
+@Observable @MainActor
+final class StreamPlayerViewModel {
+
+    // MARK: - 再生状態
+
+    /// AVPlayer の再生状態
+    enum State: Equatable {
+        /// 未再生（初期状態・stop 後）
+        case idle
+        /// マニフェスト URL を解決中
+        case resolving
+        /// AVPlayer に item を渡し再生中（バッファリング含む）
+        case playing
+        /// チャンネルがオフライン
+        case offline
+        /// 再生不可エラー（サブスク限定・地域制限・デコード失敗など）
+        case error(message: String)
+    }
+
+    // MARK: - 公開プロパティ
+
+    /// 現在の再生状態
+    private(set) var state: State = .idle
+    /// 現在再生中のチャンネルログイン名
+    private(set) var currentLogin: String?
+    /// View が参照する AVPlayer インスタンス（1インスタンスで item を差し替える）
+    let player: AVPlayer
+
+    // MARK: - プライベートプロパティ
+
+    private let resolver: any StreamPlaybackResolverProtocol
+    /// 進行中の load Task（キャンセル用）
+    private var loadTask: Task<Void, Never>?
+
+    // MARK: - 初期化
+
+    /// `StreamPlayerViewModel` を初期化する
+    ///
+    /// - Parameter resolver: HLS マニフェスト URL を解決するリゾルバー
+    init(resolver: any StreamPlaybackResolverProtocol = StreamPlaybackResolver()) {
+        self.resolver = resolver
+        self.player = AVPlayer()
+    }
+
+    // MARK: - 公開メソッド
+
+    /// 指定チャンネルの HLS 配信を読み込んで再生を開始する
+    ///
+    /// 進行中の load がある場合はキャンセルして新しい load を優先する。
+    ///
+    /// - Parameter login: チャンネルログイン名
+    func load(login: String) async {
+        loadTask?.cancel()
+        state = .resolving
+        currentLogin = login
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.performLoad(login: login)
+        }
+        loadTask = task
+        await task.value
+    }
+
+    /// 再生を停止して idle 状態に戻る
+    func stop() {
+        loadTask?.cancel()
+        loadTask = nil
+        player.pause()
+        player.replaceCurrentItem(with: nil)
+        state = .idle
+        currentLogin = nil
+    }
+
+    /// 直前のエラーから再試行する
+    func retry() async {
+        guard let login = currentLogin else { return }
+        await load(login: login)
+    }
+
+    // MARK: - プライベートヘルパー
+
+    private func performLoad(login: String) async {
+        do {
+            let manifest = try await resolver.resolve(login: login)
+            guard !Task.isCancelled else { return }
+
+            let asset = AVURLAsset(url: manifest.url)
+            let item = AVPlayerItem(asset: asset)
+            player.replaceCurrentItem(with: item)
+            player.play()
+            state = .playing
+        } catch let error as PlaybackError {
+            guard !Task.isCancelled else { return }
+            state = mapPlaybackError(error)
+        } catch {
+            guard !Task.isCancelled else { return }
+            state = .error(message: error.localizedDescription)
+        }
+    }
+
+    private func mapPlaybackError(_ error: PlaybackError) -> State {
+        switch error {
+        case .channelOffline:
+            return .offline
+        case .geoOrSubscriberRestricted:
+            return .error(message: "この配信は視聴できません（地域制限またはサブスクライバー限定）")
+        case .tokenDecodingFailed:
+            return .error(message: "再生トークンの取得に失敗しました（APIが変更された可能性があります）")
+        case .tokenRequestFailed(let statusCode):
+            return .error(message: "再生トークンの取得に失敗しました（HTTP \(statusCode)）")
+        case .manifestUnreachable(let statusCode):
+            return .error(message: "HLS マニフェストの取得に失敗しました（HTTP \(statusCode)）")
+        case .network(let urlError):
+            return .error(message: "ネットワークエラー: \(urlError.localizedDescription)")
+        }
+    }
+}

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -1,12 +1,14 @@
 // ChatDetailView.swift
 // チャット詳細ペイン
 // 選択中チャンネルのメッセージリスト・エラー表示・コメント入力バーを担当する
+// livePlayerEnabled が true のとき上部にライブプレイヤーを VSplitView で表示する
 
 import SwiftUI
 
 /// 選択中チャンネルのチャット詳細ペイン
 ///
 /// - エラー時はエラーメッセージを表示
+/// - livePlayerEnabled が true のとき上部に StreamPlayerView を VSplitView で表示
 /// - チャットメッセージを ScrollView + LazyVStack で表示
 /// - 新メッセージ到着時に自動スクロール
 /// - 下部にコメント投稿用入力バーを表示
@@ -15,6 +17,11 @@ struct ChatDetailView: View {
     var authState: AuthState
     /// プロフィール画像・表示名ストア（エモートピッカーのセクションヘッダー用）
     var profileImageStore: ProfileImageStore
+    /// ライブプレイヤー ViewModel（nil の場合はプレイヤーを表示しない）
+    var streamPlayer: StreamPlayerViewModel?
+
+    /// ライブ配信プレイヤー機能の有効・無効（SettingsView から変更可能）
+    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -27,8 +34,17 @@ struct ChatDetailView: View {
                 Divider()
             }
 
-            // チャットメッセージリスト
-            chatListView
+            // livePlayerEnabled かつ streamPlayer がある場合はプレイヤーと VSplitView
+            if livePlayerEnabled, let streamPlayer {
+                VSplitView {
+                    StreamPlayerView(viewModel: streamPlayer)
+                        .frame(minHeight: 180)
+                    chatListView
+                }
+            } else {
+                // チャットのみ表示（既存挙動）
+                chatListView
+            }
 
             // コメント投稿用入力バー
             Divider()

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -1,14 +1,14 @@
 // ChatDetailView.swift
 // チャット詳細ペイン
 // 選択中チャンネルのメッセージリスト・エラー表示・コメント入力バーを担当する
-// livePlayerEnabled が true のとき上部にライブプレイヤーを VSplitView で表示する
+// livePlayerEnabled が true のとき上部に 16:9 固定比率のプレイヤーを表示する
 
 import SwiftUI
 
 /// 選択中チャンネルのチャット詳細ペイン
 ///
 /// - エラー時はエラーメッセージを表示
-/// - livePlayerEnabled が true のとき上部に StreamPlayerView を VSplitView で表示
+/// - livePlayerEnabled が true のとき上部に 16:9 固定比率の StreamPlayerView を表示
 /// - チャットメッセージを ScrollView + LazyVStack で表示
 /// - 新メッセージ到着時に自動スクロール
 /// - 下部にコメント投稿用入力バーを表示
@@ -23,6 +23,9 @@ struct ChatDetailView: View {
     /// ライブ配信プレイヤー機能の有効・無効（SettingsView から変更可能）
     @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
 
+    /// プレイヤー高さ（横幅を onGeometryChange で計測して 16:9 から算出）
+    @State private var playerHeight: CGFloat = 0
+
     var body: some View {
         VStack(spacing: 0) {
             // エラー表示
@@ -34,13 +37,19 @@ struct ChatDetailView: View {
                 Divider()
             }
 
-            // livePlayerEnabled かつ streamPlayer がある場合はプレイヤーと VSplitView
+            // livePlayerEnabled かつ streamPlayer がある場合は横幅フル・16:9 高さでプレイヤーを上部表示
+            // aspectRatio(contentMode: .fit) は VStack の高さ制約に負けて幅が縮むため、
+            // onGeometryChange で横幅を計測して高さを明示的に設定する
             if livePlayerEnabled, let streamPlayer {
-                VSplitView {
-                    StreamPlayerView(viewModel: streamPlayer)
-                        .frame(minHeight: 180)
-                    chatListView
-                }
+                StreamPlayerView(viewModel: streamPlayer)
+                    .frame(maxWidth: .infinity, minHeight: playerHeight, maxHeight: playerHeight > 0 ? playerHeight : .infinity)
+                    .onGeometryChange(for: CGFloat.self) { proxy in
+                        proxy.size.width
+                    } action: { newWidth in
+                        playerHeight = newWidth * 9 / 16
+                    }
+                Divider()
+                chatListView
             } else {
                 // チャットのみ表示（既存挙動）
                 chatListView

--- a/Sources/TwitchChat/Views/ChatDetailView.swift
+++ b/Sources/TwitchChat/Views/ChatDetailView.swift
@@ -21,10 +21,21 @@ struct ChatDetailView: View {
     var streamPlayer: StreamPlayerViewModel?
 
     /// ライブ配信プレイヤー機能の有効・無効（SettingsView から変更可能）
-    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
+    @AppStorage(AppStorageKeys.livePlayerEnabled) private var livePlayerEnabled = false
 
-    /// プレイヤー高さ（横幅を onGeometryChange で計測して 16:9 から算出）
-    @State private var playerHeight: CGFloat = 0
+    /// プレイヤー横幅（onGeometryChange で計測）
+    @State private var playerWidth: CGFloat = 0
+    /// コンテナ（VStack 全体）高さ（playerHeight の上限算出に使用）
+    @State private var containerHeight: CGFloat = 0
+
+    /// 16:9 比率かつコンテナの 65% 以下に制限したプレイヤー高さ
+    ///
+    /// 横幅フルの 16:9 をそのまま使うと横長ウィンドウでチャット領域が潰れるため、
+    /// コンテナ高さの 65% を上限としてチャットエリアを確保する。
+    private var playerHeight: CGFloat {
+        guard playerWidth > 0, containerHeight > 0 else { return 0 }
+        return min(playerWidth * 9 / 16, containerHeight * 0.65)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -42,11 +53,12 @@ struct ChatDetailView: View {
             // onGeometryChange で横幅を計測して高さを明示的に設定する
             if livePlayerEnabled, let streamPlayer {
                 StreamPlayerView(viewModel: streamPlayer)
-                    .frame(maxWidth: .infinity, minHeight: playerHeight, maxHeight: playerHeight > 0 ? playerHeight : .infinity)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: playerHeight > 0 ? playerHeight : nil)
                     .onGeometryChange(for: CGFloat.self) { proxy in
                         proxy.size.width
                     } action: { newWidth in
-                        playerHeight = newWidth * 9 / 16
+                        if newWidth != playerWidth { playerWidth = newWidth }
                     }
                 Divider()
                 chatListView
@@ -61,6 +73,12 @@ struct ChatDetailView: View {
         }
         // タブバーのアクティブタブ色（controlBackgroundColor）と一致させる
         .background(Color(.controlBackgroundColor))
+        // VStack 全体の高さを追跡し、playerHeight の上限計算に使う
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newHeight in
+            if newHeight != containerHeight { containerHeight = newHeight }
+        }
     }
 
     /// チャットメッセージのスクロールビュー

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -21,9 +21,14 @@ struct ContentView: View {
     var followedStreamStore: FollowedStreamStore
     var followedChannelStore: FollowedChannelStore
     var profileImageStore: ProfileImageStore
+    /// ライブ配信プレイヤー ViewModel（TwitchChatApp から注入）
+    var streamPlayer: StreamPlayerViewModel
 
     /// blank tab（チャンネル名入力フォーム）が開いているかどうか
     @State private var isBlankTabOpen: Bool = false
+
+    /// ライブ配信プレイヤー機能の有効・無効（SettingsView から変更可能）
+    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
 
     var body: some View {
         NavigationSplitView {
@@ -65,7 +70,12 @@ struct ContentView: View {
                         }
                     )
                 } else if let viewModel = channelManager.selectedViewModel {
-                    ChatDetailView(viewModel: viewModel, authState: authState, profileImageStore: profileImageStore)
+                    ChatDetailView(
+                        viewModel: viewModel,
+                        authState: authState,
+                        profileImageStore: profileImageStore,
+                        streamPlayer: streamPlayer
+                    )
                 } else {
                     // タブ0個の初期状態: チャンネル名入力フォームを直接表示
                     ChannelSearchView(
@@ -81,5 +91,22 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 600, minHeight: 400)
+        .onChange(of: channelManager.selectedChannel) { _, newChannel in
+            // livePlayerEnabled かつチャンネルが切り替わった場合にのみ再生を開始する
+            guard livePlayerEnabled, let login = newChannel else {
+                if newChannel == nil { streamPlayer.stop() }
+                return
+            }
+            Task { await streamPlayer.load(login: login) }
+        }
+        .onChange(of: livePlayerEnabled) { _, enabled in
+            // 機能を OFF にしたら再生を停止する
+            if !enabled {
+                streamPlayer.stop()
+            } else if let login = channelManager.selectedChannel {
+                // ON にしたとき、選択中チャンネルがあれば即座に読み込む
+                Task { await streamPlayer.load(login: login) }
+            }
+        }
     }
 }

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
     @State private var isBlankTabOpen: Bool = false
 
     /// ライブ配信プレイヤー機能の有効・無効（SettingsView から変更可能）
-    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
+    @AppStorage(AppStorageKeys.livePlayerEnabled) private var livePlayerEnabled = false
 
     var body: some View {
         NavigationSplitView {

--- a/Sources/TwitchChat/Views/SettingsView.swift
+++ b/Sources/TwitchChat/Views/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
     /// ライブ配信プレイヤー機能の有効・無効（永続化）
     ///
     /// Twitch GQL は非公式 API のため、デフォルト OFF の Opt-in とする。
-    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
+    @AppStorage(AppStorageKeys.livePlayerEnabled) private var livePlayerEnabled = false
 
     var body: some View {
         Form {

--- a/Sources/TwitchChat/Views/SettingsView.swift
+++ b/Sources/TwitchChat/Views/SettingsView.swift
@@ -1,0 +1,32 @@
+// SettingsView.swift
+// アプリケーション設定画面
+// Cmd+, から開く macOS 標準の Settings Scene に対応する
+
+import SwiftUI
+
+/// アプリケーション設定画面
+///
+/// ライブプレイヤー（実験的機能）の Opt-in トグルなどを提供する。
+struct SettingsView: View {
+
+    /// ライブ配信プレイヤー機能の有効・無効（永続化）
+    ///
+    /// Twitch GQL は非公式 API のため、デフォルト OFF の Opt-in とする。
+    @AppStorage("livePlayerEnabled") private var livePlayerEnabled = false
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Twitch ライブ配信を再生する（実験的機能）", isOn: $livePlayerEnabled)
+                Text("Twitch の非公式 API を使用して配信映像を直接再生します。Twitch 利用規約上グレーな機能のため、デフォルトは無効になっています。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } header: {
+                Text("プレイヤー")
+            }
+        }
+        .formStyle(.grouped)
+        .padding()
+        .frame(width: 400, height: 160)
+    }
+}

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -1,15 +1,57 @@
 // StreamPlayerView.swift
 // Twitch ライブ配信 AVPlayer の表示ビュー
 // StreamPlayerViewModel の state に応じてプレイヤーまたはオーバーレイを表示する
+//
+// macOS 26 では SwiftUI の VideoPlayer（_AVKit_SwiftUI 経由）が
+// 'So12AVPlayerViewC' の demangling に失敗してクラッシュするため、
+// AVPlayerView を NSViewRepresentable で直接ラップして回避する。
 
 import AVKit
 import SwiftUI
+
+// MARK: - AVPlayerView NSViewRepresentable ラッパー
+
+/// `intrinsicContentSize` を無効化して SwiftUI のレイアウトに完全に従う `AVPlayerView` サブクラス
+///
+/// 標準の `AVPlayerView` は動画ネイティブ解像度を `intrinsicContentSize` として返し、
+/// SwiftUI の `frame(maxWidth: .infinity)` を上書きしてしまう。
+/// `noIntrinsicMetric` を返すことで SwiftUI が親から受け取ったサイズをそのまま使えるようにする。
+private final class ExpandingAVPlayerView: AVPlayerView {
+    override var intrinsicContentSize: CGSize {
+        CGSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
+    }
+}
+
+/// `AVPlayerView` を SwiftUI から使用するための `NSViewRepresentable` ラッパー
+///
+/// macOS 26 の `_AVKit_SwiftUI` バイナリ互換バグを回避するため、
+/// SwiftUI の `VideoPlayer` の代わりにこのラッパーを使用する。
+private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
+
+    let player: AVPlayer
+
+    func makeNSView(context: Context) -> ExpandingAVPlayerView {
+        let view = ExpandingAVPlayerView()
+        view.player = player
+        view.controlsStyle = .floating
+        view.videoGravity = .resizeAspect
+        return view
+    }
+
+    func updateNSView(_ nsView: ExpandingAVPlayerView, context: Context) {
+        if nsView.player !== player {
+            nsView.player = player
+        }
+    }
+}
+
+// MARK: - StreamPlayerView
 
 /// Twitch ライブ配信を表示するビュー
 ///
 /// `StreamPlayerViewModel` の状態に応じて以下を表示する:
 /// - `.idle` / `.resolving`: ProgressView
-/// - `.playing`: AVKit VideoPlayer（標準コントロール付き）
+/// - `.playing`: AVPlayerView（フローティングコントロール付き）
 /// - `.offline`: オフライン表示
 /// - `.error(message:)`: エラー表示 + 再試行ボタン
 struct StreamPlayerView: View {
@@ -25,7 +67,8 @@ struct StreamPlayerView: View {
                 ProgressView("読み込み中...")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .playing:
-                VideoPlayer(player: viewModel.player)
+                AVPlayerNSViewRepresentable(player: viewModel.player)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             case .offline:
                 offlineView
             case .error(let message):

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -1,0 +1,76 @@
+// StreamPlayerView.swift
+// Twitch ライブ配信 AVPlayer の表示ビュー
+// StreamPlayerViewModel の state に応じてプレイヤーまたはオーバーレイを表示する
+
+import AVKit
+import SwiftUI
+
+/// Twitch ライブ配信を表示するビュー
+///
+/// `StreamPlayerViewModel` の状態に応じて以下を表示する:
+/// - `.idle` / `.resolving`: ProgressView
+/// - `.playing`: AVKit VideoPlayer（標準コントロール付き）
+/// - `.offline`: オフライン表示
+/// - `.error(message:)`: エラー表示 + 再試行ボタン
+struct StreamPlayerView: View {
+
+    var viewModel: StreamPlayerViewModel
+
+    var body: some View {
+        Group {
+            switch viewModel.state {
+            case .idle:
+                idleView
+            case .resolving:
+                ProgressView("読み込み中...")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .playing:
+                VideoPlayer(player: viewModel.player)
+            case .offline:
+                offlineView
+            case .error(let message):
+                errorView(message: message)
+            }
+        }
+        .background(Color.black)
+    }
+
+    // MARK: - サブビュー
+
+    private var idleView: some View {
+        Color.black
+    }
+
+    private var offlineView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tv.slash")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+            Text("オフライン")
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+    }
+
+    private func errorView(message: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.circle")
+                .font(.system(size: 40))
+                .foregroundStyle(.red)
+            Text("再生できません")
+                .fontWeight(.medium)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+            Button("再試行") {
+                Task { await viewModel.retry() }
+            }
+            .buttonStyle(.bordered)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+    }
+}

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -50,7 +50,8 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
 /// Twitch ライブ配信を表示するビュー
 ///
 /// `StreamPlayerViewModel` の状態に応じて以下を表示する:
-/// - `.idle` / `.resolving`: ProgressView
+/// - `.idle`: 黒背景（Color.black）
+/// - `.resolving`: ProgressView（読み込み中）
 /// - `.playing`: AVPlayerView（フローティングコントロール付き）
 /// - `.offline`: オフライン表示
 /// - `.error(message:)`: エラー表示 + 再試行ボタン

--- a/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
+++ b/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
@@ -1,0 +1,241 @@
+// StreamPlaybackResolverTests.swift
+// StreamPlaybackResolver の単体テスト
+// MockTwitchPlaybackTokenClient を使ってネットワーク通信なしで URL 構築・エラー伝搬・login 正規化を検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// TwitchPlaybackTokenClient のモック実装
+actor MockTwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
+
+    /// 返すトークン（正常ケース用）
+    var tokenToReturn: StreamPlaybackToken?
+    /// 投げるエラー（nil の場合はトークンを返す）
+    var errorToThrow: PlaybackError?
+    /// fetchLiveToken が呼ばれたときの login キャプチャ（検証用）
+    private(set) var capturedLogins: [String] = []
+
+    func fetchLiveToken(login: String) async throws -> StreamPlaybackToken {
+        capturedLogins.append(login)
+        if let error = errorToThrow {
+            throw error
+        }
+        guard let token = tokenToReturn else {
+            throw PlaybackError.tokenDecodingFailed
+        }
+        return token
+    }
+}
+
+// MARK: - テストデータファクトリ
+
+/// テスト用 StreamPlaybackToken を生成する
+private func makeToken(
+    value: String = "テスト用トークン値",
+    signature: String = "テスト用シグネチャ"
+) -> StreamPlaybackToken {
+    StreamPlaybackToken(value: value, signature: signature)
+}
+
+// MARK: - テスト
+
+@Suite("StreamPlaybackResolver テスト")
+struct StreamPlaybackResolverTests {
+
+    // MARK: - login 正規化テスト
+
+    @Test("login が大文字を含む場合も小文字化して GQL クライアントに渡す")
+    func normalizesLoginToLowercase() async throws {
+        // 前提: 大文字混じりの login を渡したとき、GQL クライアントには小文字で渡ること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        _ = try await resolver.resolve(login: "NijisanjiJP")
+
+        let logins = await tokenClient.capturedLogins
+        #expect(logins.first == "nijisanjijp", "小文字化されていない: \(logins.first ?? "nil")")
+    }
+
+    @Test("小文字のみの login はそのまま渡される")
+    func keepsLowercaseLogin() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        _ = try await resolver.resolve(login: "argstar")
+
+        let logins = await tokenClient.capturedLogins
+        #expect(logins.first == "argstar")
+    }
+
+    // MARK: - Usher URL 構築テスト
+
+    @Test("Usher URL のホストが usher.ttvnw.net である")
+    func usherUrlHasCorrectHost() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken(value: "テストトークン", signature: "テストシグネチャ"))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "配信者テスト")
+
+        #expect(manifest.url.host == "usher.ttvnw.net")
+    }
+
+    @Test("Usher URL に login が含まれる")
+    func usherUrlContainsLogin() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "forsen")
+
+        #expect(manifest.url.path.contains("forsen"), "URL に login が含まれていない: \(manifest.url)")
+    }
+
+    @Test("Usher URL に sig クエリパラメータが含まれる")
+    func usherUrlContainsSigParam() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken(value: "テストトークン", signature: "シグネチャabc123"))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "テストチャンネル")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let sigValue = components?.queryItems?.first(where: { $0.name == "sig" })?.value
+        #expect(sigValue == "シグネチャabc123", "sig クエリが見つからない: \(manifest.url)")
+    }
+
+    @Test("Usher URL に token クエリパラメータが含まれる")
+    func usherUrlContainsTokenParam() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken(value: "jwt.テスト.トークン", signature: "sig"))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "テストチャンネル")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let tokenValue = components?.queryItems?.first(where: { $0.name == "token" })?.value
+        #expect(tokenValue == "jwt.テスト.トークン", "token クエリが見つからない: \(manifest.url)")
+    }
+
+    @Test("token に + や / が含まれていても URL クエリとして正しくエンコードされる")
+    func encodesSpecialCharactersInToken() async throws {
+        // Twitch の JWT トークンは Base64url 文字を含む場合がある
+        let specialToken = "eyJhb+GCI6IkpXV/CJ9.payload.sig"
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken(value: specialToken, signature: "sig"))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "テストチャンネル")
+
+        // URL として有効であること（パース可能）
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let tokenValue = components?.queryItems?.first(where: { $0.name == "token" })?.value
+        // URLComponents がデコードして元の値に戻ること
+        #expect(tokenValue == specialToken, "特殊文字のエンコードが不正: \(manifest.url)")
+    }
+
+    @Test("play_session_id クエリパラメータが呼び出しごとに別 UUID になる")
+    func playSessionIdIsUniquePerCall() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest1 = try await resolver.resolve(login: "argstar")
+        let manifest2 = try await resolver.resolve(login: "argstar")
+
+        let components1 = URLComponents(url: manifest1.url, resolvingAgainstBaseURL: false)
+        let components2 = URLComponents(url: manifest2.url, resolvingAgainstBaseURL: false)
+        let sessionId1 = components1?.queryItems?.first(where: { $0.name == "play_session_id" })?.value
+        let sessionId2 = components2?.queryItems?.first(where: { $0.name == "play_session_id" })?.value
+
+        #expect(sessionId1 != nil, "play_session_id が nil")
+        #expect(sessionId2 != nil, "play_session_id が nil")
+        #expect(sessionId1 != sessionId2, "play_session_id が毎回同じ値: \(sessionId1 ?? "")")
+    }
+
+    @Test("返却された manifest に fetchedAt タイムスタンプが設定される")
+    func manifestHasFetchedAt() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let before = Date()
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+        let manifest = try await resolver.resolve(login: "argstar")
+        let after = Date()
+
+        #expect(manifest.fetchedAt >= before)
+        #expect(manifest.fetchedAt <= after)
+    }
+
+    // MARK: - エラー伝搬テスト
+
+    @Test("tokenDecodingFailed はそのまま再スローされる")
+    func propagatesTokenDecodingFailed() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setError(.tokenDecodingFailed)
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+
+        do {
+            _ = try await resolver.resolve(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenDecodingFailed)
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("tokenRequestFailed はそのまま再スローされる")
+    func propagatesTokenRequestFailed() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setError(.tokenRequestFailed(statusCode: 500))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+
+        do {
+            _ = try await resolver.resolve(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenRequestFailed(statusCode: 500))
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("network エラーはそのまま再スローされる")
+    func propagatesNetworkError() async throws {
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setError(.network(URLError(.notConnectedToInternet)))
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient)
+
+        do {
+            _ = try await resolver.resolve(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .network(URLError(.notConnectedToInternet)))
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+}
+
+// MARK: - MockTwitchPlaybackTokenClient セッターヘルパー
+
+extension MockTwitchPlaybackTokenClient {
+    func setToken(_ token: StreamPlaybackToken) {
+        self.tokenToReturn = token
+        self.errorToThrow = nil
+    }
+
+    func setError(_ error: PlaybackError) {
+        self.errorToThrow = error
+        self.tokenToReturn = nil
+    }
+}

--- a/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
+++ b/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
@@ -21,8 +21,46 @@ actor MockStreamPlaybackResolver: StreamPlaybackResolverProtocol {
     /// resolve が呼ばれた回数
     var callCount: Int { capturedLogins.count }
 
+    // MARK: - ブロッキングサポート（in-flight 競合テスト用）
+
+    /// 次の resolve をサスペンドするかどうか
+    private var shouldSuspend = false
+    /// サスペンド中の continuation（unblock/キャンセルで resume する）
+    private var blockedContinuation: CheckedContinuation<StreamPlaybackManifest, Error>?
+    /// サスペンド到達を呼び出し元に通知する continuation
+    private var onSuspendedContinuation: CheckedContinuation<Void, Never>?
+
+    /// 次の resolve をサスペンドするよう予約する
+    func suspendNextResolve() {
+        shouldSuspend = true
+    }
+
+    /// resolve がサスペンド状態に入るまで待機する（テストの同期に使用）
+    func waitUntilSuspended() async {
+        await withCheckedContinuation { cont in
+            onSuspendedContinuation = cont
+        }
+    }
+
     func resolve(login: String) async throws -> StreamPlaybackManifest {
         capturedLogins.append(login)
+        if shouldSuspend {
+            shouldSuspend = false
+            // 呼び出し元に「サスペンド到達」を通知
+            onSuspendedContinuation?.resume()
+            onSuspendedContinuation = nil
+            // キャンセル時に continuation を resume して CancellationError を伝播する
+            return try await withTaskCancellationHandler(
+                operation: {
+                    try await withCheckedThrowingContinuation { cont in
+                        self.blockedContinuation = cont
+                    }
+                },
+                onCancel: {
+                    Task { await self.resumeBlockedWithCancellation() }
+                }
+            )
+        }
         if let error = errorToThrow {
             throw error
         }
@@ -30,6 +68,12 @@ actor MockStreamPlaybackResolver: StreamPlaybackResolverProtocol {
             throw PlaybackError.channelOffline
         }
         return manifest
+    }
+
+    /// ブロック中の continuation をキャンセルエラーで resume する
+    private func resumeBlockedWithCancellation() {
+        blockedContinuation?.resume(throwing: CancellationError())
+        blockedContinuation = nil
     }
 }
 
@@ -60,18 +104,15 @@ struct StreamPlayerViewModelTests {
 
     // MARK: - load テスト
 
-    @Test("load 開始直後の state は resolving になる")
-    func stateIsResolvingDuringLoad() async throws {
-        // 前提: resolver の呼び出しを確認するため、resolve 完了を確認するだけでよい
+    @Test("resolve 成功後 state は playing になる")
+    func stateIsPlayingAfterLoad() async throws {
         let resolver = MockStreamPlaybackResolver()
         await resolver.setManifest(makeManifest())
 
         let viewModel = StreamPlayerViewModel(resolver: resolver)
-        // Task で非同期に load を走らせて、resolving 状態をキャプチャするのは
-        // タイミング依存のため、ここでは resolve 完了後の最終状態のみ確認する
         await viewModel.load(login: "argstar")
-        // load 完了後は playing 状態（AVPlayer の status は wait しない）
-        #expect(viewModel.state != .idle)
+
+        #expect(viewModel.state == .playing)
     }
 
     @Test("resolve 成功後 currentLogin が更新される")
@@ -159,16 +200,35 @@ struct StreamPlayerViewModelTests {
 
     // MARK: - 重複 load テスト
 
-    @Test("load 中に別 login で load を呼んでも currentLogin は最後の値になる")
-    func secondLoadOverridesFirst() async throws {
+    @Test("load 中に別 login で load を呼ぶと前のロードがキャンセルされ最後の login だけが反映される")
+    func secondLoadCancelsFirstInFlight() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+        // 1回目の resolve をサスペンドして in-flight 状態を作る
+        await resolver.suspendNextResolve()
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+
+        // 1回目の load を Task で開始（await せず in-flight のまま保持）
+        let firstLoadTask = Task { await viewModel.load(login: "argstar") }
+        // resolver がサスペンド到達するまで待機（確実な同期）
+        await resolver.waitUntilSuspended()
+
+        // 2回目の load を呼ぶ（1回目がキャンセルされ、2回目が優先される）
+        await viewModel.load(login: "forsen")
+        await firstLoadTask.value
+
+        #expect(viewModel.currentLogin == "forsen")
+    }
+
+    @Test("複数回 load を順番に呼んでも currentLogin は最後の値になる")
+    func sequentialLoadsUpdateCurrentLogin() async throws {
         let resolver = MockStreamPlaybackResolver()
         await resolver.setManifest(makeManifest())
 
         let viewModel = StreamPlayerViewModel(resolver: resolver)
 
-        // 最初の load
         await viewModel.load(login: "argstar")
-        // 別チャンネルで再 load
         await viewModel.load(login: "forsen")
 
         #expect(viewModel.currentLogin == "forsen")

--- a/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
+++ b/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
@@ -1,0 +1,190 @@
+// StreamPlayerViewModelTests.swift
+// StreamPlayerViewModel の単体テスト
+// MockStreamPlaybackResolver を使ってネットワーク通信なしで state 遷移・AVPlayer 設定を検証する
+
+import AVFoundation
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// StreamPlaybackResolver のモック実装
+actor MockStreamPlaybackResolver: StreamPlaybackResolverProtocol {
+
+    /// 返すマニフェスト（正常ケース用）
+    var manifestToReturn: StreamPlaybackManifest?
+    /// 投げるエラー（nil の場合はマニフェストを返す）
+    var errorToThrow: PlaybackError?
+    /// resolve が呼ばれた login をキャプチャ（検証用）
+    private(set) var capturedLogins: [String] = []
+    /// resolve が呼ばれた回数
+    var callCount: Int { capturedLogins.count }
+
+    func resolve(login: String) async throws -> StreamPlaybackManifest {
+        capturedLogins.append(login)
+        if let error = errorToThrow {
+            throw error
+        }
+        guard let manifest = manifestToReturn else {
+            throw PlaybackError.channelOffline
+        }
+        return manifest
+    }
+}
+
+// MARK: - テストデータファクトリ
+
+/// テスト用 StreamPlaybackManifest を生成する
+private func makeManifest(url: URL = URL(string: "https://usher.ttvnw.net/api/channel/hls/argstar.m3u8?sig=s&token=t")!) -> StreamPlaybackManifest {
+    StreamPlaybackManifest(url: url, fetchedAt: Date())
+}
+
+// MARK: - テスト
+
+@Suite("StreamPlayerViewModel テスト")
+@MainActor
+struct StreamPlayerViewModelTests {
+
+    // MARK: - 初期状態テスト
+
+    @Test("初期状態は idle である")
+    func initialStateIsIdle() {
+        let resolver = MockStreamPlaybackResolver()
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+
+        #expect(viewModel.state == .idle)
+        #expect(viewModel.currentLogin == nil)
+        #expect(viewModel.player.currentItem == nil)
+    }
+
+    // MARK: - load テスト
+
+    @Test("load 開始直後の state は resolving になる")
+    func stateIsResolvingDuringLoad() async throws {
+        // 前提: resolver の呼び出しを確認するため、resolve 完了を確認するだけでよい
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        // Task で非同期に load を走らせて、resolving 状態をキャプチャするのは
+        // タイミング依存のため、ここでは resolve 完了後の最終状態のみ確認する
+        await viewModel.load(login: "argstar")
+        // load 完了後は playing 状態（AVPlayer の status は wait しない）
+        #expect(viewModel.state != .idle)
+    }
+
+    @Test("resolve 成功後 currentLogin が更新される")
+    func currentLoginIsUpdatedAfterSuccess() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+
+        #expect(viewModel.currentLogin == "argstar")
+    }
+
+    @Test("resolve 成功後 player.currentItem に AVURLAsset が設定される")
+    func playerItemIsSetAfterSuccess() async throws {
+        let testURL = URL(string: "https://usher.ttvnw.net/api/channel/hls/forsen.m3u8?sig=s&token=t")!
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest(url: testURL))
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "forsen")
+
+        guard let asset = viewModel.player.currentItem?.asset as? AVURLAsset else {
+            Issue.record("player.currentItem の asset が AVURLAsset ではない")
+            return
+        }
+        #expect(asset.url == testURL)
+    }
+
+    @Test("channelOffline エラーで state は offline になる")
+    func stateIsOfflineOnChannelOfflineError() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setError(.channelOffline)
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "オフラインチャンネル")
+
+        #expect(viewModel.state == .offline)
+    }
+
+    @Test("tokenDecodingFailed エラーで state は error になる")
+    func stateIsErrorOnTokenDecodingFailed() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setError(.tokenDecodingFailed)
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "テストチャンネル")
+
+        if case .error = viewModel.state {
+            // エラー状態になっていればよい
+        } else {
+            Issue.record("state が error でない: \(viewModel.state)")
+        }
+    }
+
+    @Test("geoOrSubscriberRestricted エラーで state は error になる")
+    func stateIsErrorOnGeoOrSubscriberRestricted() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setError(.geoOrSubscriberRestricted)
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "サブスク限定チャンネル")
+
+        if case .error = viewModel.state {
+            // エラー状態になっていればよい
+        } else {
+            Issue.record("state が error でない: \(viewModel.state)")
+        }
+    }
+
+    // MARK: - stop テスト
+
+    @Test("stop() で player.currentItem が nil になる")
+    func stopClearsPlayerItem() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+        viewModel.stop()
+
+        #expect(viewModel.player.currentItem == nil)
+        #expect(viewModel.state == .idle)
+    }
+
+    // MARK: - 重複 load テスト
+
+    @Test("load 中に別 login で load を呼んでも currentLogin は最後の値になる")
+    func secondLoadOverridesFirst() async throws {
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+
+        // 最初の load
+        await viewModel.load(login: "argstar")
+        // 別チャンネルで再 load
+        await viewModel.load(login: "forsen")
+
+        #expect(viewModel.currentLogin == "forsen")
+    }
+}
+
+// MARK: - MockStreamPlaybackResolver セッターヘルパー
+
+extension MockStreamPlaybackResolver {
+    func setManifest(_ manifest: StreamPlaybackManifest) {
+        self.manifestToReturn = manifest
+        self.errorToThrow = nil
+    }
+
+    func setError(_ error: PlaybackError) {
+        self.errorToThrow = error
+        self.manifestToReturn = nil
+    }
+}

--- a/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
@@ -1,0 +1,278 @@
+// TwitchPlaybackTokenClientTests.swift
+// TwitchPlaybackTokenClient の単体テスト
+// MockURLSessionDataFetcher を使ってネットワーク通信なしで GQL リクエスト整形・レスポンスデコード・エラーパスを検証する
+
+import Foundation
+import Testing
+@testable import TwitchChat
+
+// MARK: - テスト用モック
+
+/// URLSessionDataFetcher のモック実装
+///
+/// スタブレスポンスを返し、受け取ったリクエストをキャプチャして検証に使用する
+actor MockURLSessionDataFetcher: URLSessionDataFetcher {
+
+    /// 返すレスポンスデータと HTTP ステータスコード（正常ケース用）
+    struct Stub {
+        let statusCode: Int
+        let data: Data
+    }
+
+    /// スタブとして返す成功レスポンス（nil の場合はエラーを投げる）
+    var stub: Stub?
+    /// 投げる URLError（nil の場合はスタブデータを返す）
+    var stubbedError: URLError?
+    /// キャプチャしたリクエスト（検証用）
+    private(set) var capturedRequests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        capturedRequests.append(request)
+
+        if let error = stubbedError {
+            throw error
+        }
+
+        guard let stub else {
+            throw URLError(.badServerResponse)
+        }
+
+        let response = HTTPURLResponse(
+            url: request.url!,
+            statusCode: stub.statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (stub.data, response)
+    }
+}
+
+// MARK: - テストデータファクトリ
+
+/// 正常な GQL PlaybackAccessToken レスポンス JSON データを生成する
+private func makeSuccessResponseData(value: String = "テスト用トークン値", signature: String = "テスト用シグネチャ") -> Data {
+    let json = """
+    {
+        "data": {
+            "streamPlaybackAccessToken": {
+                "value": "\(value)",
+                "signature": "\(signature)"
+            }
+        }
+    }
+    """
+    return json.data(using: .utf8)!
+}
+
+// MARK: - テスト
+
+@Suite("TwitchPlaybackTokenClient テスト")
+struct TwitchPlaybackTokenClientTests {
+
+    // MARK: - デコードテスト
+
+    @Test("GQL レスポンスから value と signature をデコードできる")
+    func decodesValueAndSignatureFromSuccessResponse() async throws {
+        // 前提: 正常な GQL レスポンスを返すモック
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData(
+            value: "テスト用トークン値",
+            signature: "テスト用シグネチャabc123"
+        )))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        let token = try await client.fetchLiveToken(login: "テストチャンネル")
+
+        #expect(token.value == "テスト用トークン値")
+        #expect(token.signature == "テスト用シグネチャabc123")
+    }
+
+    @Test("login が大文字を含む場合も小文字化して GQL に送信する")
+    func normalizesLoginToLowercase() async throws {
+        // 前提: 大文字混じりの login を渡した場合も、リクエストボディは小文字になること
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client.fetchLiveToken(login: "NijisanjiJP")
+
+        // キャプチャしたリクエストボディで login が小文字化されているか確認
+        let requests = await fetcher.capturedRequests
+        guard let bodyData = requests.first?.httpBody,
+              let bodyString = String(data: bodyData, encoding: .utf8) else {
+            Issue.record("リクエストボディが nil")
+            return
+        }
+        #expect(bodyString.contains("\"nijisanjijp\""), "login が小文字化されていない: \(bodyString)")
+    }
+
+    @Test("GQL リクエストに Client-Id ヘッダーが付与される")
+    func addsClientIdHeader() async throws {
+        // 前提: 任意の clientID を指定したとき、リクエストヘッダーに反映されること
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テスト専用クライアントID")
+        _ = try await client.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        let headers = requests.first?.allHTTPHeaderFields ?? [:]
+        #expect(headers["Client-Id"] == "テスト専用クライアントID", "Client-Id ヘッダーが設定されていない: \(headers)")
+    }
+
+    @Test("GQL リクエストのメソッドは POST である")
+    func requestMethodIsPost() async throws {
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client.fetchLiveToken(login: "forsen")
+
+        let requests = await fetcher.capturedRequests
+        #expect(requests.first?.httpMethod == "POST")
+    }
+
+    // MARK: - エラーパステスト
+
+    @Test("HTTP 401 のとき tokenRequestFailed(statusCode: 401) を投げる")
+    func throws401Error() async throws {
+        // 前提: 401 レスポンスを返すモック
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 401, data: Data()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+
+        do {
+            _ = try await client.fetchLiveToken(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenRequestFailed(statusCode: 401))
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("HTTP 403 のとき tokenRequestFailed(statusCode: 403) を投げる")
+    func throws403Error() async throws {
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 403, data: Data()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+
+        do {
+            _ = try await client.fetchLiveToken(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenRequestFailed(statusCode: 403))
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("空ボディが返ったとき tokenDecodingFailed を投げる")
+    func throwsDecodingFailedOnEmptyBody() async throws {
+        // 前提: ステータス 200 だがボディが空（デコード不能）
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: Data()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+
+        do {
+            _ = try await client.fetchLiveToken(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenDecodingFailed)
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("不正な JSON が返ったとき tokenDecodingFailed を投げる")
+    func throwsDecodingFailedOnMalformedJSON() async throws {
+        // 前提: 200 だが GQL レスポンス形式と異なる JSON
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: #"{"unexpected": "structure"}"#.data(using: .utf8)!))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+
+        do {
+            _ = try await client.fetchLiveToken(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .tokenDecodingFailed)
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+
+    @Test("ネットワーク切断時は network(URLError) を投げる")
+    func throwsNetworkErrorOnConnectionFailure() async throws {
+        // 前提: ネットワーク接続なし（notConnectedToInternet）をシミュレート
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStubbedError(URLError(.notConnectedToInternet))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+
+        do {
+            _ = try await client.fetchLiveToken(login: "テストチャンネル")
+            Issue.record("エラーが throw されなかった")
+        } catch let error as PlaybackError {
+            #expect(error == .network(URLError(.notConnectedToInternet)))
+        } catch {
+            Issue.record("予期しないエラー型: \(error)")
+        }
+    }
+}
+
+// MARK: - MockURLSessionDataFetcher セッターヘルパー
+
+extension MockURLSessionDataFetcher {
+    func setStub(_ stub: Stub) {
+        self.stub = stub
+        self.stubbedError = nil
+    }
+
+    func setStubbedError(_ error: URLError) {
+        self.stubbedError = error
+        self.stub = nil
+    }
+}
+
+// MARK: - StreamPlaybackToken デコードテスト
+
+@Suite("GQLPlaybackTokenResponse デコードテスト")
+struct GQLPlaybackTokenResponseTests {
+
+    @Test("正常な GQL JSON を GQLPlaybackTokenResponse にデコードできる")
+    func decodesFullGQLResponse() throws {
+        // Twitch GQL の実際のレスポンス形式に近いデータ
+        let json = """
+        {
+            "data": {
+                "streamPlaybackAccessToken": {
+                    "value": "{\\"channel\\":\\"argstar\\",\\"exp\\":9999999999}",
+                    "signature": "abcdef1234567890"
+                }
+            }
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let response = try JSONDecoder().decode(GQLPlaybackTokenResponse.self, from: data)
+
+        #expect(response.data.streamPlaybackAccessToken.value.contains("argstar"))
+        #expect(response.data.streamPlaybackAccessToken.signature == "abcdef1234567890")
+    }
+
+    @Test("streamPlaybackAccessToken フィールドがないとデコードエラーになる")
+    func failsDecodingWhenFieldMissing() {
+        let json = #"{"data": {}}"#.data(using: .utf8)!
+
+        do {
+            _ = try JSONDecoder().decode(GQLPlaybackTokenResponse.self, from: json)
+            Issue.record("デコードエラーが throw されなかった")
+        } catch {
+            // DecodingError が throw されればよい
+            #expect(error is DecodingError)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Twitch GQL `PlaybackAccessToken` API で HLS マニフェスト URL を取得する `TwitchPlaybackTokenClient`（actor）を新設
- GQL トークンから Usher URL を組み立てる `StreamPlaybackResolver`（actor）を新設
- `AVPlayer` の state 遷移（idle/resolving/playing/offline/error）を管理する `StreamPlayerViewModel` を新設
- `ChatDetailView` を `VSplitView` で上=プレイヤー / 下=チャット構造に再構成
- `SettingsView`（Cmd+, 環境設定）に「ライブ配信を再生する（実験的機能）」トグルを追加
- デフォルト OFF の Opt-in 設計。チャンネル切替に追従してプレイヤーが自動更新される

## 設計上の注意

- Twitch GQL は非公式 API のため利用規約上グレー。設定画面に注意書きを表示し、デフォルト OFF にしている
- GQL persisted query ハッシュ（`0828119d...`）は Twitch Web 更新で変わる可能性があり、`TwitchPlaybackTokenClient.liveQueryHash` に集約して管理している
- 匿名アクセス（Bearer なし）のため、サブスク限定配信は視聴不可（`geoOrSubscriberRestricted` エラーを表示）
- VOD 再生は将来の別 PR（Phase 5）に分離

## Test plan

- [x] `swift build` 警告なし
- [x] 今回追加した 32 件のテストがすべてグリーン（TwitchPlaybackTokenClient 11件・StreamPlaybackResolver 12件・StreamPlayerViewModel 9件）
- [x] `swiftlint lint` 警告ゼロ
- [ ] 手動 QA: 設定 ON → 配信中チャンネル選択 → 5秒以内に映像再生開始
- [ ] 手動 QA: チャンネル切替で再生対象が連動すること
- [ ] 手動 QA: オフラインチャンネル選択で「オフライン」表示
- [ ] 手動 QA: 設定 OFF に戻すとプレイヤーが非表示になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Twitchのライブストリームをアプリ内で視聴できるライブプレイヤーを追加しました
  * 設定画面からライブプレイヤー機能の有効/無効を切り替えられます
  * ストリーム再生のエラーハンドリングと再試行機能に対応しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->