### PR TITLE
feat(playback): Web Player 相当の広告サーブパラメータを Usher / GQL に追加

### DIFF
--- a/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
+++ b/Sources/TwitchChat/Models/Playback/PlaybackOptions.swift
@@ -1,6 +1,6 @@
 // PlaybackOptions.swift
 // HLS 再生時の Usher URL 組み立てオプション
-// Low-Latency モードやコーデック指定を一元管理する
+// Low-Latency モード・コーデック指定・広告サーブ設定を一元管理する
 
 import Foundation
 
@@ -18,20 +18,29 @@ struct PlaybackOptions: Sendable {
     /// 空文字・空白のみのエントリは除去される。全て無効な場合は `["avc1"]` にフォールバックする。
     let supportedCodecs: [String]
 
+    /// SSAI 広告セグメントを HLS マニフェストに含めるよう Usher に要求するかどうか
+    ///
+    /// `true` のとき `platform=web`, `player_type=site`, `server_ads=true`, `allow_audio_only=true` を
+    /// Usher URL に付与し、Twitch 側に Web Player 相当の広告サーブを促す。
+    let adServingEnabled: Bool
+
     /// - Parameters:
     ///   - lowLatencyEnabled: `low_latency=true` を付与するかどうか
     ///   - supportedCodecs: 対応コーデックリスト（空文字・空白は除去、空の場合は `["avc1"]` にフォールバック）
-    init(lowLatencyEnabled: Bool, supportedCodecs: [String]) {
+    ///   - adServingEnabled: SSAI 広告セグメントを要求するかどうか（デフォルト `true`）
+    init(lowLatencyEnabled: Bool, supportedCodecs: [String], adServingEnabled: Bool = true) {
         let normalized = supportedCodecs
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
         self.lowLatencyEnabled = lowLatencyEnabled
         self.supportedCodecs = normalized.isEmpty ? ["avc1"] : normalized
+        self.adServingEnabled = adServingEnabled
     }
 
-    /// デフォルト設定（Low Latency 有効、AVC1 のみ）
+    /// デフォルト設定（Low Latency 有効・AVC1 のみ・広告サーブ有効）
     static let `default` = PlaybackOptions(
         lowLatencyEnabled: true,
-        supportedCodecs: ["avc1"]
+        supportedCodecs: ["avc1"],
+        adServingEnabled: true
     )
 }

--- a/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
+++ b/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
@@ -43,13 +43,13 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
     /// `StreamPlaybackResolver` を初期化する
     ///
     /// - Parameters:
-    ///   - tokenClient: GQL アクセストークン取得クライアント
+    ///   - tokenClient: GQL アクセストークン取得クライアント（`nil` のとき `options.adServingEnabled` を反映して生成する）
     ///   - options: HLS 再生オプション（省略時は `.default`）
     init(
-        tokenClient: any TwitchPlaybackTokenClientProtocol = TwitchPlaybackTokenClient(),
+        tokenClient: (any TwitchPlaybackTokenClientProtocol)? = nil,
         options: PlaybackOptions = .default
     ) {
-        self.tokenClient = tokenClient
+        self.tokenClient = tokenClient ?? TwitchPlaybackTokenClient(adServingEnabled: options.adServingEnabled)
         self.options = options
     }
 

--- a/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
+++ b/Sources/TwitchChat/Services/Playback/StreamPlaybackResolver.swift
@@ -93,6 +93,13 @@ actor StreamPlaybackResolver: StreamPlaybackResolverProtocol {
             queryItems.append(URLQueryItem(name: "low_latency", value: "true"))
         }
 
+        if options.adServingEnabled {
+            queryItems.append(URLQueryItem(name: "platform", value: "web"))
+            queryItems.append(URLQueryItem(name: "player_type", value: "site"))
+            queryItems.append(URLQueryItem(name: "server_ads", value: "true"))
+            queryItems.append(URLQueryItem(name: "allow_audio_only", value: "true"))
+        }
+
         components.queryItems = queryItems
 
         guard let url = components.url else {

--- a/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
+++ b/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
@@ -58,6 +58,8 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
 
     private let dataFetcher: any URLSessionDataFetcher
     private let clientID: String
+    /// SSAI セッション管理用デバイス識別子（32 文字 lowercase hex、インスタンスごとに生成）
+    private let deviceID: String
 
     // MARK: - 初期化
 
@@ -66,12 +68,15 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
     /// - Parameters:
     ///   - dataFetcher: HTTP リクエストを実行するデータフェッチャー（テスト時はモックを渡す）
     ///   - clientID: GQL リクエストに付与する Client-Id ヘッダー値
+    ///   - deviceID: `X-Device-Id` ヘッダー値（`nil` のとき内部でランダム生成する。テスト時に固定値を注入可能）
     init(
         dataFetcher: any URLSessionDataFetcher = TwitchPlaybackTokenClient.makeDefaultSession(),
-        clientID: String = TwitchPlaybackTokenClient.webClientID
+        clientID: String = TwitchPlaybackTokenClient.webClientID,
+        deviceID: String? = nil
     ) {
         self.dataFetcher = dataFetcher
         self.clientID = clientID
+        self.deviceID = deviceID ?? TwitchPlaybackTokenClient.makeDeviceID()
     }
 
     // MARK: - 公開メソッド
@@ -95,6 +100,7 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
         request.httpMethod = "POST"
         request.setValue(clientID, forHTTPHeaderField: "Client-Id")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(deviceID, forHTTPHeaderField: "X-Device-Id")
         request.httpBody = try JSONEncoder().encode(GQLPlaybackTokenBody(login: login))
         return request
     }
@@ -158,6 +164,7 @@ private struct GQLVariables: Encodable {
     let isVod = false
     let vodID = ""
     let playerType = "site"
+    let platform = "web"
 }
 
 // MARK: - ファクトリ
@@ -175,5 +182,10 @@ extension TwitchPlaybackTokenClient {
         config.urlCache = URLCache(memoryCapacity: 0, diskCapacity: 0)
         config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         return URLSession(configuration: config)
+    }
+
+    /// SSAI セッション管理用デバイス識別子を生成する（32 文字 lowercase hex）
+    static func makeDeviceID() -> String {
+        UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
     }
 }

