### PR TITLE
debug: チャンネルポイントエモートのグレーアウト原因切り分け用診断ログ追加

### DIFF
--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -196,7 +196,7 @@ final class EmotePickerViewModel {
         lastBuiltUserIds    = Set(user.map(\.id))
         #if DEBUG
         loggedAvailableIds.removeAll()
-        print("[EmotePickerVM] load currentBroadcasterId=\(currentBroadcasterId ?? "nil") channel=\(channel.count) user=\(user.count) global=\(global.count)")
+        print("[EmotePickerVM] load broadcasterId=\(currentBroadcasterId ?? "nil") ch=\(channel.count) usr=\(user.count) gl=\(global.count)")
         print("[EmotePickerVM] load userEmoteIds=\(userEmoteIds.count) userEmoteSets=\(userEmoteSets.map { String($0.count) } ?? "nil")")
         if let sets = userEmoteSets, !sets.isEmpty {
             print("[EmotePickerVM] load emote-sets: \(sets.sorted().joined(separator: ","))")
@@ -237,6 +237,15 @@ final class EmotePickerViewModel {
         return assembleSections(classified: classified, global: global, seen: &seen)
     }
 
+    #if DEBUG
+    private func emoteClassifyLog(_ emote: HelixEmote, section: String) {
+        let type  = emote.emoteType ?? "nil"
+        let owner = emote.ownerId   ?? "nil"
+        let setId = emote.emoteSetId ?? "nil"
+        print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) type=\(type) owner=\(owner) setId=\(setId) → \(section)")
+    }
+    #endif
+
     /// エモートをセクション種別ごとに分類して中間構造を返す
     ///
     /// 分類ルール（優先順位）:
@@ -266,20 +275,20 @@ final class EmotePickerViewModel {
         for emote in channel where seen.insert(emote.id).inserted {
             currentChannelEmotes.append(emote)
             #if DEBUG
-            print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → currentChannel(channel-ep)")
+            emoteClassifyLog(emote, section: "currentChannel(channel-ep)")
             #endif
         }
         for emote in user {
             guard seen.insert(emote.id).inserted else {
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → skipped(seen)")
+                emoteClassifyLog(emote, section: "skipped(seen)")
                 #endif
                 continue
             }
             if emote.emoteType == "hypetrain" {
                 hypeEmotes.append(emote)
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → hypeTrain")
+                emoteClassifyLog(emote, section: "hypeTrain")
                 #endif
             } else if emote.emoteType == "globals" || globalIdSet.contains(emote.id) {
                 // globals タイプまたはグローバルエンドポイントに存在する ID は global セクションへ送る
@@ -287,25 +296,25 @@ final class EmotePickerViewModel {
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → global")
+                emoteClassifyLog(emote, section: "global")
                 #endif
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
                 currentChannelEmotes.append(emote)
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(ownerId) emoteSetId=\(emote.emoteSetId ?? "nil") → currentChannel(user-ep)")
+                emoteClassifyLog(emote, section: "currentChannel(user-ep)")
                 #endif
             } else if let ownerId = emote.ownerId, ownerId != "0", !ownerId.isEmpty {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(ownerId) emoteSetId=\(emote.emoteSetId ?? "nil") → subscribedChannel(\(ownerId))")
+                emoteClassifyLog(emote, section: "subscribedChannel(\(ownerId))")
                 #endif
             } else {
                 // ownerId なし / "0" / 空文字エモートは global セクションで処理するため seen から除外する
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
                 #if DEBUG
-                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → global(no-owner)")
+                emoteClassifyLog(emote, section: "global(no-owner)")
                 #endif
             }
         }

--- a/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
+++ b/Sources/TwitchChat/ViewModels/EmotePickerViewModel.swift
@@ -62,6 +62,12 @@ final class EmotePickerViewModel {
     /// 最後にセクションを構築したときのユーザーエモート ID セット
     private var lastBuiltUserIds: Set<String> = []
 
+    #if DEBUG
+    /// isAvailable のログ出力済みエモート ID セット（同一 ID の重複出力を防ぐ）
+    @ObservationIgnored
+    private var loggedAvailableIds: Set<String> = []
+    #endif
+
     // MARK: - 初期化
 
     /// EmotePickerViewModel を初期化する
@@ -120,6 +126,9 @@ final class EmotePickerViewModel {
                 allSections = buildSections(channel: channel, user: user, global: global)
             }
 
+            #if DEBUG
+            loggedAvailableIds.removeAll()
+            #endif
             applyFilter()
         }
     }
@@ -135,10 +144,38 @@ final class EmotePickerViewModel {
     /// - Parameter emote: 判定対象のエモート
     /// - Returns: 使用可能な場合は true
     func isAvailable(_ emote: HelixEmote) -> Bool {
-        if userEmoteIds.contains(emote.id) { return true }
-        guard let sets = userEmoteSets else { return true }
-        guard let emoteSetId = emote.emoteSetId else { return true }
-        return sets.contains(emoteSetId)
+        if userEmoteIds.contains(emote.id) {
+            #if DEBUG
+            if loggedAvailableIds.insert(emote.id).inserted {
+                print("[EmotePickerVM] available id=\(emote.id) name=\(emote.name) branch=userEmoteIds.hit result=true")
+            }
+            #endif
+            return true
+        }
+        guard let sets = userEmoteSets else {
+            #if DEBUG
+            if loggedAvailableIds.insert(emote.id).inserted {
+                print("[EmotePickerVM] available id=\(emote.id) name=\(emote.name) branch=userEmoteSets.nil result=true")
+            }
+            #endif
+            return true
+        }
+        guard let emoteSetId = emote.emoteSetId else {
+            #if DEBUG
+            if loggedAvailableIds.insert(emote.id).inserted {
+                print("[EmotePickerVM] available id=\(emote.id) name=\(emote.name) emoteSetId=nil branch=emoteSetId.nil result=true")
+            }
+            #endif
+            return true
+        }
+        let result = sets.contains(emoteSetId)
+        #if DEBUG
+        if loggedAvailableIds.insert(emote.id).inserted {
+            let branch = result ? "userEmoteSets.hit" : "userEmoteSets.miss"
+            print("[EmotePickerVM] available id=\(emote.id) name=\(emote.name) emoteSetId=\(emoteSetId) branch=\(branch) result=\(result)")
+        }
+        #endif
+        return result
     }
 
     // MARK: - プライベートメソッド
@@ -157,6 +194,14 @@ final class EmotePickerViewModel {
         await profileImageStore.fetchUsers(userIds: collectOwnerIds(channel: channel, user: user))
         lastBuiltChannelIds = Set(channel.map(\.id))
         lastBuiltUserIds    = Set(user.map(\.id))
+        #if DEBUG
+        loggedAvailableIds.removeAll()
+        print("[EmotePickerVM] load currentBroadcasterId=\(currentBroadcasterId ?? "nil") channel=\(channel.count) user=\(user.count) global=\(global.count)")
+        print("[EmotePickerVM] load userEmoteIds=\(userEmoteIds.count) userEmoteSets=\(userEmoteSets.map { String($0.count) } ?? "nil")")
+        if let sets = userEmoteSets, !sets.isEmpty {
+            print("[EmotePickerVM] load emote-sets: \(sets.sorted().joined(separator: ","))")
+        }
+        #endif
         allSections = buildSections(channel: channel, user: user, global: global)
         applyFilter()
     }
@@ -220,24 +265,48 @@ final class EmotePickerViewModel {
 
         for emote in channel where seen.insert(emote.id).inserted {
             currentChannelEmotes.append(emote)
+            #if DEBUG
+            print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → currentChannel(channel-ep)")
+            #endif
         }
-        for emote in user where seen.insert(emote.id).inserted {
+        for emote in user {
+            guard seen.insert(emote.id).inserted else {
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → skipped(seen)")
+                #endif
+                continue
+            }
             if emote.emoteType == "hypetrain" {
                 hypeEmotes.append(emote)
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → hypeTrain")
+                #endif
             } else if emote.emoteType == "globals" || globalIdSet.contains(emote.id) {
                 // globals タイプまたはグローバルエンドポイントに存在する ID は global セクションへ送る
                 // seen から除外して assembleSections の global 合算処理で拾う
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → global")
+                #endif
             } else if let ownerId = emote.ownerId, ownerId == currentBroadcasterId {
                 currentChannelEmotes.append(emote)
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(ownerId) emoteSetId=\(emote.emoteSetId ?? "nil") → currentChannel(user-ep)")
+                #endif
             } else if let ownerId = emote.ownerId, ownerId != "0", !ownerId.isEmpty {
                 if subscribedByOwnerId[ownerId] == nil { subscribedOwnerIds.append(ownerId) }
                 subscribedByOwnerId[ownerId, default: []].append(emote)
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(ownerId) emoteSetId=\(emote.emoteSetId ?? "nil") → subscribedChannel(\(ownerId))")
+                #endif
             } else {
                 // ownerId なし / "0" / 空文字エモートは global セクションで処理するため seen から除外する
                 seen.remove(emote.id)
                 otherEmotes.append(emote)
+                #if DEBUG
+                print("[EmotePickerVM] classify id=\(emote.id) name=\(emote.name) emoteType=\(emote.emoteType ?? "nil") ownerId=\(emote.ownerId ?? "nil") emoteSetId=\(emote.emoteSetId ?? "nil") → global(no-owner)")
+                #endif
             }
         }
         return (currentChannelEmotes, hypeEmotes, subscribedOwnerIds, subscribedByOwnerId, otherEmotes)


### PR DESCRIPTION
## Summary

- `EmotePickerViewModel` に `#if DEBUG` 限定の診断ログを追加し、チャンネルポイント取得エモートが当該チャンネルでグレーアウトする原因を切り分けられる状態を作る
- リリースビルドへの影響ゼロ（全ログは `#if DEBUG` でガード済み）

## 追加したログ

| プレフィックス | 出力タイミング | 確認できること |
|---|---|---|
| `[EmotePickerVM] load` | `refreshSections()` 呼び出し時 | `currentBroadcasterId`、`userEmoteIds` 件数、`userEmoteSets` 内容 |
| `[EmotePickerVM] classify` | `classifyEmotes` 各エモート処理時 | `id`, `name`, `type`, `owner`, `setId` と振り分け先セクション（`channel-ep` / `user-ep` / `subscribedChannel` / `skipped(seen)` 等） |
| `[EmotePickerVM] available` | `isAvailable` 呼び出し時（初回のみ） | 判定経路（`userEmoteIds.hit` / `userEmoteSets.nil` / `emoteSetId.nil` / `userEmoteSets.hit` / `userEmoteSets.miss`）と結果 |

## 検証手順

1. DEBUG ビルドでアプリを起動し、問題の配信者チャンネルに入室
2. エモートピッカーを開く
3. グレーアウトしているエモートの ID で `[EmotePickerVM]` ログをフィルタ
4. `available` 行の `branch=` を確認して仮説（H1/H2/H3）を絞り込む

## 仮説

- **H1**: `/helix/chat/emotes/user` のレスポンスに当該エモート ID が含まれていない → `userEmoteIds` に未収録 → `branch=userEmoteSets.miss`
- **H2**: `userEmoteIds` に収録済みだが `EmotePickerViewModel` のスナップショットが古い
- **H3**: channel エンドポイントと user エンドポイントで同エモートの ID が異なる → `classify` ログで確認可能

本 PR は Phase A（切り分けログ）のみ。Phase B（正式修正）はログ結果を受けて別途プランニングする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ユーザー向けの機能変更はありません。内部のデバッグトレーシングが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->