### PR TITLE
feat: PlaybackOptions 導入と Usher URL への low_latency=true 付与 (LL-HLS PR-1)

### DIFF
--- a/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
+++ b/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
@@ -1,0 +1,24 @@
+// PlaybackOptions.swift
+// HLS 再生時の Usher URL 組み立てオプション
+// Low-Latency モードやコーデック指定を一元管理する
+
+import Foundation
+
+/// Twitch ライブ配信 HLS 再生オプション
+///
+/// Usher URL のクエリパラメータに影響する設定を保持する。
+/// UI なし方針のため、現在は `default` を常時使用する。
+struct PlaybackOptions: Sendable {
+
+    /// `low_latency=true` クエリを Usher URL に付与するかどうか
+    let lowLatencyEnabled: Bool
+
+    /// `supported_codecs` クエリに使用するコーデックリスト（カンマ連結される）
+    let supportedCodecs: [String]
+
+    /// デフォルト設定（Low Latency 有効、AVC1 のみ）
+    static let `default` = PlaybackOptions(
+        lowLatencyEnabled: true,
+        supportedCodecs: ["avc1"]
+    )
+}

--- a/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
+++ b/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
@@ -7,14 +7,27 @@ import Foundation
 /// Twitch ライブ配信 HLS 再生オプション
 ///
 /// Usher URL のクエリパラメータに影響する設定を保持する。
-/// UI なし方針のため、現在は `default` を常時使用する。
+/// 基本設定は `default` だが、テスト用途や将来の UI・機能拡張に備えて差し替え可能。
 struct PlaybackOptions: Sendable {
 
     /// `low_latency=true` クエリを Usher URL に付与するかどうか
     let lowLatencyEnabled: Bool
 
     /// `supported_codecs` クエリに使用するコーデックリスト（カンマ連結される）
+    ///
+    /// 空文字・空白のみのエントリは除去される。全て無効な場合は `["avc1"]` にフォールバックする。
     let supportedCodecs: [String]
+
+    /// - Parameters:
+    ///   - lowLatencyEnabled: `low_latency=true` を付与するかどうか
+    ///   - supportedCodecs: 対応コーデックリスト（空文字・空白は除去、空の場合は `["avc1"]` にフォールバック）
+    init(lowLatencyEnabled: Bool, supportedCodecs: [String]) {
+        let normalized = supportedCodecs
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        self.lowLatencyEnabled = lowLatencyEnabled
+        self.supportedCodecs = normalized.isEmpty ? ["avc1"] : normalized
+    }
 
     /// デフォルト設定（Low Latency 有効、AVC1 のみ）
     static let `default` = PlaybackOptions(

--- a/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
+++ b/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
@@ -36,14 +36,21 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
     // MARK: - プロパティ
 
     private let tokenClient: any TwitchPlaybackTokenClientProtocol
+    private let options: PlaybackOptions
 
     // MARK: - 初期化
 
     /// `StreamPlaybackResolver` を初期化する
     ///
-    /// - Parameter tokenClient: GQL アクセストークン取得クライアント
-    init(tokenClient: any TwitchPlaybackTokenClientProtocol = TwitchPlaybackTokenClient()) {
+    /// - Parameters:
+    ///   - tokenClient: GQL アクセストークン取得クライアント
+    ///   - options: HLS 再生オプション（省略時は `.default`）
+    init(
+        tokenClient: any TwitchPlaybackTokenClientProtocol = TwitchPlaybackTokenClient(),
+        options: PlaybackOptions = .default
+    ) {
         self.tokenClient = tokenClient
+        self.options = options
     }
 
     // MARK: - 公開メソッド
@@ -67,7 +74,7 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
             throw PlaybackError.badURL
         }
 
-        components.queryItems = [
+        var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "allow_source", value: "true"),
             URLQueryItem(name: "fast_bread", value: "true"),
             URLQueryItem(name: "p", value: String(Int.random(in: 100000...999999))),
@@ -76,11 +83,17 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
             URLQueryItem(name: "playlist_include_framerate", value: "true"),
             URLQueryItem(name: "reassignments_supported", value: "true"),
             URLQueryItem(name: "sig", value: token.signature),
-            URLQueryItem(name: "supported_codecs", value: "avc1"),
+            URLQueryItem(name: "supported_codecs", value: options.supportedCodecs.joined(separator: ",")),
             URLQueryItem(name: "token", value: token.value),
             URLQueryItem(name: "cdm", value: "wv"),
             URLQueryItem(name: "player_version", value: "1.27.0")
         ]
+
+        if options.lowLatencyEnabled {
+            queryItems.append(URLQueryItem(name: "low_latency", value: "true"))
+        }
+
+        components.queryItems = queryItems
 
         guard let url = components.url else {
             throw PlaybackError.badURL

--- a/Tests/TwitchChatTests/PlaybackOptionsTests.swift
+++ b/Tests/TwitchChatTests/PlaybackOptionsTests.swift
@@ -33,4 +33,34 @@ struct PlaybackOptionsTests {
         let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: ["avc1", "hevc"])
         #expect(options.supportedCodecs == ["avc1", "hevc"])
     }
+
+    // MARK: - バリデーションテスト
+
+    @Test("supportedCodecs に空文字が含まれる場合は除去される")
+    func emptyStringCodecIsFiltered() {
+        // 前提: ["avc1", ""] のように空文字を含む配列を渡したとき
+        // 検証: supportedCodecs から空文字が除去されること
+        let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: ["avc1", ""])
+        #expect(options.supportedCodecs == ["avc1"])
+    }
+
+    @Test("supportedCodecs がスペースのみのコーデックを含む場合は除去される")
+    func whitespaceOnlyCodecIsFiltered() {
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["  ", "avc1"])
+        #expect(options.supportedCodecs == ["avc1"])
+    }
+
+    @Test("supportedCodecs が全て無効な場合は avc1 にフォールバックする")
+    func emptyCodecsFallbackToAvc1() {
+        // 前提: 空配列または空文字のみを渡したとき
+        // 検証: supportedCodecs が ["avc1"] にフォールバックすること
+        let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: [])
+        #expect(options.supportedCodecs == ["avc1"])
+    }
+
+    @Test("supportedCodecs の各コーデックは前後のスペースがトリムされる")
+    func codecsAreTrimmed() {
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: [" avc1 ", "hevc"])
+        #expect(options.supportedCodecs == ["avc1", "hevc"])
+    }
 }