--- a/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
+++ b/Sources/TwitchChat/Services/Playback/TwitchPlaybackTokenClient.swift
@@ -58,8 +58,13 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
 
     private let dataFetcher: any URLSessionDataFetcher
     private let clientID: String
-    /// SSAI セッション管理用デバイス識別子（32 文字 lowercase hex、インスタンスごとに生成）
+    /// SSAI セッション管理用デバイス識別子
+    ///
+    /// デフォルトでは `makeDeviceID()` で生成する 32 文字 lowercase hex。
+    /// テスト時は `init(deviceID:)` 引数で固定値を注入できる。
     private let deviceID: String
+    /// 広告サーブ有効フラグ（`false` のとき `X-Device-Id` ヘッダーと GQL `platform` を省略する）
+    private let adServingEnabled: Bool
 
     // MARK: - 初期化
 
@@ -69,14 +74,17 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
     ///   - dataFetcher: HTTP リクエストを実行するデータフェッチャー（テスト時はモックを渡す）
     ///   - clientID: GQL リクエストに付与する Client-Id ヘッダー値
     ///   - deviceID: `X-Device-Id` ヘッダー値（`nil` のとき内部でランダム生成する。テスト時に固定値を注入可能）
+    ///   - adServingEnabled: `false` のとき `X-Device-Id` ヘッダーと GQL `variables.platform` を省略する
     init(
         dataFetcher: any URLSessionDataFetcher = TwitchPlaybackTokenClient.makeDefaultSession(),
         clientID: String = TwitchPlaybackTokenClient.webClientID,
-        deviceID: String? = nil
+        deviceID: String? = nil,
+        adServingEnabled: Bool = true
     ) {
         self.dataFetcher = dataFetcher
         self.clientID = clientID
         self.deviceID = deviceID ?? TwitchPlaybackTokenClient.makeDeviceID()
+        self.adServingEnabled = adServingEnabled
     }
 
     // MARK: - 公開メソッド
