### PR TITLE
feat: ライブエッジ追従 + stall 検知（LL-HLS PR-3）

### DIFF
--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -85,6 +85,7 @@ final class StreamPlayerViewModel {
         currentLogin = login
         isStalled = false
         currentLatency = nil
+        lastSeekDate = nil
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -105,6 +106,7 @@ final class StreamPlayerViewModel {
         currentLogin = nil
         isStalled = false
         currentLatency = nil
+        lastSeekDate = nil
     }
 
     /// 直前のエラーから再試行する
@@ -172,6 +174,8 @@ final class StreamPlayerViewModel {
     }
 
     private func startObservers() {
+        // 二重登録を防ぐため既存オブザーバーを事前解除する
+        stopObservers()
         // 1. 1秒ごとのライブエッジ乖離チェック
         let interval = CMTime(seconds: 1.0, preferredTimescale: 1000)
         periodicTimeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] _ in
@@ -192,10 +196,10 @@ final class StreamPlayerViewModel {
             }
         }
 
-        // 3. バッファ不足による stall 通知
+        // 3. バッファ不足による stall 通知（この ViewModel の item のみ対象）
         stalledObserver = NotificationCenter.default.addObserver(
             forName: AVPlayerItem.playbackStalledNotification,
-            object: nil,
+            object: player.currentItem,
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -40,7 +40,7 @@ final class StreamPlayerViewModel {
     /// View が参照する AVPlayer インスタンス（1インスタンスで item を差し替える）
     let player: AVPlayer
     /// 現在のライブエッジとの遅延秒数（再生中のみ更新、デバッグ用）
-    private(set) var currentLatency: Double? = nil
+    private(set) var currentLatency: Double?
     /// バッファ不足による stall 中かどうか
     private(set) var isStalled: Bool = false
 

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -1,5 +1,6 @@
 // StreamPlayerViewModel.swift
 // Twitch ライブ配信 AVPlayer の状態管理 ViewModel
+// ライブエッジ追従・stall 検知を含む LL-HLS チューニング済み
 
 import AVFoundation
 import Foundation
@@ -38,12 +39,24 @@ final class StreamPlayerViewModel {
     private(set) var currentLogin: String?
     /// View が参照する AVPlayer インスタンス（1インスタンスで item を差し替える）
     let player: AVPlayer
+    /// 現在のライブエッジとの遅延秒数（再生中のみ更新、デバッグ用）
+    private(set) var currentLatency: Double? = nil
+    /// バッファ不足による stall 中かどうか
+    private(set) var isStalled: Bool = false
 
     // MARK: - プライベートプロパティ
 
     private let resolver: any StreamPlaybackResolverProtocol
     /// 進行中の load Task（キャンセル用）
     private var loadTask: Task<Void, Never>?
+    /// 直前の seek 実行時刻（クールダウン判定用）
+    private var lastSeekDate: Date?
+    /// 周期的時刻オブザーバーのトークン（removeTimeObserver 用）
+    private var periodicTimeObserverToken: Any?
+    /// timeControlStatus KVO 観察（invalidate 用）
+    private var timeControlObservation: NSKeyValueObservation?
+    /// AVPlayerItemPlaybackStalledNotification 購読トークン（removeObserver 用）
+    private var stalledObserver: NSObjectProtocol?
 
     // MARK: - 初期化
 
@@ -64,11 +77,14 @@ final class StreamPlayerViewModel {
     /// - Parameter login: チャンネルログイン名
     func load(login: String) async {
         loadTask?.cancel()
+        stopObservers()
         // チャンネル切替直後に前の配信音声が流れ続けないよう即座に停止する
         player.pause()
         player.replaceCurrentItem(with: nil)
         state = .resolving
         currentLogin = login
+        isStalled = false
+        currentLatency = nil
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -82,16 +98,45 @@ final class StreamPlayerViewModel {
     func stop() {
         loadTask?.cancel()
         loadTask = nil
+        stopObservers()
         player.pause()
         player.replaceCurrentItem(with: nil)
         state = .idle
         currentLogin = nil
+        isStalled = false
+        currentLatency = nil
     }
 
     /// 直前のエラーから再試行する
     func retry() async {
         guard let login = currentLogin else { return }
         await load(login: login)
+    }
+
+    // MARK: - ライブエッジ追従
+
+    /// ライブエッジへの seek が必要かどうかを判定する純粋関数
+    ///
+    /// - Parameters:
+    ///   - currentLatency: 現在のライブエッジとの遅延秒数
+    ///   - recommended: AVPlayer が推奨するオフセット秒数（0 以下の場合は未確立として判定しない）
+    ///   - lastSeekAge: 直前の seek からの経過秒数（クールダウン判定用）
+    /// - Returns: seek すべきなら `true`
+    static func shouldSeekToLive(
+        currentLatency: Double,
+        recommended: Double,
+        lastSeekAge: Double
+    ) -> Bool {
+        guard recommended > 0 else { return false }
+        guard lastSeekAge >= 5.0 else { return false }
+        return currentLatency > recommended * 1.5
+    }
+
+    // MARK: - stall ハンドラ（テスト用に internal）
+
+    /// stall 通知を受けたときの処理
+    func handlePlaybackStalled() {
+        isStalled = true
     }
 
     // MARK: - プライベートヘルパー
@@ -112,6 +157,7 @@ final class StreamPlayerViewModel {
             player.replaceCurrentItem(with: item)
             player.playImmediately(atRate: 1.0)
             state = .playing
+            startObservers()
         } catch let error as PlaybackError {
             guard !Task.isCancelled else { return }
             player.pause()
@@ -122,6 +168,73 @@ final class StreamPlayerViewModel {
             player.pause()
             player.replaceCurrentItem(with: nil)
             state = .error(message: error.localizedDescription)
+        }
+    }
+
+    private func startObservers() {
+        // 1. 1秒ごとのライブエッジ乖離チェック
+        let interval = CMTime(seconds: 1.0, preferredTimescale: 1000)
+        periodicTimeObserverToken = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.updateLiveEdgeLatency()
+            }
+        }
+
+        // 2. timeControlStatus KVO: 再生再開で isStalled をリセット
+        timeControlObservation = player.observe(\.timeControlStatus, options: [.new]) { [weak self] player, _ in
+            guard let self else { return }
+            let isPlaying = player.timeControlStatus == .playing
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if isPlaying {
+                    self.isStalled = false
+                }
+            }
+        }
+
+        // 3. バッファ不足による stall 通知
+        stalledObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.playbackStalledNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.handlePlaybackStalled()
+            }
+        }
+    }
+
+    private func stopObservers() {
+        if let token = periodicTimeObserverToken {
+            player.removeTimeObserver(token)
+            periodicTimeObserverToken = nil
+        }
+        timeControlObservation?.invalidate()
+        timeControlObservation = nil
+        if let observer = stalledObserver {
+            NotificationCenter.default.removeObserver(observer)
+            stalledObserver = nil
+        }
+    }
+
+    private func updateLiveEdgeLatency() {
+        guard let item = player.currentItem,
+              let seekableRange = item.seekableTimeRanges.last?.timeRangeValue else {
+            currentLatency = nil
+            return
+        }
+        let liveEdge = CMTimeRangeGetEnd(seekableRange)
+        let current = item.currentTime()
+        let latency = max(0, (liveEdge - current).seconds)
+        currentLatency = latency
+
+        let recommended = item.recommendedTimeOffsetFromLive.seconds
+        let lastSeekAge = lastSeekDate.map { Date().timeIntervalSince($0) } ?? Double.infinity
+
+        if Self.shouldSeekToLive(currentLatency: latency, recommended: recommended, lastSeekAge: lastSeekAge) {
+            let target = liveEdge - CMTime(seconds: recommended, preferredTimescale: 1000)
+            player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
+            lastSeekDate = Date()
         }
     }
 

--- a/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
+++ b/Tests/TwitchChatTests/StreamPlayerViewModelTests.swift
@@ -234,6 +234,109 @@ struct StreamPlayerViewModelTests {
         #expect(viewModel.currentLogin == "forsen")
     }
 
+    // MARK: - shouldSeekToLive 純粋関数テスト
+
+    @Test("currentLatency が recommended * 1.5 を超えたら shouldSeekToLive は true を返す")
+    func shouldSeekToLiveReturnsTrueWhenLatencyExceedsThreshold() {
+        // 前提: currentLatency=4.5, recommended=2.0（閾値 = 2.0 * 1.5 = 3.0 を超える）
+        // 検証: shouldSeekToLive が true を返すこと
+        let result = StreamPlayerViewModel.shouldSeekToLive(
+            currentLatency: 4.5,
+            recommended: 2.0,
+            lastSeekAge: 10.0
+        )
+        #expect(result == true)
+    }
+
+    @Test("直近5秒以内に seek していたら shouldSeekToLive は false（クールダウン）")
+    func shouldSeekToLiveReturnsFalseWhenInCooldown() {
+        // 前提: lastSeekAge=3.0（5秒以内のクールダウン中）、latency は閾値超え
+        // 検証: クールダウン中は false を返すこと（チャクチャク防止）
+        let result = StreamPlayerViewModel.shouldSeekToLive(
+            currentLatency: 10.0,
+            recommended: 2.0,
+            lastSeekAge: 3.0
+        )
+        #expect(result == false)
+    }
+
+    @Test("currentLatency が recommended * 1.5 以下なら shouldSeekToLive は false")
+    func shouldSeekToLiveReturnsFalseWhenLatencyWithinThreshold() {
+        // 前提: currentLatency=2.5, recommended=2.0（閾値 = 3.0 以下）
+        // 検証: ライブエッジに十分近い場合は seek しないこと
+        let result = StreamPlayerViewModel.shouldSeekToLive(
+            currentLatency: 2.5,
+            recommended: 2.0,
+            lastSeekAge: 10.0
+        )
+        #expect(result == false)
+    }
+
+    @Test("recommended が 0 のとき shouldSeekToLive は false")
+    func shouldSeekToLiveReturnsFalseWhenRecommendedIsZero() {
+        // 前提: recommended=0（AVPlayer が推奨オフセットを未確立）
+        // 検証: recommended=0 のときは不用意に seek しないこと
+        let result = StreamPlayerViewModel.shouldSeekToLive(
+            currentLatency: 5.0,
+            recommended: 0,
+            lastSeekAge: 10.0
+        )
+        #expect(result == false)
+    }
+
+    // MARK: - isStalled / currentLatency テスト
+
+    @Test("初期状態で isStalled は false である")
+    func initialIsStalledIsFalse() {
+        let resolver = MockStreamPlaybackResolver()
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        #expect(viewModel.isStalled == false)
+    }
+
+    @Test("初期状態で currentLatency は nil である")
+    func initialCurrentLatencyIsNil() {
+        let resolver = MockStreamPlaybackResolver()
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        #expect(viewModel.currentLatency == nil)
+    }
+
+    @Test("handlePlaybackStalled() を呼ぶと isStalled が true になる")
+    func handlePlaybackStalledSetsIsStalledTrue() {
+        // 前提: 通常再生中のとき（AVPlayerItemPlaybackStalledNotification を受信した状況を再現）
+        // 検証: isStalled が true になること
+        let resolver = MockStreamPlaybackResolver()
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        viewModel.handlePlaybackStalled()
+        #expect(viewModel.isStalled == true)
+    }
+
+    @Test("stop() 後に isStalled が false にリセットされる")
+    func stopResetsIsStalled() async {
+        // 前提: stall 状態のとき stop() を呼ぶ
+        // 検証: isStalled が false にリセットされること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        await viewModel.load(login: "argstar")
+        viewModel.handlePlaybackStalled()
+        #expect(viewModel.isStalled == true, "前提: stall 状態であること")
+        viewModel.stop()
+        #expect(viewModel.isStalled == false)
+    }
+
+    @Test("load() を呼ぶと isStalled がリセットされる")
+    func loadResetsIsStalled() async {
+        // 前提: stall 状態のとき別チャンネルの load() を呼ぶ
+        // 検証: 新しい load 開始時に isStalled が false にリセットされること
+        let resolver = MockStreamPlaybackResolver()
+        await resolver.setManifest(makeManifest())
+        let viewModel = StreamPlayerViewModel(resolver: resolver)
+        viewModel.handlePlaybackStalled()
+        #expect(viewModel.isStalled == true, "前提: stall 状態であること")
+        await viewModel.load(login: "forsen")
+        #expect(viewModel.isStalled == false)
+    }
+
     // MARK: - AVPlayer LL-HLS チューニングテスト
 
     @Test("load 後の AVPlayerItem で automaticallyPreservesTimeOffsetFromLive が true になる")


### PR DESCRIPTION
## Summary

- `addPeriodicTimeObserver(1s)` でライブエッジとの遅延を毎秒算出、`currentLatency` プロパティに公開
- `shouldSeekToLive(currentLatency:recommended:lastSeekAge:)` 純粋関数でヒステリシス（`recommended * 1.5`）+ 5 秒クールダウンにより自動 seek を判定
- `AVPlayerItemPlaybackStalledNotification` 購読で `isStalled = true`
- `timeControlStatus` KVO で再生再開時に `isStalled = false`
- `stop()` / `load()` でオブザーバーを確実にクリーンアップ

## Background

Twitch の `fast_bread` 配信は Apple LL-HLS 非準拠（Case C: 1 秒セグメント配信）のため、長時間視聴でバッファが蓄積してライブエッジから乖離しやすい。本 PR はライブエッジへの自動復帰とスタール状態の管理を実装し、継続視聴時の実質的な低遅延体験を維持する。

## 実装詳細

```
shouldSeekToLive の判定ロジック:
- recommended <= 0  → false（AVPlayer が未確立）
- lastSeekAge < 5.0 → false（クールダウン中）
- currentLatency > recommended * 1.5 → true（seek を実行）
```

## Test plan

- [x] `shouldSeekToLive` 純粋関数テスト 4 件追加（TDD RED → GREEN）
- [x] `isStalled` / `currentLatency` プロパティテスト 5 件追加
- [x] `swift test --filter StreamPlayerViewModelTests` 全 23 テストパス
- [x] `swift build` 警告ゼロ

## 手動検証（マージ後）

1. ライブ配信中のチャンネルに接続して 30 分以上視聴
2. `currentLatency` の変動を観察してライブエッジ乖離 → 自動 seek の発火を確認
3. Network Link Conditioner で帯域を絞り stall 発生 → `isStalled = true` → 復帰時 `false` を確認

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)