--- a/Tests/TwitchChatTests/PlaybackOptionsTests.swift
+++ b/Tests/TwitchChatTests/PlaybackOptionsTests.swift
@@ -1,0 +1,36 @@
+// PlaybackOptionsTests.swift
+// PlaybackOptions の単体テスト
+// デフォルト値および各フィールドの初期化・挙動を検証する
+
+import Testing
+@testable import TwitchChat
+
+@Suite("PlaybackOptions テスト")
+struct PlaybackOptionsTests {
+
+    @Test("PlaybackOptions.default は lowLatencyEnabled が true である")
+    func defaultIsLowLatencyEnabled() {
+        // PlaybackOptions.default を使うと低遅延モードが有効になること
+        let options = PlaybackOptions.default
+        #expect(options.lowLatencyEnabled == true)
+    }
+
+    @Test("PlaybackOptions.default の supportedCodecs は avc1 のみ")
+    func defaultSupportedCodecsIsAvc1Only() {
+        // デフォルトのコーデックは avc1 のみであること
+        let options = PlaybackOptions.default
+        #expect(options.supportedCodecs == ["avc1"])
+    }
+
+    @Test("lowLatencyEnabled=false で初期化すると低遅延モードが無効になる")
+    func initWithLowLatencyDisabled() {
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1"])
+        #expect(options.lowLatencyEnabled == false)
+    }
+
+    @Test("supportedCodecs に複数コーデックを指定して初期化できる")
+    func initWithMultipleCodecs() {
+        let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: ["avc1", "hevc"])
+        #expect(options.supportedCodecs == ["avc1", "hevc"])
+    }
+}

--- a/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
+++ b/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
@@ -172,6 +172,55 @@ struct StreamPlaybackResolverTests {
         #expect(manifest.fetchedAt <= after)
     }
 