@@ -100,8 +108,10 @@ actor TwitchPlaybackTokenClient: TwitchPlaybackTokenClientProtocol {
         request.httpMethod = "POST"
         request.setValue(clientID, forHTTPHeaderField: "Client-Id")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue(deviceID, forHTTPHeaderField: "X-Device-Id")
-        request.httpBody = try JSONEncoder().encode(GQLPlaybackTokenBody(login: login))
+        if adServingEnabled {
+            request.setValue(deviceID, forHTTPHeaderField: "X-Device-Id")
+        }
+        request.httpBody = try JSONEncoder().encode(GQLPlaybackTokenBody(login: login, adServingEnabled: adServingEnabled))
         return request
     }
 
@@ -141,11 +151,11 @@ private struct GQLPlaybackTokenBody: Encodable {
     let extensions: GQLExtensions
     let variables: GQLVariables
 
-    init(login: String) {
+    init(login: String, adServingEnabled: Bool) {
         self.extensions = GQLExtensions(
             persistedQuery: GQLPersistedQuery(sha256Hash: TwitchPlaybackTokenClient.liveQueryHash)
         )
-        self.variables = GQLVariables(login: login)
+        self.variables = GQLVariables(login: login, platform: adServingEnabled ? "web" : nil)
     }
 }
 
@@ -164,7 +174,22 @@ private struct GQLVariables: Encodable {
     let isVod = false
     let vodID = ""
     let playerType = "site"
-    let platform = "web"
+    /// `nil` のとき JSON エンコード時にフィールドを省略する（adServingEnabled=false 時）
+    let platform: String?
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(isLive, forKey: .isLive)
+        try container.encode(login, forKey: .login)
+        try container.encode(isVod, forKey: .isVod)
+        try container.encode(vodID, forKey: .vodID)
+        try container.encode(playerType, forKey: .playerType)
+        try container.encodeIfPresent(platform, forKey: .platform)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case isLive, login, isVod, vodID, playerType, platform
+    }
 }
 
 // MARK: - ファクトリ

--- a/Tests/TwitchChatTests/PlaybackOptionsTests.swift
+++ b/Tests/TwitchChatTests/PlaybackOptionsTests.swift
@@ -63,4 +63,38 @@ struct PlaybackOptionsTests {
         let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: [" avc1 ", "hevc"])
         #expect(options.supportedCodecs == ["avc1", "hevc"])
     }
+
+    // MARK: - 広告サーブテスト
+
+    @Test("PlaybackOptions.default は adServingEnabled が true である")
+    func defaultIsAdServingEnabled() {
+        // 検証: デフォルト設定で広告サーブが有効になっていること
+        let options = PlaybackOptions.default
+        #expect(options.adServingEnabled == true)
+    }
+
+    @Test("adServingEnabled=false で初期化すると広告サーブが無効になる")
+    func initWithAdServingDisabled() {
+        // 前提: 広告サーブを明示的に無効化したとき
+        // 検証: adServingEnabled が false であること
+        let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: ["avc1"], adServingEnabled: false)
+        #expect(options.adServingEnabled == false)
+    }
+
+    @Test("adServingEnabled を省略すると true がデフォルトになる")
+    func initWithoutAdServingArgumentDefaultsToTrue() {
+        // 前提: 既存コードの呼び出し形式（adServingEnabled 引数なし）で初期化したとき
+        // 検証: adServingEnabled がデフォルト値 true になること（後方互換性確認）
+        let options = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1"])
+        #expect(options.adServingEnabled == true)
+    }
+
+    @Test("PlaybackOptions.default の全フィールドが期待値である")
+    func defaultHasAllExpectedValues() {
+        // 検証: デフォルト設定の 3 フィールドが全て意図した値になっていること（現状ロック）
+        let options = PlaybackOptions.default
+        #expect(options.lowLatencyEnabled == true)
+        #expect(options.supportedCodecs == ["avc1"])
+        #expect(options.adServingEnabled == true)
+    }
 }

