### PR TITLE
feat: AVPlayer LL-HLS チューニング（ライブエッジ追従設定）(LL-HLS PR-2)

### DIFF
--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -103,8 +103,14 @@ final class StreamPlayerViewModel {
 
             let asset = AVURLAsset(url: manifest.url)
             let item = AVPlayerItem(asset: asset)
+            // LL-HLS チューニング: ライブエッジへの追従を最優先にする
+            // Twitch は 1 秒セグメント配信（fast_bread）のため 1 セグメント分だけ先読みする
+            item.automaticallyPreservesTimeOffsetFromLive = true
+            item.configuredTimeOffsetFromLive = CMTime(seconds: 2.0, preferredTimescale: 1000)
+            item.preferredForwardBufferDuration = 1.0
+            player.automaticallyWaitsToMinimizeStalling = false
             player.replaceCurrentItem(with: item)
-            player.play()
+            player.playImmediately(atRate: 1.0)
             state = .playing
         } catch let error as PlaybackError {
             guard !Task.isCancelled else { return }

--- a/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
+++ b/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
@@ -233,6 +233,72 @@ struct StreamPlayerViewModelTests {
 
         #expect(viewModel.currentLogin == "forsen")
     }
+
+    // MARK: - AVPlayer LL-HLS チューニングテスト
+
+    @Test("load 後の AVPlayerItem で automaticallyPreservesTimeOffsetFromLive が true になる")
+    func playerItemPreservesTimeOffsetFromLive() async throws {
+        // 前提: resolve が成功し playing 状態になったとき
+        // 検証: AVPlayerItem.automaticallyPreservesTimeOffsetFromLive が true であること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+
+        guard let item = viewModel.player.currentItem else {
+            Issue.record("player.currentItem が nil")
+            return
+        }
+        #expect(item.automaticallyPreservesTimeOffsetFromLive == true)
+    }
+
+    @Test("load 後の AVPlayerItem で configuredTimeOffsetFromLive が 2.0 秒になる")
+    func playerItemConfiguredTimeOffsetFromLiveIs2Seconds() async throws {
+        // 前提: resolve が成功し playing 状態になったとき
+        // 検証: AVPlayerItem.configuredTimeOffsetFromLive が 2.0 秒であること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+
+        guard let item = viewModel.player.currentItem else {
+            Issue.record("player.currentItem が nil")
+            return
+        }
+        #expect(item.configuredTimeOffsetFromLive.seconds == 2.0)
+    }
+
+    @Test("load 後の AVPlayerItem で preferredForwardBufferDuration が 1.0 秒になる")
+    func playerItemPreferredForwardBufferDurationIs1Second() async throws {
+        // 前提: Twitch は 1 秒セグメント配信のため、1 セグメント分だけ先読みする設定
+        // 検証: AVPlayerItem.preferredForwardBufferDuration が 1.0 であること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+
+        guard let item = viewModel.player.currentItem else {
+            Issue.record("player.currentItem が nil")
+            return
+        }
+        #expect(item.preferredForwardBufferDuration == 1.0)
+    }
+
+    @Test("load 後の AVPlayer で automaticallyWaitsToMinimizeStalling が false になる")
+    func playerDoesNotWaitToMinimizeStalling() async throws {
+        // 前提: ライブエッジへの積極的な追従を優先するため自動待機を無効化する
+        // 検証: AVPlayer.automaticallyWaitsToMinimizeStalling が false であること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+
+        #expect(viewModel.player.automaticallyWaitsToMinimizeStalling == false)
+    }
 }
 
 // MARK: - MockStreamPlaybackResolver セッターヘルパー


### PR DESCRIPTION
## Summary

- `AVPlayerItem.automaticallyPreservesTimeOffsetFromLive = true` でライブエッジを基準としたオフセット管理を有効化
- `AVPlayerItem.configuredTimeOffsetFromLive = 2.0s` でライブエッジとの目標遅延を 2 秒に設定
- `AVPlayerItem.preferredForwardBufferDuration = 1.0` で Twitch の 1 秒セグメント配信に合わせた最小先読みを設定
- `AVPlayer.automaticallyWaitsToMinimizeStalling = false` + `playImmediately(atRate: 1.0)` でライブエッジへの即時追従を優先

## Background

PR-1 の検証で Twitch `fast_bread` 配信は Apple LL-HLS 仕様（`#EXT-X-PART` / `#EXT-X-SERVER-CONTROL`）非準拠のケース C であることが確定した。
実態は `#EXT-X-VERSION:3` + `#EXTINF:1.000,live` による 1 秒セグメント配信のため、AVPlayer の LL-HLS 設定は「Apple LL-HLS としての効果」はないが、ライブエッジからの乖離を最小化する追従設定として機能する。

## Test plan

- [x] `StreamPlayerViewModelTests` に AVPlayerItem / AVPlayer 設定値検証テスト 4 件を追加（TDD RED → GREEN）
- [x] `swift test --filter StreamPlayerViewModelTests` 全 14 テストパス
- [x] `swift build` 警告ゼロ

## 手動検証（マージ後）

1. ライブ配信中のチャンネルに接続して再生が開始されること
2. PR-1 比較で配信開始からの初動遅延を体感評価
3. Network Link Conditioner で帯域制限をかけて stall 後の挙動を確認（PR-3 で本格対応）

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)