+    // MARK: - PlaybackOptions テスト
+
+    @Test("PlaybackOptions.default で resolve すると low_latency=true クエリが付与される")
+    func defaultOptionsIncludesLowLatencyParam() async throws {
+        // 前提: PlaybackOptions.default の lowLatencyEnabled は true
+        // 検証: Usher URL に low_latency=true クエリが含まれること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let lowLatencyValue = components?.queryItems?.first(where: { $0.name == "low_latency" })?.value
+        #expect(lowLatencyValue == "true", "low_latency=true が含まれていない: \(manifest.url)")
+    }
+
+    @Test("PlaybackOptions(lowLatencyEnabled: false) のとき low_latency クエリは付与されない")
+    func disabledLowLatencyExcludesParam() async throws {
+        // 前提: lowLatencyEnabled=false の PlaybackOptions を渡したとき
+        // 検証: Usher URL に low_latency クエリが含まれないこと
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1"])
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: options)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let hasLowLatency = components?.queryItems?.contains(where: { $0.name == "low_latency" }) ?? false
+        #expect(!hasLowLatency, "low_latency クエリが含まれてしまっている: \(manifest.url)")
+    }
+
+    @Test("supportedCodecs が複数のとき supported_codecs はカンマ連結される")
+    func multipleCodecsAreJoinedWithComma() async throws {
+        // 前提: ["avc1", "hevc"] を supportedCodecs に指定したとき
+        // 検証: supported_codecs=avc1,hevc としてクエリに含まれること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1", "hevc"])
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: options)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let codecsValue = components?.queryItems?.first(where: { $0.name == "supported_codecs" })?.value
+        #expect(codecsValue == "avc1,hevc", "supported_codecs が期待値と異なる: \(codecsValue ?? "nil")")
+    }
+
     // MARK: - エラー伝搬テスト
 
     @Test("tokenDecodingFailed はそのまま再スローされる")


### PR DESCRIPTION
## 概要

Twitch LL-HLS 対応の段階的実装 PR-1。
`PlaybackOptions` struct を新設し、`StreamPlaybackResolver` が `low_latency` および `supported_codecs` クエリをオプション経由で制御できるようにします。

## 変更内容

- `Sources/TwitchChat/Models/Playback/PlaybackOptions.swift`（新設）: `lowLatencyEnabled` / `supportedCodecs` を保持する struct。デフォルトは `lowLatencyEnabled: true, supportedCodecs: ["avc1"]`
- `Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift`: `init(options:)` 追加、`buildUsherURL` で `low_latency=true` と `supported_codecs` をオプション経由に変更
- `Tests/TwitchChatTests/PlaybackOptionsTests.swift`（新設）: PlaybackOptions 単体テスト
- `Tests/TwitchChatTests/StreamPlaybackResolverTests.swift`: low_latency / supported_codecs クエリのテスト追加（3件）

## LL-HLS 検証結果（ケースC確定）

PR-1 の検証フェーズで Twitch の `fast_bread` 配信マニフェストを確認した結果：

| タグ | 観測結果 |
|---|---|
| `#EXT-X-SERVER-CONTROL` | **なし** |
| `#EXT-X-PART-INF` | **なし** |
| `#EXT-X-PART` | **なし** |
| `#EXTINF:1.000,live` | 1 秒セグメント化のみ |

`fast_bread=true` の実態は **1 秒セグメント化による擬似低遅延**であり、Apple LL-HLS（パーシャルセグメント + ブロッキングリロード）ではないことが確定。

**後続 PR の方針（ケースC向け調整）:**
- PR-2: `automaticallyPreservesTimeOffsetFromLive=true` + `preferredForwardBufferDuration=1.0`（1セグメント分）+ `playImmediately(atRate:)` で初期レイテンシ削減
- PR-3: 定期 seek to live edge + stall 検知が実質的な低遅延化の主役

## テスト

```bash
swift test --filter "PlaybackOptionsTests|StreamPlaybackResolverTests"
# 19 tests passed
```

Refs #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Twitchプレイバック設定オプションを追加。低遅延モードの有効化・無効化が可能に。
  * HLSストリーム再生時のコーデック設定をカスタマイズ可能に。デフォルトでは低遅延を有効化。

* **テスト**
  * プレイバック設定とURLクエリ構築に関するテストケースを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->