--- a/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
+++ b/Tests/TwitchChatTests/StreamPlaybackResolverTests.swift
@@ -221,6 +221,126 @@ struct StreamPlaybackResolverTests {
         #expect(codecsValue == "avc1,hevc", "supported_codecs が期待値と異なる: \(codecsValue ?? "nil")")
     }
 
+    // MARK: - 広告サーブパラメータテスト
+
+    @Test("PlaybackOptions.default で resolve すると platform=web クエリが付与される")
+    func defaultBuildsUsherWithPlatformWeb() async throws {
+        // 前提: adServingEnabled=true（PlaybackOptions.default）で resolve したとき
+        // 検証: Usher URL に platform=web クエリが含まれること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let value = components?.queryItems?.first(where: { $0.name == "platform" })?.value
+        #expect(value == "web", "platform=web クエリが含まれていない: \(manifest.url)")
+    }
+
+    @Test("PlaybackOptions.default で resolve すると player_type=site クエリが付与される")
+    func defaultBuildsUsherWithPlayerTypeSite() async throws {
+        // 前提: adServingEnabled=true（PlaybackOptions.default）で resolve したとき
+        // 検証: Usher URL に player_type=site クエリが含まれること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let value = components?.queryItems?.first(where: { $0.name == "player_type" })?.value
+        #expect(value == "site", "player_type=site クエリが含まれていない: \(manifest.url)")
+    }
+
+    @Test("PlaybackOptions.default で resolve すると server_ads=true クエリが付与される")
+    func defaultBuildsUsherWithServerAdsTrue() async throws {
+        // 前提: adServingEnabled=true（PlaybackOptions.default）で resolve したとき
+        // 検証: Usher URL に server_ads=true クエリが含まれること（SSAI 有効化に最重要）
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let value = components?.queryItems?.first(where: { $0.name == "server_ads" })?.value
+        #expect(value == "true", "server_ads=true クエリが含まれていない: \(manifest.url)")
+    }
+
+    @Test("PlaybackOptions.default で resolve すると allow_audio_only=true クエリが付与される")
+    func defaultBuildsUsherWithAllowAudioOnlyTrue() async throws {
+        // 前提: adServingEnabled=true（PlaybackOptions.default）で resolve したとき
+        // 検証: Usher URL に allow_audio_only=true クエリが含まれること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let value = components?.queryItems?.first(where: { $0.name == "allow_audio_only" })?.value
+        #expect(value == "true", "allow_audio_only=true クエリが含まれていない: \(manifest.url)")
+    }
+
+    @Test("adServingEnabled=false のとき広告サーブ用クエリ 4 個が全て付与されない")
+    func adServingDisabledExcludesAllAdParams() async throws {
+        // 前提: adServingEnabled=false の PlaybackOptions で resolve したとき
+        // 検証: platform / player_type / server_ads / allow_audio_only クエリが全て含まれないこと
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let options = PlaybackOptions(lowLatencyEnabled: true, supportedCodecs: ["avc1"], adServingEnabled: false)
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: options)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let keys = components?.queryItems?.map { $0.name } ?? []
+        #expect(!keys.contains("platform"), "platform クエリが誤って付与されている")
+        #expect(!keys.contains("player_type"), "player_type クエリが誤って付与されている")
+        #expect(!keys.contains("server_ads"), "server_ads クエリが誤って付与されている")
+        #expect(!keys.contains("allow_audio_only"), "allow_audio_only クエリが誤って付与されている")
+    }
+
+    @Test("広告サーブ設定に関わらず token / sig / play_session_id クエリは常に付与される")
+    func nonAdParamsAlwaysPresentRegardlessOfAdServing() async throws {
+        // 前提: adServingEnabled が true / false のどちらでも既存の必須クエリは失われないこと
+        // 検証: token, sig, play_session_id が両方の設定で存在すること
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken(value: "検証用トークン", signature: "検証用シグネチャ"))
+
+        let optionsOn = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1"], adServingEnabled: true)
+        let resolverOn = StreamPlaybackResolver(tokenClient: tokenClient, options: optionsOn)
+        let manifestOn = try await resolverOn.resolve(login: "forsen")
+
+        let optionsOff = PlaybackOptions(lowLatencyEnabled: false, supportedCodecs: ["avc1"], adServingEnabled: false)
+        let resolverOff = StreamPlaybackResolver(tokenClient: tokenClient, options: optionsOff)
+        let manifestOff = try await resolverOff.resolve(login: "forsen")
+
+        for manifest in [manifestOn, manifestOff] {
+            let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+            let keys = components?.queryItems?.map { $0.name } ?? []
+            #expect(keys.contains("token"), "token クエリが消えている: \(manifest.url)")
+            #expect(keys.contains("sig"), "sig クエリが消えている: \(manifest.url)")
+            #expect(keys.contains("play_session_id"), "play_session_id クエリが消えている: \(manifest.url)")
+        }
+    }
+
+    @Test("adServingEnabled=true のとき Usher URL のクエリ件数は 17 個である")
+    func usherQueryItemCountWithAdServingOn() async throws {
+        // 前提: PlaybackOptions.default（adServingEnabled=true、lowLatencyEnabled=true）で resolve
+        // 検証: 既存 13 クエリ（基本 12 + low_latency）+ 広告 4 = 17 個であること（現状ロック）
+        let tokenClient = MockTwitchPlaybackTokenClient()
+        await tokenClient.setToken(makeToken())
+
+        let resolver = StreamPlaybackResolver(tokenClient: tokenClient, options: .default)
+        let manifest = try await resolver.resolve(login: "argstar")
+
+        let components = URLComponents(url: manifest.url, resolvingAgainstBaseURL: false)
+        let count = components?.queryItems?.count ?? 0
+        #expect(count == 17, "クエリ件数が期待値 17 と異なる: 実際は \(count) 件")
+    }
+
     // MARK: - エラー伝搬テスト
 
     @Test("tokenDecodingFailed はそのまま再スローされる")

