### PR TITLE
fix(player): 起動時・チャンネル選択・AVPlayerView 生成時の自動再生を修正

### DIFF
--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -137,8 +137,12 @@ final class StreamPlayerViewModel {
     // MARK: - stall ハンドラ（テスト用に internal）
 
     /// stall 通知を受けたときの処理
+    ///
+    /// `automaticallyWaitsToMinimizeStalling = false` 環境では stall 後の自動再開は行われないため、
+    /// 明示的に `player.play()` を呼んで再生を再開する。
     func handlePlaybackStalled() {
         isStalled = true
+        player.play()
     }
 
     // MARK: - プライベートヘルパー

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -57,6 +57,10 @@ final class StreamPlayerViewModel {
     private var timeControlObservation: NSKeyValueObservation?
     /// AVPlayerItemPlaybackStalledNotification 購読トークン（removeObserver 用）
     private var stalledObserver: NSObjectProtocol?
+    /// player.rate KVO（デバッグ用：rate が変化するたびに出力）
+    private var rateObservation: NSKeyValueObservation?
+    /// AVPlayerItem.status KVO（readyToPlay 検知用）
+    private var itemStatusObservation: NSKeyValueObservation?
 
     // MARK: - 初期化
 
@@ -161,7 +165,9 @@ final class StreamPlayerViewModel {
             item.preferredForwardBufferDuration = 1.0
             player.automaticallyWaitsToMinimizeStalling = false
             player.replaceCurrentItem(with: item)
+            print("[Player] replaceCurrentItem 完了 rate=\(player.rate) status=\(item.status.rawValue)")
             player.playImmediately(atRate: 1.0)
+            print("[Player] playImmediately 呼び出し後 rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
             state = .playing
             startObservers()
         } catch let error as PlaybackError {
@@ -210,6 +216,24 @@ final class StreamPlayerViewModel {
                 self?.handlePlaybackStalled()
             }
         }
+
+        // 4. AVPlayerItem.status KVO: readyToPlay で再生を確実に開始する
+        if let item = player.currentItem {
+            itemStatusObservation = item.observe(\.status, options: [.new]) { [weak self] item, _ in
+                print("[Player] item.status 変化 → \(item.status.rawValue)")
+                guard item.status == .readyToPlay else { return }
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    print("[Player] item readyToPlay: rate=\(self.player.rate) → playImmediately 呼び出し")
+                    self.player.playImmediately(atRate: 1.0)
+                }
+            }
+        }
+
+        // 5. player.rate KVO: rate 変化をすべてログ出力（デバッグ用）
+        rateObservation = player.observe(\.rate, options: [.new]) { player, change in
+            print("[Player] rate 変化 → \(change.newValue ?? -1) timeControlStatus=\(player.timeControlStatus.rawValue)")
+        }
     }
 
     private func stopObservers() {
@@ -223,6 +247,10 @@ final class StreamPlayerViewModel {
             NotificationCenter.default.removeObserver(observer)
             stalledObserver = nil
         }
+        itemStatusObservation?.invalidate()
+        itemStatusObservation = nil
+        rateObservation?.invalidate()
+        rateObservation = nil
     }
 
     private func updateLiveEdgeLatency() {

--- a/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/StreamPlayerViewModel.swift
@@ -57,8 +57,6 @@ final class StreamPlayerViewModel {
     private var timeControlObservation: NSKeyValueObservation?
     /// AVPlayerItemPlaybackStalledNotification 購読トークン（removeObserver 用）
     private var stalledObserver: NSObjectProtocol?
-    /// player.rate KVO（デバッグ用：rate が変化するたびに出力）
-    private var rateObservation: NSKeyValueObservation?
     /// AVPlayerItem.status KVO（readyToPlay 検知用）
     private var itemStatusObservation: NSKeyValueObservation?
 
@@ -165,9 +163,7 @@ final class StreamPlayerViewModel {
             item.preferredForwardBufferDuration = 1.0
             player.automaticallyWaitsToMinimizeStalling = false
             player.replaceCurrentItem(with: item)
-            print("[Player] replaceCurrentItem 完了 rate=\(player.rate) status=\(item.status.rawValue)")
             player.playImmediately(atRate: 1.0)
-            print("[Player] playImmediately 呼び出し後 rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
             state = .playing
             startObservers()
         } catch let error as PlaybackError {
@@ -218,21 +214,17 @@ final class StreamPlayerViewModel {
         }
 
         // 4. AVPlayerItem.status KVO: readyToPlay で再生を確実に開始する
+        // automaticallyWaitsToMinimizeStalling=false + LL-HLS の live edge 位置決め処理により
+        // playImmediately 直後に rate が 0 に戻ることがある。
+        // アイテムが readyToPlay になった（マニフェスト取得・live edge 確定後）タイミングで
+        // 再度 playImmediately を呼ぶことで自動再生を保証する。
         if let item = player.currentItem {
             itemStatusObservation = item.observe(\.status, options: [.new]) { [weak self] item, _ in
-                print("[Player] item.status 変化 → \(item.status.rawValue)")
                 guard item.status == .readyToPlay else { return }
                 Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    print("[Player] item readyToPlay: rate=\(self.player.rate) → playImmediately 呼び出し")
-                    self.player.playImmediately(atRate: 1.0)
+                    self?.player.playImmediately(atRate: 1.0)
                 }
             }
-        }
-
-        // 5. player.rate KVO: rate 変化をすべてログ出力（デバッグ用）
-        rateObservation = player.observe(\.rate, options: [.new]) { player, change in
-            print("[Player] rate 変化 → \(change.newValue ?? -1) timeControlStatus=\(player.timeControlStatus.rawValue)")
         }
     }
 
@@ -249,8 +241,6 @@ final class StreamPlayerViewModel {
         }
         itemStatusObservation?.invalidate()
         itemStatusObservation = nil
-        rateObservation?.invalidate()
-        rateObservation = nil
     }
 
     private func updateLiveEdgeLatency() {

--- a/Sources/TwitchChat/Views/ContentView.swift
+++ b/Sources/TwitchChat/Views/ContentView.swift
@@ -91,6 +91,12 @@ struct ContentView: View {
             }
         }
         .frame(minWidth: 600, minHeight: 400)
+        .onAppear {
+            // 起動時に livePlayerEnabled かつ選択中チャンネルがある場合、即座に再生を開始する
+            // onChange は値が変化したときのみ発火するため、起動時の初期再生はここで行う
+            guard livePlayerEnabled, let login = channelManager.selectedChannel else { return }
+            Task { await streamPlayer.load(login: login) }
+        }
         .onChange(of: channelManager.selectedChannel) { _, newChannel in
             // livePlayerEnabled かつチャンネルが切り替わった場合にのみ再生を開始する
             guard livePlayerEnabled, let login = newChannel else {

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -35,20 +35,16 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
     let player: AVPlayer
 
     func makeNSView(context: Context) -> ExpandingAVPlayerView {
-        print("[AVPlayerView] makeNSView 呼び出し rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
         let view = ExpandingAVPlayerView()
         view.player = player
         view.controlsStyle = .floating
         view.videoGravity = .resizeAspect
-        print("[AVPlayerView] makeNSView 完了 rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
         return view
     }
 
     func updateNSView(_ nsView: ExpandingAVPlayerView, context: Context) {
-        print("[AVPlayerView] updateNSView 呼び出し rate=\(player.rate) playerChanged=\(nsView.player !== player)")
         if nsView.player !== player {
             nsView.player = player
-            print("[AVPlayerView] updateNSView: player を差し替え")
         }
     }
 }

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -35,16 +35,20 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
     let player: AVPlayer
 
     func makeNSView(context: Context) -> ExpandingAVPlayerView {
+        print("[AVPlayerView] makeNSView 呼び出し rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
         let view = ExpandingAVPlayerView()
         view.player = player
         view.controlsStyle = .floating
         view.videoGravity = .resizeAspect
+        print("[AVPlayerView] makeNSView 完了 rate=\(player.rate) timeControlStatus=\(player.timeControlStatus.rawValue)")
         return view
     }
 
     func updateNSView(_ nsView: ExpandingAVPlayerView, context: Context) {
+        print("[AVPlayerView] updateNSView 呼び出し rate=\(player.rate) playerChanged=\(nsView.player !== player)")
         if nsView.player !== player {
             nsView.player = player
+            print("[AVPlayerView] updateNSView: player を差し替え")
         }
     }
 }

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -1,10 +1,14 @@
 // StreamPlayerView.swift
 // Twitch ライブ配信 AVPlayer の表示ビュー
-// StreamPlayerViewModel の state に応じてプレイヤーまたはオーバーレイを表示する
+// StreamPlayerViewModel の state に応じてオーバーレイを切り替える
 //
 // macOS 26 では SwiftUI の VideoPlayer（_AVKit_SwiftUI 経由）が
 // 'So12AVPlayerViewC' の demangling に失敗してクラッシュするため、
 // AVPlayerView を NSViewRepresentable で直接ラップして回避する。
+//
+// AVPlayerNSViewRepresentable は ZStack 最下層に常時配置する。
+// state 遷移ごとに makeNSView が再呼び出しされると view.player 再設定で
+// rate がリセットされてしまうため、この構造でその問題を回避する。
 
 import AVKit
 import SwiftUI
@@ -35,9 +39,6 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
         view.player = player
         view.controlsStyle = .floating
         view.videoGravity = .resizeAspect
-        // AVPlayerView は player を設定すると内部的にレートをリセットするため、
-        // 明示的に再生を再開する（currentItem がない場合は no-op）
-        player.play()
         return view
     }
 
@@ -52,41 +53,51 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
 
 /// Twitch ライブ配信を表示するビュー
 ///
-/// `StreamPlayerViewModel` の状態に応じて以下を表示する:
-/// - `.idle`: 黒背景（Color.black）
-/// - `.resolving`: ProgressView（読み込み中）
-/// - `.playing`: AVPlayerView（フローティングコントロール付き）
-/// - `.offline`: オフライン表示
-/// - `.error(message:)`: エラー表示 + 再試行ボタン
+/// `AVPlayerNSViewRepresentable` を ZStack 最下層に常時配置し、
+/// `StreamPlayerViewModel` の状態に応じてオーバーレイを切り替える:
+/// - `.idle`: 黒オーバーレイ（プレイヤーを隠す）
+/// - `.resolving`: ProgressView オーバーレイ（読み込み中）
+/// - `.playing`: オーバーレイなし（プレイヤーが見える）
+/// - `.offline`: オフライン表示オーバーレイ
+/// - `.error(message:)`: エラー表示 + 再試行ボタンオーバーレイ
 struct StreamPlayerView: View {
 
     var viewModel: StreamPlayerViewModel
 
     var body: some View {
-        Group {
-            switch viewModel.state {
-            case .idle:
-                idleView
-            case .resolving:
-                ProgressView("読み込み中...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .playing:
-                AVPlayerNSViewRepresentable(player: viewModel.player)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .offline:
-                offlineView
-            case .error(let message):
-                errorView(message: message)
-            }
+        ZStack {
+            // AVPlayer は state によらず常にビュー階層に保持する
+            // state 変化で makeNSView が再呼び出しされると view.player 設定で
+            // rate がリセットされるため、このビューを常駐させて回避する
+            AVPlayerNSViewRepresentable(player: viewModel.player)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            overlayForCurrentState
         }
         .background(Color.black)
     }
 
-    // MARK: - サブビュー
+    // MARK: - オーバーレイ
 
-    private var idleView: some View {
-        Color.black
+    @ViewBuilder
+    private var overlayForCurrentState: some View {
+        switch viewModel.state {
+        case .idle:
+            Color.black
+        case .resolving:
+            ProgressView("読み込み中...")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.black)
+        case .playing:
+            EmptyView()
+        case .offline:
+            offlineView
+        case .error(let message):
+            errorView(message: message)
+        }
     }
+
+    // MARK: - サブビュー
 
     private var offlineView: some View {
         VStack(spacing: 8) {

--- a/Sources/TwitchChat/Views/StreamPlayerView.swift
+++ b/Sources/TwitchChat/Views/StreamPlayerView.swift
@@ -35,6 +35,9 @@ private struct AVPlayerNSViewRepresentable: NSViewRepresentable {
         view.player = player
         view.controlsStyle = .floating
         view.videoGravity = .resizeAspect
+        // AVPlayerView は player を設定すると内部的にレートをリセットするため、
+        // 明示的に再生を再開する（currentItem がない場合は no-op）
+        player.play()
         return view
     }
 


### PR DESCRIPTION
## 問題

1. **起動時に自動再生されない**: `livePlayerEnabled=true` でアプリを起動しチャンネルが選択済みでも再生されなかった。`onChange(of: channelManager.selectedChannel)` は値が**変化したとき**にのみ発火するため、起動時に `selectedChannel` が既に設定されていると `load()` が呼ばれなかった。

2. **stall 後に自動再開されない**: `automaticallyWaitsToMinimizeStalling = false` の環境では stall 後 AVPlayer が自動再開しない。

3. **チャンネル選択後に自動再生されない（主要因）**: `performLoad` で `player.playImmediately(atRate: 1.0)` → `state = .playing` の順で呼んでいるが、SwiftUI が状態変化を検知して `AVPlayerNSViewRepresentable` を新規生成 → `makeNSView` で `view.player = player` を設定する際に AVPlayerView が内部的にプレイヤーのレートをリセットするため、`playImmediately` の効果が消えていた。

## 修正

### 1. 起動時の自動再生（`ContentView.swift`）
`.onAppear` を追加し、起動時に `livePlayerEnabled=true` かつ選択済みチャンネルがある場合は即座に `streamPlayer.load()` を呼ぶ。

### 2. stall 後の自動再開（`StreamPlayerViewModel.swift`）
`handlePlaybackStalled()` に `player.play()` を追加し、stall 後に明示的に再生を再開する。

### 3. AVPlayerView のレートリセット補正（`StreamPlayerView.swift`）
`makeNSView` の末尾で `player.play()` を呼び、`view.player = player` で消えたレートを復元する。`currentItem` がない場合は no-op。

```swift
func makeNSView(context: Context) -> ExpandingAVPlayerView {
    let view = ExpandingAVPlayerView()
    view.player = player
    view.controlsStyle = .floating
    view.videoGravity = .resizeAspect
    player.play()  // view.player 設定でリセットされたレートを復元
    return view
}
```

## 動作確認

- アプリ起動時: `livePlayerEnabled=true` かつチャンネル選択済みであれば自動再生される
- チャンネル切り替え時: 選択直後に自動再生される
- `livePlayerEnabled` を ON にしたとき: 選択中チャンネルが自動再生される
- stall 後: 自動で再生を再開する