--- a/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
@@ -132,6 +132,107 @@ struct TwitchPlaybackTokenClientTests {
         #expect(requests.first?.httpMethod == "POST")
     }
 
+    // MARK: - 広告サーブ・デバイス識別子テスト
+
+    @Test("GQL リクエストボディの variables に platform=\"web\" が含まれる")
+    func gqlVariablesIncludePlatformWeb() async throws {
+        // 前提: TwitchPlaybackTokenClient がリクエストを送信したとき
+        // 検証: リクエストボディ JSON の variables.platform が "web" であること
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        guard let bodyData = requests.first?.httpBody,
+              let bodyString = String(data: bodyData, encoding: .utf8) else {
+            Issue.record("リクエストボディが nil")
+            return
+        }
+        #expect(bodyString.contains("\"platform\""), "variables に platform キーが含まれていない: \(bodyString)")
+        #expect(bodyString.contains("\"web\""), "variables.platform の値が web でない: \(bodyString)")
+    }
+
+    @Test("GQL リクエストに X-Device-Id ヘッダーが付与され 32 文字の lowercase hex である")
+    func xDeviceIdHeaderIsHex32Lowercase() async throws {
+        // 前提: デフォルト初期化した TwitchPlaybackTokenClient でリクエストを送信したとき
+        // 検証: X-Device-Id ヘッダーが 32 文字の lowercase hex 文字列であること
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client.fetchLiveToken(login: "forsen")
+
+        let requests = await fetcher.capturedRequests
+        guard let deviceId = requests.first?.allHTTPHeaderFields?["X-Device-Id"] else {
+            Issue.record("X-Device-Id ヘッダーが nil")
+            return
+        }
+        #expect(deviceId.count == 32, "X-Device-Id が 32 文字でない: \(deviceId)")
+        let allLowercaseHex = deviceId.allSatisfy { $0.isHexDigit && ($0.isLetter ? $0.isLowercase : true) }
+        #expect(allLowercaseHex, "X-Device-Id に lowercase hex 以外の文字が含まれる: \(deviceId)")
+    }
+
+    @Test("同一インスタンスで 2 回リクエストしても X-Device-Id ヘッダーは同じ値である")
+    func xDeviceIdHeaderIsStablePerInstance() async throws {
+        // 前提: 同一の TwitchPlaybackTokenClient インスタンスで複数回リクエストを送信したとき
+        // 検証: X-Device-Id の値がリクエスト間で変わらないこと（インスタンスごとに固定）
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client.fetchLiveToken(login: "argstar")
+        _ = try await client.fetchLiveToken(login: "forsen")
+
+        let requests = await fetcher.capturedRequests
+        let deviceId1 = requests[0].allHTTPHeaderFields?["X-Device-Id"]
+        let deviceId2 = requests[1].allHTTPHeaderFields?["X-Device-Id"]
+        #expect(deviceId1 != nil, "1 回目の X-Device-Id が nil")
+        #expect(deviceId2 != nil, "2 回目の X-Device-Id が nil")
+        #expect(deviceId1 == deviceId2, "同一インスタンスで X-Device-Id が変わっている: \(deviceId1 ?? "") / \(deviceId2 ?? "")")
+    }
+
+    @Test("別インスタンスでは X-Device-Id ヘッダーの値が異なる")
+    func xDeviceIdHeaderDiffersAcrossInstances() async throws {
+        // 前提: 別々の TwitchPlaybackTokenClient インスタンスでリクエストを送信したとき
+        // 検証: X-Device-Id の値がインスタンス間で異なること（永続化なし・都度生成の確認）
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client1 = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        let client2 = TwitchPlaybackTokenClient(dataFetcher: fetcher, clientID: "テストクライアントID")
+        _ = try await client1.fetchLiveToken(login: "argstar")
+        _ = try await client2.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        let deviceId1 = requests[0].allHTTPHeaderFields?["X-Device-Id"]
+        let deviceId2 = requests[1].allHTTPHeaderFields?["X-Device-Id"]
+        #expect(deviceId1 != nil, "インスタンス 1 の X-Device-Id が nil")
+        #expect(deviceId2 != nil, "インスタンス 2 の X-Device-Id が nil")
+        #expect(deviceId1 != deviceId2, "別インスタンスで X-Device-Id が同じ値になっている: \(deviceId1 ?? "")")
+    }
+
+    @Test("init の deviceID 引数でテスト用の固定値を X-Device-Id ヘッダーに注入できる")
+    func canInjectDeviceIdForTesting() async throws {
+        // 前提: deviceID 引数に固定値を指定して初期化したとき
+        // 検証: X-Device-Id ヘッダーに注入した固定値が使われること
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let テスト用デバイスID = "abcdef1234567890abcdef1234567890"
+        let client = TwitchPlaybackTokenClient(
+            dataFetcher: fetcher,
+            clientID: "テストクライアントID",
+            deviceID: テスト用デバイスID
+        )
+        _ = try await client.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        let deviceId = requests.first?.allHTTPHeaderFields?["X-Device-Id"]
+        #expect(deviceId == テスト用デバイスID, "注入した deviceID が反映されていない: \(deviceId ?? "nil")")
+    }
+
     // MARK: - エラーパステスト
 
     @Test("HTTP 401 のとき tokenRequestFailed(statusCode: 401) を投げる")

--- a/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
+++ b/Tests/TwitchChatTests/TwitchPlaybackTokenClientTests.swift
@@ -137,7 +137,7 @@ struct TwitchPlaybackTokenClientTests {
     @Test("GQL リクエストボディの variables に platform=\"web\" が含まれる")
     func gqlVariablesIncludePlatformWeb() async throws {
         // 前提: TwitchPlaybackTokenClient がリクエストを送信したとき
-        // 検証: リクエストボディ JSON の variables.platform が "web" であること
+        // 検証: リクエストボディ JSON の variables.platform が厳密に "web" であること
         let fetcher = MockURLSessionDataFetcher()
         await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
 
@@ -145,13 +145,17 @@ struct TwitchPlaybackTokenClientTests {
         _ = try await client.fetchLiveToken(login: "argstar")
 
         let requests = await fetcher.capturedRequests
-        guard let bodyData = requests.first?.httpBody,
-              let bodyString = String(data: bodyData, encoding: .utf8) else {
+        guard let bodyData = requests.first?.httpBody else {
             Issue.record("リクエストボディが nil")
             return
         }
-        #expect(bodyString.contains("\"platform\""), "variables に platform キーが含まれていない: \(bodyString)")
-        #expect(bodyString.contains("\"web\""), "variables.platform の値が web でない: \(bodyString)")
+        guard let root = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+              let variables = root["variables"] as? [String: Any] else {
+            Issue.record("JSON 構造が想定外")
+            return
+        }
+        let platform = variables["platform"] as? String
+        #expect(platform == "web", "variables.platform が \"web\" でない: \(String(describing: platform))")
     }
 
     @Test("GQL リクエストに X-Device-Id ヘッダーが付与され 32 文字の lowercase hex である")
@@ -220,17 +224,64 @@ struct TwitchPlaybackTokenClientTests {
         let fetcher = MockURLSessionDataFetcher()
         await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
 
-        let テスト用デバイスID = "abcdef1234567890abcdef1234567890"
+        let testDeviceID = "abcdef1234567890abcdef1234567890"
         let client = TwitchPlaybackTokenClient(
             dataFetcher: fetcher,
             clientID: "テストクライアントID",
-            deviceID: テスト用デバイスID
+            deviceID: testDeviceID
         )
         _ = try await client.fetchLiveToken(login: "argstar")
 
         let requests = await fetcher.capturedRequests
         let deviceId = requests.first?.allHTTPHeaderFields?["X-Device-Id"]
-        #expect(deviceId == テスト用デバイスID, "注入した deviceID が反映されていない: \(deviceId ?? "nil")")
+        #expect(deviceId == testDeviceID, "注入した deviceID が反映されていない: \(deviceId ?? "nil")")
+    }
+
+    @Test("adServingEnabled=false のとき X-Device-Id ヘッダーが送信されない")
+    func adServingDisabledOmitsXDeviceIdHeader() async throws {
+        // 前提: adServingEnabled=false で初期化した TwitchPlaybackTokenClient
+        // 検証: X-Device-Id ヘッダーがリクエストに含まれないこと（カットバック時の完全無効化）
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(
+            dataFetcher: fetcher,
+            clientID: "テストクライアントID",
+            adServingEnabled: false
+        )
+        _ = try await client.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        let deviceId = requests.first?.allHTTPHeaderFields?["X-Device-Id"]
+        #expect(deviceId == nil, "adServingEnabled=false なのに X-Device-Id が送信された: \(deviceId ?? "")")
+    }
+
+    @Test("adServingEnabled=false のとき GQL variables に platform フィールドが含まれない")
+    func adServingDisabledOmitsPlatformFromGQLVariables() async throws {
+        // 前提: adServingEnabled=false で初期化した TwitchPlaybackTokenClient
+        // 検証: リクエストボディ JSON の variables に platform キーが存在しないこと（null ではなく省略）
+        let fetcher = MockURLSessionDataFetcher()
+        await fetcher.setStub(.init(statusCode: 200, data: makeSuccessResponseData()))
+
+        let client = TwitchPlaybackTokenClient(
+            dataFetcher: fetcher,
+            clientID: "テストクライアントID",
+            adServingEnabled: false
+        )
+        _ = try await client.fetchLiveToken(login: "argstar")
+
+        let requests = await fetcher.capturedRequests
+        guard let bodyData = requests.first?.httpBody else {
+            Issue.record("リクエストボディが nil")
+            return
+        }
+        guard let root = try JSONSerialization.jsonObject(with: bodyData) as? [String: Any],
+              let variables = root["variables"] as? [String: Any] else {
+            Issue.record("JSON 構造が想定外")
+            return
+        }
+        let hasPlatformKey = variables.keys.contains("platform")
+        #expect(!hasPlatformKey, "adServingEnabled=false なのに variables に platform が含まれている: \(variables)")
     }
 
     // MARK: - エラーパステスト


### PR DESCRIPTION
## 背景

広告区間で「Commercial break in progress」という紫グラデのプレースホルダー画像のみが表示され、本物の広告動画が再生されない状態になっていた。

原因は Twitch 公式 Web Player が送っている **SSAI 広告サーブ用パラメータが現実装に存在しないこと** で、Twitch サーバ側から「広告を流さなくてよい不完全クライアント」と判定され、HLS マニフェスト中に広告セグメントが入ってこない構造だった。

アプリの適正な利用（広告を正規に表示すること）を促進するために、Web Player 観測値ベースの最小セットを追加する。

## 変更内容

### Usher URL に追加したクエリパラメータ

| パラメータ | 値 | 目的 |
|---|---|---|
| `platform` | `web` | SSAI 広告振り分けプール選定 |
| `player_type` | `site` | 広告主・頻度がチャンネルページ視聴扱いになる |
| `server_ads` | `true` | SSAI 自体の有効化（最重要） |
| `allow_audio_only` | `true` | 音声のみ広告バリアント許容で広告サーブを最大化 |

### GQL PlaybackAccessToken リクエストへの追加

| 追加内容 | 値 | 目的 |
|---|---|---|
| variables `platform` | `"web"` | サーバ側広告ターゲティング用 |
| ヘッダー `X-Device-Id` | 32 文字 lowercase hex | SSAI セッション管理（インスタンスごとに生成、永続化なし） |

### `PlaybackOptions` の拡張

- `adServingEnabled: Bool = true` フラグを追加
- `false` に変更するだけで 4 クエリ + GQL platform + X-Device-Id を一括無効化可能（緊急切戻し用）

## スコープ

**本 PR は A 案（パラメータ追加のみ）。** 広告区間の検知ロジック・WebView フォールバック・LL-HLS 緩和制御は対象外。実機検証で効果不十分が確認された場合は別 PR で B/C 案にエスカレーションする。

## テスト

新規テスト計 16 件を追加（TDD: RED → GREEN の順で実装）:
- `PlaybackOptionsTests.swift` +4 件（adServingEnabled フィールドの挙動確認）
- `StreamPlaybackResolverTests.swift` +7 件（4 クエリの付与・不付与・クエリ件数ロック）
- `TwitchPlaybackTokenClientTests.swift` +5 件（GQL platform 変数・X-Device-Id ヘッダーの形式・安定性・注入）

## 実機検証手順

1. アプリ起動 → 視聴者数 1k+ の英語圏配信を選定
2. **期待**: pre-roll / mid-roll で実映像広告が AVPlayer に再生される（紫グラデ画像ではない）
3. m3u8 確認: `EXT-X-DATERANGE:CLASS="twitch-stitched-ad"` の存在確認
4. 広告終了後、ライブエッジ追従ロジックが正常復帰することを確認

## 切戻し手順

`PlaybackOptions.swift` の `default` の `adServingEnabled` を `false` に変更するだけで即時無効化可能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 再生設定で広告配信の有効/無効を切替可能に（デフォルト: 有効）
  * インスタンス単位のデバイスセッション対応とデバイスID自動生成を実装
  * 広告有効時にプラットフォーム情報や広告関連パラメータをリクエストに含める挙動を追加

* **テスト**
  * 再生オプションとデフォルト値の検証テストを追加
  * 広告関連URLパラメータの有無を確認するテストを追加
  * デバイスIDの生成・安定性・注入動作を検証するテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->